### PR TITLE
Fix/genbash

### DIFF
--- a/oasislmf/model_execution/bash.py
+++ b/oasislmf/model_execution/bash.py
@@ -553,8 +553,8 @@ def genbash(max_process_id, analysis_settings, filename, _get_getmodel_cmd=get_g
                         'number_of_samples'      : number_of_samples,
                         'gul_threshold'          : gul_threshold,
                         'use_random_number_file' : use_random_number_file,
-                        'coverage_output'        : 'fifo/gul_P{}'.format(process_id),
-                        'item_output'            : '-',
+                        'coverage_output'        : '-'.format(process_id),
+                        'item_output'            : '',
                         'process_id'             : process_id,
                         'max_process_id'         : max_process_id
                     }
@@ -571,7 +571,7 @@ def genbash(max_process_id, analysis_settings, filename, _get_getmodel_cmd=get_g
                         'number_of_samples'      : number_of_samples,
                         'gul_threshold'          : gul_threshold,
                         'use_random_number_file' : use_random_number_file,
-                        'coverage_output'        : 'fifo/gul_P{}'.format(process_id),
+                        'coverage_output'        : ''.format(process_id),
                         'item_output'            : '-',
                         'process_id'             : process_id,
                         'max_process_id'         : max_process_id

--- a/oasislmf/model_execution/bash.py
+++ b/oasislmf/model_execution/bash.py
@@ -455,7 +455,6 @@ def get_getmodel_cmd(number_of_samples, gul_threshold, use_random_number_file, c
 
     return cmd
 
-
 def genbash(max_process_id, analysis_settings, filename, _get_getmodel_cmd=get_getmodel_cmd, extra_args={}):
     """
     Generates a bash script containing ktools calculation instructions for an
@@ -538,7 +537,7 @@ def genbash(max_process_id, analysis_settings, filename, _get_getmodel_cmd=get_g
                 coverage_output        = 'fifo/gul_P{}'.format(process_id),
                 item_output            = '-'
             )
-            getmodel_args = {**default_args, **extra_args}
+            getmodel_args = default_args.update(extra_args)
             getmodel_cmd = _get_getmodel_cmd(**getmodel_args)
             print_command(
                 filename,
@@ -555,7 +554,7 @@ def genbash(max_process_id, analysis_settings, filename, _get_getmodel_cmd=get_g
                         coverage_output        = '-',
                         item_output            = ''
                     )
-                    getmodel_args = {**default_args, **extra_args}
+                    getmodel_args = default_args.update(extra_args)
                     getmodel_cmd = _get_getmodel_cmd(**getmodel_args)
                     print_command(
                         filename,
@@ -571,7 +570,7 @@ def genbash(max_process_id, analysis_settings, filename, _get_getmodel_cmd=get_g
                         coverage_output        = '',
                         item_output            = '-'
                     )
-                    getmodel_args = {**default_args, **extra_args}
+                    getmodel_args = default_args.update(extra_args)
                     getmodel_cmd = _get_getmodel_cmd(**getmodel_args)
                     print_command(
                         filename,

--- a/oasislmf/model_execution/bash.py
+++ b/oasislmf/model_execution/bash.py
@@ -535,7 +535,9 @@ def genbash(max_process_id, analysis_settings, filename, _get_getmodel_cmd=get_g
                 gul_threshold          = gul_threshold,
                 use_random_number_file = use_random_number_file,
                 coverage_output        = 'fifo/gul_P{}'.format(process_id),
-                item_output            = '-'
+                item_output            = '-',
+                process_id            = process_id,
+                max_process_id        = max_process_id
             )
             getmodel_args.update(extra_args)
             getmodel_cmd = _get_getmodel_cmd(**getmodel_args)
@@ -552,7 +554,9 @@ def genbash(max_process_id, analysis_settings, filename, _get_getmodel_cmd=get_g
                         gul_threshold          = gul_threshold,
                         use_random_number_file = use_random_number_file,
                         coverage_output        = '-',
-                        item_output            = ''
+                        item_output            = '',
+                        process_id            = process_id,
+                        max_process_id        = max_process_id
                     )
                     getmodel_args.update(extra_args)
                     getmodel_cmd = _get_getmodel_cmd(**getmodel_args)
@@ -568,7 +572,9 @@ def genbash(max_process_id, analysis_settings, filename, _get_getmodel_cmd=get_g
                         gul_threshold          = gul_threshold,
                         use_random_number_file = use_random_number_file,
                         coverage_output        = '',
-                        item_output            = '-'
+                        item_output            = '-',
+                        process_id            = process_id,
+                        max_process_id        = max_process_id
                     )
                     getmodel_args.update(extra_args)
                     getmodel_cmd = _get_getmodel_cmd(**getmodel_args)

--- a/oasislmf/model_execution/bash.py
+++ b/oasislmf/model_execution/bash.py
@@ -530,7 +530,7 @@ def genbash(max_process_id, analysis_settings, filename, _get_getmodel_cmd=get_g
     for process_id in range(1, max_process_id + 1):
         if gul_output and il_output:
 
-              getmodel_args = dict(
+            getmodel_args = dict(
                 number_of_samples      = number_of_samples,
                 gul_threshold          = gul_threshold,
                 use_random_number_file = use_random_number_file,

--- a/oasislmf/model_execution/bash.py
+++ b/oasislmf/model_execution/bash.py
@@ -538,7 +538,7 @@ def genbash(max_process_id, analysis_settings, filename, _get_getmodel_cmd=get_g
                 coverage_output        = 'fifo/gul_P{}'.format(process_id),
                 item_output            = '-'
             )
-            getmodel_cmd = _get_getmodel_cmd({**default_args, **extra_args})
+            getmodel_cmd = _get_getmodel_cmd(*{**default_args, **extra_args})
             print_command(
                 filename,
                 'eve {0} {1} | {2} | fmcalc > fifo/il_P{0}  &'.format(process_id, max_process_id, getmodel_cmd)

--- a/oasislmf/model_execution/bash.py
+++ b/oasislmf/model_execution/bash.py
@@ -530,14 +530,14 @@ def genbash(max_process_id, analysis_settings, filename, _get_getmodel_cmd=get_g
     for process_id in range(1, max_process_id + 1):
         if gul_output and il_output:
 
-            default_args = dict(
+              getmodel_args = dict(
                 number_of_samples      = number_of_samples,
                 gul_threshold          = gul_threshold,
                 use_random_number_file = use_random_number_file,
                 coverage_output        = 'fifo/gul_P{}'.format(process_id),
                 item_output            = '-'
             )
-            getmodel_args = default_args.update(extra_args)
+            getmodel_args.update(extra_args)
             getmodel_cmd = _get_getmodel_cmd(**getmodel_args)
             print_command(
                 filename,
@@ -547,14 +547,14 @@ def genbash(max_process_id, analysis_settings, filename, _get_getmodel_cmd=get_g
             #  Now the mainprocessing
             if gul_output:
                 if 'gul_summaries' in analysis_settings:
-                    default_args = dict(
+                    getmodel_args = dict(
                         number_of_samples      = number_of_samples,
                         gul_threshold          = gul_threshold,
                         use_random_number_file = use_random_number_file,
                         coverage_output        = '-',
                         item_output            = ''
                     )
-                    getmodel_args = default_args.update(extra_args)
+                    getmodel_args.update(extra_args)
                     getmodel_cmd = _get_getmodel_cmd(**getmodel_args)
                     print_command(
                         filename,
@@ -563,14 +563,14 @@ def genbash(max_process_id, analysis_settings, filename, _get_getmodel_cmd=get_g
 
             if il_output:
                 if 'il_summaries' in analysis_settings:
-                    default_args = dict(
+                    getmodel_args = dict(
                         number_of_samples      = number_of_samples,
                         gul_threshold          = gul_threshold,
                         use_random_number_file = use_random_number_file,
                         coverage_output        = '',
                         item_output            = '-'
                     )
-                    getmodel_args = default_args.update(extra_args)
+                    getmodel_args.update(extra_args)
                     getmodel_cmd = _get_getmodel_cmd(**getmodel_args)
                     print_command(
                         filename,

--- a/oasislmf/model_execution/bash.py
+++ b/oasislmf/model_execution/bash.py
@@ -530,15 +530,15 @@ def genbash(max_process_id, analysis_settings, filename, _get_getmodel_cmd=get_g
     for process_id in range(1, max_process_id + 1):
         if gul_output and il_output:
 
-            getmodel_args = dict(
-                number_of_samples      = number_of_samples,
-                gul_threshold          = gul_threshold,
-                use_random_number_file = use_random_number_file,
-                coverage_output        = 'fifo/gul_P{}'.format(process_id),
-                item_output            = '-',
-                process_id             = process_id,
-                max_process_id         = max_process_id
-            )
+            getmodel_args = { 
+                'number_of_samples'      : number_of_samples,
+                'gul_threshold'          : gul_threshold,
+                'use_random_number_file' : use_random_number_file,
+                'coverage_output'        : 'fifo/gul_P{}'.format(process_id),
+                'item_output'            : '-',
+                'process_id'             : process_id,
+                'max_process_id'         : max_process_id
+            }
             getmodel_args.update(custom_args)
             getmodel_cmd = _get_getmodel_cmd(**getmodel_args)
             print_command(
@@ -549,15 +549,15 @@ def genbash(max_process_id, analysis_settings, filename, _get_getmodel_cmd=get_g
             #  Now the mainprocessing
             if gul_output:
                 if 'gul_summaries' in analysis_settings:
-                    getmodel_args = dict(
-                        number_of_samples      = number_of_samples,
-                        gul_threshold          = gul_threshold,
-                        use_random_number_file = use_random_number_file,
-                        coverage_output        = '-',
-                        item_output            = '',
-                        process_id             = process_id,
-                        max_process_id         = max_process_id
-                    )
+                    getmodel_args = { 
+                        'number_of_samples'      : number_of_samples,
+                        'gul_threshold'          : gul_threshold,
+                        'use_random_number_file' : use_random_number_file,
+                        'coverage_output'        : 'fifo/gul_P{}'.format(process_id),
+                        'item_output'            : '-',
+                        'process_id'             : process_id,
+                        'max_process_id'         : max_process_id
+                    }
                     getmodel_args.update(custom_args)
                     getmodel_cmd = _get_getmodel_cmd(**getmodel_args)
                     print_command(
@@ -567,15 +567,15 @@ def genbash(max_process_id, analysis_settings, filename, _get_getmodel_cmd=get_g
 
             if il_output:
                 if 'il_summaries' in analysis_settings:
-                    getmodel_args = dict(
-                        number_of_samples      = number_of_samples,
-                        gul_threshold          = gul_threshold,
-                        use_random_number_file = use_random_number_file,
-                        coverage_output        = '',
-                        item_output            = '-',
-                        process_id             = process_id,
-                        max_process_id         = max_process_id
-                    )
+                    getmodel_args = { 
+                        'number_of_samples'      : number_of_samples,
+                        'gul_threshold'          : gul_threshold,
+                        'use_random_number_file' : use_random_number_file,
+                        'coverage_output'        : 'fifo/gul_P{}'.format(process_id),
+                        'item_output'            : '-',
+                        'process_id'             : process_id,
+                        'max_process_id'         : max_process_id
+                    }
                     getmodel_args.update(custom_args)
                     getmodel_cmd = _get_getmodel_cmd(**getmodel_args)
                     print_command(

--- a/oasislmf/model_execution/bash.py
+++ b/oasislmf/model_execution/bash.py
@@ -456,7 +456,7 @@ def get_getmodel_cmd(number_of_samples, gul_threshold, use_random_number_file, c
     return cmd
 
 
-def genbash(max_process_id, analysis_settings, filename, _get_getmodel_cmd=None):
+def genbash(max_process_id, analysis_settings, filename, _get_getmodel_cmd=get_getmodel_cmd, extra_args={}):
     """
     Generates a bash script containing ktools calculation instructions for an
     Oasis model.
@@ -472,7 +472,6 @@ def genbash(max_process_id, analysis_settings, filename, _get_getmodel_cmd=None)
     :type get_getmodel_cmd: callable
     """
     process_counter = Counter()
-    _get_getmodel_cmd = _get_getmodel_cmd or get_getmodel_cmd
 
     use_random_number_file = False
     gul_output = False
@@ -531,14 +530,15 @@ def genbash(max_process_id, analysis_settings, filename, _get_getmodel_cmd=None)
 
     for process_id in range(1, max_process_id + 1):
         if gul_output and il_output:
-            getmodel_cmd = _get_getmodel_cmd(
-                number_of_samples,
-                gul_threshold,
-                use_random_number_file,
-                'fifo/gul_P{}'.format(process_id),
-                '-'
-            )
 
+            default_args = dict(
+                number_of_samples      = number_of_samples,
+                gul_threshold          = gul_threshold,
+                use_random_number_file = use_random_number_file,
+                coverage_output        = 'fifo/gul_P{}'.format(process_id),
+                item_output            = '-'
+            )
+            getmodel_cmd = _get_getmodel_cmd({**default_args, **extra_args})
             print_command(
                 filename,
                 'eve {0} {1} | {2} | fmcalc > fifo/il_P{0}  &'.format(process_id, max_process_id, getmodel_cmd)
@@ -547,13 +547,14 @@ def genbash(max_process_id, analysis_settings, filename, _get_getmodel_cmd=None)
             #  Now the mainprocessing
             if gul_output:
                 if 'gul_summaries' in analysis_settings:
-                    getmodel_cmd = _get_getmodel_cmd(
-                        number_of_samples,
-                        gul_threshold,
-                        use_random_number_file,
-                        '-',
-                        '')
-
+                    default_args = dict(
+                        number_of_samples      = number_of_samples,
+                        gul_threshold          = gul_threshold,
+                        use_random_number_file = use_random_number_file,
+                        coverage_output        = '-',
+                        item_output            = ''
+                    )
+                    getmodel_cmd = _get_getmodel_cmd({**default_args, **extra_args})
                     print_command(
                         filename,
                         'eve {0} {1} | {2} > fifo/gul_P{0}  &'.format(process_id, max_process_id, getmodel_cmd)
@@ -561,14 +562,14 @@ def genbash(max_process_id, analysis_settings, filename, _get_getmodel_cmd=None)
 
             if il_output:
                 if 'il_summaries' in analysis_settings:
-                    getmodel_cmd = _get_getmodel_cmd(
-                        number_of_samples,
-                        gul_threshold,
-                        use_random_number_file,
-                        '',
-                        '-'
+                    default_args = dict(
+                        number_of_samples      = number_of_samples,
+                        gul_threshold          = gul_threshold,
+                        use_random_number_file = use_random_number_file,
+                        coverage_output        = '',
+                        item_output            = '-'
                     )
-
+                    getmodel_cmd = _get_getmodel_cmd({**default_args, **extra_args})
                     print_command(
                         filename,
                         "eve {0} {1} | {2} | fmcalc > fifo/il_P{0}  &".format(process_id, max_process_id, getmodel_cmd)

--- a/oasislmf/model_execution/bash.py
+++ b/oasislmf/model_execution/bash.py
@@ -538,7 +538,8 @@ def genbash(max_process_id, analysis_settings, filename, _get_getmodel_cmd=get_g
                 coverage_output        = 'fifo/gul_P{}'.format(process_id),
                 item_output            = '-'
             )
-            getmodel_cmd = _get_getmodel_cmd(*{**default_args, **extra_args})
+            getmodel_args = {**default_args, **extra_args}
+            getmodel_cmd = _get_getmodel_cmd(**getmodel_args)
             print_command(
                 filename,
                 'eve {0} {1} | {2} | fmcalc > fifo/il_P{0}  &'.format(process_id, max_process_id, getmodel_cmd)
@@ -554,7 +555,8 @@ def genbash(max_process_id, analysis_settings, filename, _get_getmodel_cmd=get_g
                         coverage_output        = '-',
                         item_output            = ''
                     )
-                    getmodel_cmd = _get_getmodel_cmd({**default_args, **extra_args})
+                    getmodel_args = {**default_args, **extra_args}
+                    getmodel_cmd = _get_getmodel_cmd(**getmodel_args)
                     print_command(
                         filename,
                         'eve {0} {1} | {2} > fifo/gul_P{0}  &'.format(process_id, max_process_id, getmodel_cmd)
@@ -569,7 +571,8 @@ def genbash(max_process_id, analysis_settings, filename, _get_getmodel_cmd=get_g
                         coverage_output        = '',
                         item_output            = '-'
                     )
-                    getmodel_cmd = _get_getmodel_cmd({**default_args, **extra_args})
+                    getmodel_args = {**default_args, **extra_args}
+                    getmodel_cmd = _get_getmodel_cmd(**getmodel_args)
                     print_command(
                         filename,
                         "eve {0} {1} | {2} | fmcalc > fifo/il_P{0}  &".format(process_id, max_process_id, getmodel_cmd)

--- a/oasislmf/model_execution/bash.py
+++ b/oasislmf/model_execution/bash.py
@@ -422,7 +422,7 @@ def do_kwaits(filename, process_counter):
     do_waits('kpid', process_counter['kpid_monitor_count'], filename)
 
 
-def get_getmodel_cmd(number_of_samples, gul_threshold, use_random_number_file, coverage_output, item_output):
+def get_getmodel_cmd(number_of_samples, gul_threshold, use_random_number_file, coverage_output, item_output, **kwargs):
     """
     Gets the getmodel ktools command
 
@@ -455,7 +455,7 @@ def get_getmodel_cmd(number_of_samples, gul_threshold, use_random_number_file, c
 
     return cmd
 
-def genbash(max_process_id, analysis_settings, filename, _get_getmodel_cmd=get_getmodel_cmd, extra_args={}):
+def genbash(max_process_id, analysis_settings, filename, _get_getmodel_cmd=get_getmodel_cmd, custom_args={}):
     """
     Generates a bash script containing ktools calculation instructions for an
     Oasis model.
@@ -536,10 +536,10 @@ def genbash(max_process_id, analysis_settings, filename, _get_getmodel_cmd=get_g
                 use_random_number_file = use_random_number_file,
                 coverage_output        = 'fifo/gul_P{}'.format(process_id),
                 item_output            = '-',
-                process_id            = process_id,
-                max_process_id        = max_process_id
+                process_id             = process_id,
+                max_process_id         = max_process_id
             )
-            getmodel_args.update(extra_args)
+            getmodel_args.update(custom_args)
             getmodel_cmd = _get_getmodel_cmd(**getmodel_args)
             print_command(
                 filename,
@@ -555,10 +555,10 @@ def genbash(max_process_id, analysis_settings, filename, _get_getmodel_cmd=get_g
                         use_random_number_file = use_random_number_file,
                         coverage_output        = '-',
                         item_output            = '',
-                        process_id            = process_id,
-                        max_process_id        = max_process_id
+                        process_id             = process_id,
+                        max_process_id         = max_process_id
                     )
-                    getmodel_args.update(extra_args)
+                    getmodel_args.update(custom_args)
                     getmodel_cmd = _get_getmodel_cmd(**getmodel_args)
                     print_command(
                         filename,
@@ -573,10 +573,10 @@ def genbash(max_process_id, analysis_settings, filename, _get_getmodel_cmd=get_g
                         use_random_number_file = use_random_number_file,
                         coverage_output        = '',
                         item_output            = '-',
-                        process_id            = process_id,
-                        max_process_id        = max_process_id
+                        process_id             = process_id,
+                        max_process_id         = max_process_id
                     )
-                    getmodel_args.update(extra_args)
+                    getmodel_args.update(custom_args)
                     getmodel_cmd = _get_getmodel_cmd(**getmodel_args)
                     print_command(
                         filename,


### PR DESCRIPTION
New optional argument `extra_args={}` which merges with the 5 standard arguments. 
If `genbash()` is drastically different, then its probably better for the supplier to override that function instead of  `get_getmodel_cmd()`. 

Note: still needs testing 
