### PR TITLE
Hotfix/coverage type matching for gul items generation

### DIFF
--- a/oasislmf/exposures/manager.py
+++ b/oasislmf/exposures/manager.py
@@ -522,7 +522,7 @@ class OasisExposuresManager(implements(OasisExposuresManagerInterface)):
             tiv_field_matches = tuple(t for t in tiv_fields if t['CoverageTypeID'] == keys_item['coveragetypeid'])
 
             if not tiv_field_matches:
-                raise OasisException('No match between canonical profile coverage types and model-defined coverage types')
+                pass
 
             for tiv_field in tiv_field_matches:
                 tiv_lookup = tiv_field['ProfileElementName'].lower()
@@ -539,6 +539,9 @@ class OasisExposuresManager(implements(OasisExposuresManagerInterface)):
                         'summary_id': 1,
                         'summaryset_id': 1,
                     }])
+
+        if item_id == 0:
+            raise OasisException('No items generated - no matches between canonical exposure coverage types and model-defined coverage types')
 
         return result
 

--- a/tests/cmd/test_test_testmoddelapi.py
+++ b/tests/cmd/test_test_testmoddelapi.py
@@ -7,7 +7,11 @@ import os
 
 import shutil
 import six
-from hypothesis import given
+from hypothesis import (
+    given,
+    HealthCheck,
+    settings,
+)
 from hypothesis.strategies import sampled_from, text, dictionaries, booleans, integers
 from mock import Mock, ANY, patch
 from backports.tempfile import mkdtemp, TemporaryDirectory
@@ -110,6 +114,7 @@ class TestModelApiCmdRunAnalysis(TestCase):
         client.upload_inputs_from_directory.assert_called_once_with(input_dir, bin_directory=ANY, do_il=do_il, do_build=True)
         client.run_analysis_and_poll.assert_called_once_with(settings, 'input_location', output_dir)
 
+    @settings(suppress_health_check=[HealthCheck.too_slow])
     @given(text(), text(), dictionaries(text(), text()), booleans(), integers(min_value=0, max_value=5), integers(min_value=0, max_value=5))
     def test_uploading_raises_an_error___failed_counter_is_incremented(self, input_dir, output_dir, settings, do_il, initial_complete, initial_failed):
         client = OasisAPIClient('http://localhost:8001')

--- a/tests/exposures/test_oasisexposuremanager.py
+++ b/tests/exposures/test_oasisexposuremanager.py
@@ -150,6 +150,7 @@ class OasisExposureManagerLoadCanonicalExposuresProfile(TestCase):
             self.assertEqual(expected, profile)
             self.assertEqual(expected, model.resources['canonical_exposures_profile'])
 
+    @settings(suppress_health_check=[HealthCheck.too_slow])
     @given(dictionaries(text(), text()), dictionaries(text(), text()))
     def test_model_is_set_with_profile_json_path_and_profile_json_path_is_passed_through_kwargs___kwargs_profile_is_used(
         self,

--- a/tests/utils/test_compress.py
+++ b/tests/utils/test_compress.py
@@ -2,7 +2,11 @@ from unittest import TestCase
 
 import zlib
 
-from hypothesis import given
+from hypothesis import (
+    given,
+    HealthCheck,
+    settings,
+)
 from hypothesis.strategies import binary
 from mock import patch, Mock
 
@@ -14,6 +18,7 @@ MOCKED_CHUNK_SIZE = 100
 
 @patch('oasislmf.utils.compress.CHUNK_SIZE', MOCKED_CHUNK_SIZE)
 class CompressData(TestCase):
+    @settings(suppress_health_check=[HealthCheck.too_slow])
     @given(binary(min_size=0, max_size=MOCKED_CHUNK_SIZE - 1))
     def test_data_is_less_than_than_the_chunk_size___result_is_the_compressed_version_of_the_full_data(self, data):
         compressor = zlib.compressobj()
@@ -23,6 +28,7 @@ class CompressData(TestCase):
 
         self.assertEqual(expected, result)
 
+    @settings(suppress_health_check=[HealthCheck.too_slow])
     @given(binary(min_size=MOCKED_CHUNK_SIZE, max_size=MOCKED_CHUNK_SIZE))
     def test_data_is_equal_to_the_the_chunk_size___result_is_the_compressed_version_of_the_full_data(self, data):
         compressor = zlib.compressobj()
@@ -32,6 +38,7 @@ class CompressData(TestCase):
 
         self.assertEqual(expected, result)
 
+    @settings(suppress_health_check=[HealthCheck.too_slow])
     @given(binary(min_size=MOCKED_CHUNK_SIZE, max_size=MOCKED_CHUNK_SIZE), binary(min_size=0, max_size=MOCKED_CHUNK_SIZE - 1))
     def test_data_is_larger_than_the_chunk_size___result_is_the_concatenated_compressed_version_of_the_chunks(self, front, overflow):
         compressor = zlib.compressobj()


### PR DESCRIPTION
Fix coverage type matching in GUL items generator in exposure manager