### PR TITLE
Fix ordering of bulk lookup generation in base generic lookup

### DIFF
--- a/oasislmf/keys/lookup.py
+++ b/oasislmf/keys/lookup.py
@@ -184,7 +184,7 @@ class OasisBaseLookup(object):
         elif isinstance(locs, pd.DataFrame):
             locs_seq = (loc for _, loc in locs.iterrows())
 
-        for peril_id, coverage_type, loc in itertools.product(self.peril_ids, self.coverage_types, locs_seq):
+        for loc, peril_id, coverage_type in itertools.product(locs_seq, self.peril_ids, self.coverage_types):
             yield self.lookup(loc, peril_id, coverage_type)
 
 


### PR DESCRIPTION
Fix ordering of bulk lookup generation in base generic lookup - records should be generated as (loc. ID, peril ID, coverage type ID) combinations.