### PR TITLE
Fix/multiprocessing tweak for Celery/API clients

### DIFF
--- a/oasislmf/utils/concurrency.py
+++ b/oasislmf/utils/concurrency.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import multiprocessing
-
 try:
     from queue import Queue, Empty
 except ImportError:
@@ -10,7 +8,7 @@ except ImportError:
 import sys
 import types
 
-from multiprocessing import Pool
+import billiard
 
 from signal import (
     signal,
@@ -161,7 +159,7 @@ def multiprocess(tasks, pool_size=10):
     caller.
     """
 
-    pool = Pool(pool_size)
+    pool = billiard.Pool(pool_size)
 
     result_q = Queue()
 

--- a/requirements-package.in
+++ b/requirements-package.in
@@ -1,5 +1,6 @@
 argparsetree==0.0.5
 backports.tempfile
+billiard==3.5.0.4
 chainmap
 future
 jsonpickle

--- a/requirements-package.in
+++ b/requirements-package.in
@@ -9,7 +9,7 @@ pathlib2
 pyodbc
 python-interface
 pytz
-requests
+requests==2.20.0
 rtree==0.8.3
 requests-toolbelt
 shapely==1.6.4.post1

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ attrs==17.4.0             # via hypothesis, pytest
 babel==2.5.3              # via sphinx
 backports.tempfile==1.0
 backports.weakref==1.0.post1  # via backports.tempfile
+billiard==3.5.0.4
 certifi==2017.11.5        # via requests
 chainmap==1.0.2
 chardet==3.0.4            # via requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,9 +20,11 @@ cookies==2.2.1            # via responses
 coverage==4.4.2
 discover==0.4.0
 docutils==0.14            # via sphinx
+enum34==1.1.6             # via flake8, hypothesis
 first==2.0.1              # via pip-tools
 flake8==3.5.0
 freezegun==0.3.9
+funcsigs==1.0.2           # via mock, pytest, python-interface
 future==0.16.0
 hypothesis==3.44.16
 idna==2.6                 # via requests
@@ -51,9 +53,10 @@ python-dateutil==2.6.1    # via freezegun, pandas
 python-interface==1.4.0
 pytz==2017.3
 requests-toolbelt==0.8.0
-requests==2.18.4
+requests==2.20.0
 responses==0.8.1
 rtree==0.8.3
+scandir==1.9.0            # via pathlib2
 shapely==1.6.4.post1
 shutilwhich==1.1.0
 six==1.11.0
@@ -61,5 +64,6 @@ snowballstemmer==1.2.1    # via sphinx
 sphinx==1.6.7
 sphinxcontrib-websupport==1.0.1  # via sphinx
 tox==2.9.1
+typing==3.6.6             # via python-interface, sphinx
 urllib3==1.22             # via requests
 virtualenv==15.1.0        # via tox

--- a/tests/exposures/test_oasisexposuremanager.py
+++ b/tests/exposures/test_oasisexposuremanager.py
@@ -238,17 +238,17 @@ class CreateModel(TestCase):
             self.assertEqual(res_keys_errors_file_path, keys_errors_file_path)
 
     @given(
-        supplier_id=text(min_size=1),
-        model_id=text(min_size=1),
-        version=text(min_size=1),
+        supplier_id=text(alphabet=string.ascii_letters, min_size=1),
+        model_id=text(alphabet=string.ascii_letters, min_size=1),
+        version=text(alphabet=string.ascii_letters, min_size=1),
         model_lookup=text(min_size=1, alphabet=string.ascii_letters), 
-        model_keys_fp=text(min_size=1, alphabet=string.ascii_letters),
-        model_keys_errors_fp=text(min_size=1, alphabet=string.ascii_letters),
-        model_exposures_fp=text(min_size=1, alphabet=string.ascii_letters),
+        model_keys_fp=text(alphabet=string.ascii_letters, min_size=1),
+        model_keys_errors_fp=text(alphabet=string.ascii_letters, min_size=1),
+        model_exposures_fp=text(alphabet=string.ascii_letters, min_size=1),
         lookup=text(min_size=1, alphabet=string.ascii_letters),
-        keys_fp=text(min_size=1, alphabet=string.ascii_letters),
-        keys_errors_fp=text(min_size=1, alphabet=string.ascii_letters),
-        exposures_fp=text(min_size=1, alphabet=string.ascii_letters)
+        keys_fp=text(alphabet=string.ascii_letters, min_size=1),
+        keys_errors_fp=text(alphabet=string.ascii_letters, min_size=1),
+        exposures_fp=text(alphabet=string.ascii_letters, min_size=1)
     )
     def test_supplier_and_model_and_version_and_absolute_oasis_files_path_only_are_supplied___correct_model_is_returned(
         self,
@@ -305,10 +305,10 @@ class CreateModel(TestCase):
         self.assertIsNone(model.resources.get('canonical_exposures_profile'))
 
     @given(
-        supplier_id=text(min_size=1),
-        model_id=text(min_size=1),
-        version_id=text(min_size=1),
-        oasis_files_path=text(min_size=1)
+        supplier_id=text(alphabet=string.ascii_letters, min_size=1),
+        model_id=text(alphabet=string.ascii_letters, min_size=1),
+        version_id=text(alphabet=string.ascii_letters, min_size=1),
+        oasis_files_path=text(alphabet=string.ascii_letters, min_size=1)
     )
     def test_supplier_and_model_and_version_and_relative_oasis_files_path_only_are_supplied___correct_model_is_returned_with_absolute_oasis_file_path(
         self,
@@ -337,9 +337,9 @@ class CreateModel(TestCase):
         self.assertIsNone(model.resources.get('canonical_exposures_profile'))
 
     @given(
-        supplier_id=text(min_size=1),
-        model_id=text(min_size=1),
-        version_id=text(min_size=1),
+        supplier_id=text(alphabet=string.ascii_letters, min_size=1),
+        model_id=text(alphabet=string.ascii_letters, min_size=1),
+        version_id=text(alphabet=string.ascii_letters, min_size=1),
         canonical_exposures_profile=dictionaries(text(min_size=1), text(min_size=1))
     )
     def test_supplier_and_model_and_version_and_canonical_exposures_profile_only_are_supplied___correct_model_is_returned(
@@ -367,10 +367,10 @@ class CreateModel(TestCase):
         self.assertTrue(isinstance(model.resources['oasis_files_pipeline'], OasisFilesPipeline))
 
     @given(
-        supplier_id=text(min_size=1),
-        model_id=text(min_size=1),
-        version_id=text(min_size=1),
-        oasis_files_path=text(min_size=1),
+        supplier_id=text(alphabet=string.ascii_letters, min_size=1),
+        model_id=text(alphabet=string.ascii_letters, min_size=1),
+        version_id=text(alphabet=string.ascii_letters, min_size=1),
+        oasis_files_path=text(alphabet=string.ascii_letters, min_size=1),
         canonical_exposures_profile=dictionaries(text(min_size=1), text(min_size=1))
     )
     def test_supplier_and_model_and_version_and_relative_oasis_files_path_and_canonical_exposures_profile_only_are_supplied___correct_model_is_returned(
@@ -399,10 +399,10 @@ class CreateModel(TestCase):
         self.assertTrue(isinstance(model.resources['oasis_files_pipeline'], OasisFilesPipeline))
 
     @given(
-        supplier_id=text(min_size=1),
-        model_id=text(min_size=1),
-        version_id=text(min_size=1),
-        oasis_files_path=text(min_size=1),
+        supplier_id=text(alphabet=string.ascii_letters, min_size=1),
+        model_id=text(alphabet=string.ascii_letters, min_size=1),
+        version_id=text(alphabet=string.ascii_letters, min_size=1),
+        oasis_files_path=text(alphabet=string.ascii_letters, min_size=1),
         canonical_exposures_profile=dictionaries(text(min_size=1), text(min_size=1))
     )
     def test_supplier_and_model_and_version_and_absolute_oasis_files_path_and_canonical_exposures_profile_only_are_supplied___correct_model_is_returned(
@@ -430,10 +430,10 @@ class CreateModel(TestCase):
         self.assertTrue(isinstance(model.resources['oasis_files_pipeline'], OasisFilesPipeline))
 
     @given(
-        supplier_id=text(min_size=1),
-        model_id=text(min_size=1),
-        version_id=text(min_size=1),
-        source_accounts_file_path=text(min_size=1)
+        supplier_id=text(alphabet=string.ascii_letters, min_size=1),
+        model_id=text(alphabet=string.ascii_letters, min_size=1),
+        version_id=text(alphabet=string.ascii_letters, min_size=1),
+        source_accounts_file_path=text(alphabet=string.ascii_letters, min_size=1)
     )
     def test_supplier_and_model_and_version_and_source_accounts_file_path_only_are_supplied___correct_model_is_returned(
         self,
@@ -463,10 +463,10 @@ class CreateModel(TestCase):
         self.assertIsNone(model.resources.get('canonical_accounts_profile'))
 
     @given(
-        supplier_id=text(min_size=1),
-        model_id=text(min_size=1),
-        version_id=text(min_size=1),
-        source_accounts_file_path=text(min_size=1),
+        supplier_id=text(alphabet=string.ascii_letters, min_size=1),
+        model_id=text(alphabet=string.ascii_letters, min_size=1),
+        version_id=text(alphabet=string.ascii_letters, min_size=1),
+        source_accounts_file_path=text(alphabet=string.ascii_letters, min_size=1),
         canonical_accounts_profile=dictionaries(text(min_size=1), text(min_size=1))
     )
     def test_supplier_and_model_and_version_and_source_accounts_file_path_and_canonical_accounts_profile_only_are_supplied___correct_model_is_returned(
@@ -499,11 +499,11 @@ class CreateModel(TestCase):
         self.assertEqual(resources['canonical_accounts_profile'], model.resources['canonical_accounts_profile'])
 
     @given(
-        supplier_id=text(min_size=1),
-        model_id=text(min_size=1),
-        version_id=text(min_size=1),
+        supplier_id=text(alphabet=string.ascii_letters, min_size=1),
+        model_id=text(alphabet=string.ascii_letters, min_size=1),
+        version_id=text(alphabet=string.ascii_letters, min_size=1),
         canonical_exposures_profile=dictionaries(text(min_size=1), text(min_size=1)),
-        source_accounts_file_path=text(min_size=1),
+        source_accounts_file_path=text(alphabet=string.ascii_letters, min_size=1),
         canonical_accounts_profile=dictionaries(text(min_size=1), text(min_size=1))
     )
     def test_supplier_and_model_and_version_and_canonical_exposures_profile_and_source_accounts_file_path_and_canonical_accounts_profile_only_are_supplied___correct_model_is_returned(
@@ -541,12 +541,12 @@ class CreateModel(TestCase):
         self.assertEqual(resources['canonical_accounts_profile'], model.resources['canonical_accounts_profile'])
 
     @given(
-        supplier_id=text(min_size=1),
-        model_id=text(min_size=1),
-        version_id=text(min_size=1),
-        oasis_files_path=text(min_size=1),
+        supplier_id=text(alphabet=string.ascii_letters, min_size=1),
+        model_id=text(alphabet=string.ascii_letters, min_size=1),
+        version_id=text(alphabet=string.ascii_letters, min_size=1),
+        oasis_files_path=text(alphabet=string.ascii_letters, min_size=1),
         canonical_exposures_profile=dictionaries(text(min_size=1), text(min_size=1)),
-        source_accounts_file_path=text(min_size=1),
+        source_accounts_file_path=text(alphabet=string.ascii_letters, min_size=1),
         canonical_accounts_profile=dictionaries(text(min_size=1), text(min_size=1))
     )
     def test_supplier_and_model_and_version_and_absolute_oasis_files_path_and_canonical_exposures_profile_and_source_accounts_file_path_and_canonical_accounts_profile_only_are_supplied___correct_model_is_returned(

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py27,py35,py36
 skipsdist = true
 
 [testenv]
-deps = -rrequirements.txt
+deps = -r{toxinidir}/requirements.txt
 commands = pytest -p no:flaky --cov=oasislmf
 setenv =
     COV_CORE_SOURCE={toxinidir}/oasislmf


### PR DESCRIPTION
Update concurrency utils - replace `multiprocessing.Pool` by `billiard.Pool` in multiprocessing wrapper (`oasislmf.utils.concurrency.multiprocess`) to fix a problem with Celery tasks unable to run applications which use processes or process pools created using the built-in `multiprocessing` package.
