### PR TITLE
Fix processing of analysis settings file during model execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,20 @@
 
 # OasisLMF
 
-The `oasislmf` Python package, loosely called the *model development kit (MDK)* or the *MDK package*, provides a command line interface and reusable libraries for developing and running Oasis models end-to-end, locally or remotely via the Oasis API. For running models locally the CLI provides a `model` subcommand with the following main subcommands:
+The `oasislmf` Python package, loosely called the *model development kit (MDK)* or the *MDK package*, provides a command line interface and reusable libraries primarly for developing and running Oasis models end-to-end locally, or remotely via the Oasis API, for the purpose of generating group-up losses (GUL), direct/insured losses (IL) and reinsurance losses (RIL). The package also provides end users with a way to generate deterministic losses at all levels, GUL, IL or RIL.
+
+For running models locally the CLI provides a `model` subcommand with the following main subcommands:
 
 * `model generate-keys`: generates Oasis keys files that model lookups would generate; these are essentially line items of (location ID, peril ID, coverage type ID, area peril ID, vulnerability ID) where peril ID and coverage type ID span the full set of perils and coverage types that the model supports
-* `model generate-oasis-files`: generates the Oasis input CSV files, from which ground up loss (GUL), direct insured losses (IL/FM) and/or reinsurance losses are generated; it requires the provision of source exposure and optionally source accounts and reinsurance info. and scope files (in OED or RMS format), canonical profiles and aggregation profiles that describe the financial terms in "canonical" versions of the source exposure and accounts files, and other model data related assets
-* `model generate-losses`: generates GUL, or GUL + IL, or GUL + IL + RI losses from pre-generated Oasis files
-* `model run`: runs the model from start to finish by generating losses (GUL, or GUL + IL, or GUL + IL + RI) from the source data, canonical and aggregation profiles, and model data.
+* `model generate-oasis-files`: generates the Oasis input CSV files for losses (GUL, GUL + IL, or GUL + IL + RIL); it requires the provision of source exposure and optionally source accounts and reinsurance info. and scope files (in OED format), as well as assets for instantiating model lookups and generating keys files
+* `model generate-losses`: generates losses (GUL, or GUL + IL, or GUL + IL + RIL) from a set of pre-existing Oasis files
+* `model run`: runs the model from start to finish by generating losses (GUL, or GUL + IL, or GUL + IL + RIL) from the source exposure, and optionally source accounts and reinsurance info. and scope files (in OED or RMS format), as well as assets for instantiating model lookups and generating keys files
 
 For remote model execution the `api` subcommand provides the following main subcommand:
 
 * `api run`: runs the model remotely (same as `model run`) but via the Oasis API
+
+For generating deterministic losses (GUL, or GUL + IL, or GUL + IL + RIL) the CLI provides an `exposure run` subcommand.
 
 The reusable libraries are organised into several sub-packages, the most relevant of which from a model developer or user's perspective are:
 

--- a/oasislmf/model_execution/bin.py
+++ b/oasislmf/model_execution/bin.py
@@ -148,7 +148,7 @@ def prepare_run_directory(
             else:
                 shutil.move(src, run_dir)
 
-        dst = os.path.join(run_dir, 'analysis_settings.json')
+        dst = os.path.join(run_dir, os.path.basename(analysis_settings_fp))
         shutil.copy(analysis_settings_fp, dst) if not (os.path.exists(dst) and filecmp.cmp(analysis_settings_fp, dst, shallow=False)) else None
 
         model_data_dst_fp = os.path.join(run_dir, 'static')

--- a/requirements-package.in
+++ b/requirements-package.in
@@ -7,7 +7,7 @@ chainmap
 future
 jsonpickle
 lxml>=4.1.1
-pandas>=0.22.0
+pandas>=0.24.0
 pathlib2
 pyodbc
 python-interface

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ markupsafe==1.0           # via jinja2
 mccabe==0.6.1             # via flake8
 mock==2.0.0
 numpy==1.14.0             # via pandas
-pandas>=0.24.0
+pandas==0.24.1
 parameterized==0.6.1
 pathlib2==2.3.0
 pbr==3.1.1                # via mock

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ except ImportError:
     from urllib2 import urlopen, URLError
 
 
-KTOOLS_VERSION = '3.0.6'
+KTOOLS_VERSION = '3.0.5'
 
 SCRIPT_DIR = os.path.abspath(os.path.dirname(__file__))
 

--- a/tests/model_execution/test_bin.py
+++ b/tests/model_execution/test_bin.py
@@ -536,7 +536,7 @@ class PrepareRunDirectory(TestCase):
 
             prepare_run_directory(run_dir, oasis_src_fp, model_data_fp, analysis_settings_fp.name)
 
-            with io_open(os.path.join(run_dir, 'analysis_settings.json'), encoding='utf-8') as expected_analysis_settings:
+            with io_open(os.path.join(run_dir, analysis_settings_fp.name), encoding='utf-8') as expected_analysis_settings:
                 self.assertEqual('{"analysis_settings": "analysis_settings"}', expected_analysis_settings.read())
 
     def test_model_data_src_is_supplied___symlink_to_output_dir_static_is_created(self):


### PR DESCRIPTION
* Preserve original filename of the analysis settings file during the model run directory preparation step in the model execution stage
* Upgrade Pandas version to a minimum of `0.24.0`
* Downgrade ktools version to `3.0.5` (due to fmcalc problems in version `3.0.6`)