### PR TITLE
Fixes in peril areas Rtree file index generation cmd

### DIFF
--- a/oasislmf/cli/model.py
+++ b/oasislmf/cli/model.py
@@ -106,11 +106,13 @@ class GeneratePerilAreasRtreeFileIndexCmd(OasisBaseCommand):
 
         index_fp = as_path(inputs.get('index_file_path', required=True, is_path=True), 'Index output file path', preexists=False)
 
-        om().generate_peril_areas_rtree_file_index(
+        _index_fp = om().generate_peril_areas_rtree_file_index(
             keys_data_fp,
             index_fp,
             lookup_config_fp=config_fp
         )
+
+        self.logger.info('\nGenerated peril areas Rtree file index {}\n'.format(_index_fp))
 
 
 class GenerateKeysCmd(OasisBaseCommand):

--- a/oasislmf/manager.py
+++ b/oasislmf/manager.py
@@ -176,7 +176,7 @@ class OasisManager(object):
 
         config = lookup_config or get_json(src_fp=lookup_config_fp)
 
-        config_dir = os.path.dirname(config_fp)
+        config_dir = os.path.dirname(lookup_config_fp) if lookup_config_fp else keys_data_fp
 
         peril_config = config.get('peril')
 


### PR DESCRIPTION
* set lookup config. file parent folder path consistently
* log results to stdout in cmd