### PR TITLE
Improvements to error logging, debugging, test runner

### DIFF
--- a/oasislmf/cli/base.py
+++ b/oasislmf/cli/base.py
@@ -102,6 +102,8 @@ class OasisBaseCommand(BaseCommand):
     """
     def __init__(self, *args, **kwargs):
         self._logger = None
+        self.args = None
+        self.log_verbose = False
         super(OasisBaseCommand, self).__init__(*args, **kwargs)
 
     def add_args(self, parser):
@@ -129,18 +131,19 @@ class OasisBaseCommand(BaseCommand):
         """
         try:
             self.args = super(OasisBaseCommand, self).parse_args()
-            self.setup_logger(self.args.verbose)
+            self.log_verbose = self.args.verbose
+            self.setup_logger()
             return self.args
         except Exception:
-            self.setup_logger(False)
+            self.setup_logger()
             raise
 
-    def setup_logger(self, verbose):
+    def setup_logger(self):
         """
         The logger to use for the command with the verbosity set
         """
         if not self._logger:
-            if verbose:
+            if self.log_verbose:
                 log_level = logging.DEBUG
                 log_format = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
             else:

--- a/oasislmf/cli/root.py
+++ b/oasislmf/cli/root.py
@@ -39,5 +39,9 @@ class RootCmd(OasisBaseCommand):
         try:
             return super(OasisBaseCommand, self).run(args=args)
         except OasisException as e:
-            self.logger.error(str(e))
+            if self.log_verbose:
+                # Log with traceback
+                self.logger.exception(str(e))
+            else:
+                self.logger.error(str(e))
             return 1

--- a/oasislmf/manager.py
+++ b/oasislmf/manager.py
@@ -614,7 +614,7 @@ class OasisManager(object):
         try:
             check_call(cmd, shell=True)
         except CalledProcessError as e:
-            raise OasisException(e)
+            raise OasisException from e
 
         guls.drop(guls[guls['sidx'] != 1].index, inplace=True)
         guls.reset_index(drop=True, inplace=True)
@@ -663,7 +663,7 @@ class OasisManager(object):
                         try:
                             check_call(cmd, shell=True)
                         except CalledProcessError as e:
-                            raise OasisException(e)
+                            raise OasisException from e
                         rils = pd.read_csv(ri_layer_fp)
                         rils.drop(rils[rils['sidx'] != 1].index, inplace=True)
                         rils.drop('sidx', axis=1, inplace=True)

--- a/oasislmf/model_execution/bash.py
+++ b/oasislmf/model_execution/bash.py
@@ -31,10 +31,12 @@ WAIT_PROCESSING_SWITCHES = {
     'wheatsheaf_mean_oep': '-m',
 }
 
+
 def print_command(command_file, cmd):
     """
     Writes the supplied command to the end of the generated script
 
+    :param command_file: File to append command to.
     :param cmd: The command to append
     """
     with io.open(command_file, "a", encoding='utf-8') as myfile:
@@ -178,7 +180,8 @@ def remove_workfolders(runtype, analysis_settings, filename):
 def do_make_fifos(runtype, analysis_settings, process_id, filename, fifo_dir=''):
     do_fifos('mkfifo', runtype, analysis_settings, process_id, filename, fifo_dir)
 
-def do_ktools_mem_limit(max_process_id ,filename):
+
+def do_ktools_mem_limit(max_process_id, filename):
     """
         Set each Ktools pipeline to trap and terminate on hitting its
         memory allocation limit
@@ -187,6 +190,7 @@ def do_ktools_mem_limit(max_process_id ,filename):
     """
     cmd_mem_limit = 'ulimit -v $(ktgetmem {})'.format(max_process_id)
     print_command(filename, cmd_mem_limit)
+
 
 def do_remove_fifos(runtype, analysis_settings, process_id, filename, fifo_dir=''):
     do_fifos('rm', runtype, analysis_settings, process_id, filename, fifo_dir)
@@ -241,8 +245,8 @@ def do_kats(runtype, analysis_settings, max_process_id, filename, process_counte
     return anykats
 
 
-def do_summarycalcs(
-    runtype, analysis_settings, process_id, filename, fifo_dir='', num_reinsurance_iterations=0):
+def do_summarycalcs(runtype, analysis_settings, process_id, filename, fifo_dir='',
+                    num_reinsurance_iterations=0):
 
     summaries = analysis_settings.get('{}_summaries'.format(runtype))
     if not summaries:
@@ -344,7 +348,6 @@ def do_any(runtype, analysis_settings, process_id, filename, process_counter, fi
                     )
                 )
 
-
         print_command(filename, '')
 
 
@@ -421,6 +424,9 @@ def do_waits(wait_variable, wait_count, filename):
 
     :param wait_count: The number of processes to wait for
     :type wait_count: int
+
+    :param filename: Script to add waits to
+    :type filename: str
     """
     if wait_count > 0:
         cmd = 'wait'
@@ -460,9 +466,9 @@ def do_kwaits(filename, process_counter):
 
 
 def get_getmodel_cmd(
-    number_of_samples, gul_threshold, use_random_number_file, 
-    coverage_output, item_output,
-    process_id, max_process_id, **kwargs):
+        number_of_samples, gul_threshold, use_random_number_file,
+        coverage_output, item_output,
+        process_id, max_process_id, **kwargs):
     """
     Gets the getmodel ktools command
 
@@ -573,6 +579,9 @@ def genbash(
 
     print_command(filename, '#!/bin/bash')
 
+    # Use 'set -e' so that any errors in script commands are passed back
+    print_command(filename, '')
+    print_command(filename, 'set -e')
     print_command(filename, '')
 
     print_command(filename, 'rm -R -f output/*')
@@ -630,7 +639,7 @@ def genbash(
 
     for process_id in range(1, max_process_id + 1):
 
-        ##! Should be able to streamline the logic a little
+        # ! Should be able to streamline the logic a little
         if num_reinsurance_iterations > 0 and ri_output:
 
             getmodel_args = {
@@ -755,6 +764,11 @@ def genbash(
 
     do_awaits(filename, process_counter)  # waits for aalcalc
     do_lwaits(filename, process_counter)  # waits for leccalc
+
+    # Unset '-e' so that a failure to remove temoprary files doesn't kill the entire model run
+    print_command(filename, '')
+    print_command(filename, 'set +e')
+    print_command(filename, '')
 
     if gul_output:
         do_gul_remove_fifo(analysis_settings, max_process_id, filename, fifo_queue_dir)

--- a/oasislmf/model_execution/bin.py
+++ b/oasislmf/model_execution/bin.py
@@ -163,7 +163,7 @@ def prepare_run_directory(
             except Exception:
                 shutil.copytree(model_data_fp, os.path.join(model_data_dst_fp, fn))
     except OSError as e:
-        raise OasisException(e)
+        raise OasisException from e
 
 
 def _prepare_input_bin(run_dir, bin_name, model_settings, setting_key=None, ri=False):
@@ -205,7 +205,7 @@ def prepare_run_inputs(analysis_settings, run_dir, ri=False):
         if os.path.exists(os.path.join(run_dir, 'static', 'periods.bin')):
             _prepare_input_bin(run_dir, 'periods', model_settings, ri=ri)
     except (OSError, IOError) as e:
-        raise OasisException(e)
+        raise OasisException from e
 
 
 @oasis_log
@@ -310,7 +310,7 @@ def _csv_to_bin(csv_directory, bin_directory, il=False):
         try:
             subprocess.check_call(cmd_str, stderr=subprocess.STDOUT, shell=True)
         except subprocess.CalledProcessError as e:
-            raise OasisException(e)
+            raise OasisException from e
 
 @oasis_log
 def check_binary_tar_file(tar_file_path, check_il=False):

--- a/oasislmf/model_preparation/gul_inputs.py
+++ b/oasislmf/model_preparation/gul_inputs.py
@@ -263,7 +263,7 @@ def get_gul_input_items(
         }
         set_dataframe_column_dtypes(gul_inputs_df, col_dtypes)
     except (AttributeError, KeyError, IndexError, TypeError, ValueError) as e:
-        raise OasisException(e)
+        raise OasisException from e
 
     return gul_inputs_df, exposure_df
 
@@ -291,7 +291,7 @@ def write_complex_items_file(gul_inputs_df, complex_items_fp, chunksize=100000):
             index=False
         )
     except (IOError, OSError) as e:
-        raise OasisException(e)
+        raise OasisException from e
 
 
 @oasis_log
@@ -317,7 +317,7 @@ def write_items_file(gul_inputs_df, items_fp, chunksize=100000):
             index=False
         )
     except (IOError, OSError) as e:
-        raise OasisException(e)
+        raise OasisException from e
 
     return items_fp
 
@@ -345,7 +345,7 @@ def write_coverages_file(gul_inputs_df, coverages_fp, chunksize=100000):
             index=False
         )
     except (IOError, OSError) as e:
-        raise OasisException(e)
+        raise OasisException from e
 
     return coverages_fp
 
@@ -373,7 +373,7 @@ def write_gulsummaryxref_file(gul_inputs_df, gulsummaryxref_fp, chunksize=100000
             index=False
         )
     except (IOError, OSError) as e:
-        raise OasisException(e)
+        raise OasisException from e
 
     return gulsummaryxref_fp
 

--- a/oasislmf/model_preparation/il_inputs.py
+++ b/oasislmf/model_preparation/il_inputs.py
@@ -502,7 +502,7 @@ def get_il_input_items(
         il_inputs_calc_rules_df = merge_dataframes(il_inputs_calc_rules_df, calc_rules, how='left', on='id_key')
         il_inputs_df['calcrule_id'] = il_inputs_calc_rules_df['calcrule_id']
     except (AttributeError, KeyError, IndexError, TypeError, ValueError) as e:
-        raise OasisException(e)
+        raise OasisException from e
 
     return il_inputs_df, accounts_df
 
@@ -538,7 +538,7 @@ def write_fm_policytc_file(il_inputs_df, fm_policytc_fp, chunksize=100000):
             index=False
         )
     except (IOError, OSError) as e:
-        raise OasisException(e)
+        raise OasisException from e
 
     return fm_policytc_fp
 
@@ -586,7 +586,7 @@ def write_fm_profile_file(il_inputs_df, fm_profile_fp, chunksize=100000):
             index=False
         )
     except (IOError, OSError) as e:
-        raise OasisException(e)
+        raise OasisException from e
 
     return fm_profile_fp
 
@@ -633,7 +633,7 @@ def write_fm_programme_file(il_inputs_df, fm_programme_fp, chunksize=100000):
             index=False
         )
     except (IOError, OSError) as e:
-        raise OasisException(e)
+        raise OasisException from e
 
     return fm_programme_fp
 
@@ -668,7 +668,7 @@ def write_fm_xref_file(il_inputs_df, fm_xref_fp, chunksize=100000):
             index=False
         )
     except (IOError, OSError) as e:
-        raise OasisException(e)
+        raise OasisException from e
 
     return fm_xref_fp
 
@@ -703,7 +703,7 @@ def write_fmsummaryxref_file(il_inputs_df, fmsummaryxref_fp, chunksize=100000):
             index=False
         )
     except (IOError, OSError) as e:
-        raise OasisException(e)
+        raise OasisException from e
 
     return fmsummaryxref_fp
 

--- a/oasislmf/model_preparation/utils.py
+++ b/oasislmf/model_preparation/utils.py
@@ -57,6 +57,6 @@ def prepare_input_files_directory(
                 dst = os.path.join(target_dir, os.path.basename(src))
                 shutil.copy2(src, target_dir) if not (os.path.exists(dst) and filecmp.cmp(src, dst, shallow=False)) else None
     except (FileNotFoundError, IOError, OSError, shutil.Error, TypeError, ValueError) as e:
-        raise OasisException(e)
+        raise OasisException from e
 
     return target_dir

--- a/oasislmf/utils/compress.py
+++ b/oasislmf/utils/compress.py
@@ -46,6 +46,6 @@ def compress_data(s):
 
         compressed += compressor.flush()
     except zlib.error as e:
-        raise OasisException(str(e))
+        raise OasisException from e
 
     return compressed

--- a/oasislmf/utils/conf.py
+++ b/oasislmf/utils/conf.py
@@ -35,7 +35,7 @@ def load_ini_file(ini_file_path):
                 l.strip() for l in [l for l in f.read().split('\n') if l and not l.startswith('[')]
             ]
     except IOError as e:
-        raise OasisException(str(e))
+        raise OasisException from e
 
     di = {
         kv[0].strip(): kv[1].strip() for kv in tuple(line.split('=') for line in lines)
@@ -82,4 +82,4 @@ def replace_in_file(source_file_path, target_file_path, var_names, var_values):
                         outline = outline.replace(var_name, var_value)
                 f.write(outline)
     except (OSError, IOError) as e:
-        raise OasisException(str(e))
+        raise OasisException from e

--- a/oasislmf/utils/diff.py
+++ b/oasislmf/utils/diff.py
@@ -37,7 +37,7 @@ def unified_diff(file1, file2, as_string=False):
                     tofile=f2.name,
                 )
     except (OSError, IOError) as e:
-        raise OasisException(str(e))
+        raise OasisException from e
 
     if as_string:
         return ''.join(diff)

--- a/tests/model_execution/kparse_reference/all_calcs_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/all_calcs_1_output_1_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -72,6 +74,9 @@ leccalc -r -Kil_S1_summaryleccalc -F output/il_S1_leccalc_full_uncertainty_aep.c
 aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv & lpid3=$!
 leccalc -r -Kgul_S1_summaryleccalc -F output/gul_S1_leccalc_full_uncertainty_aep.csv -f output/gul_S1_leccalc_full_uncertainty_oep.csv -S output/gul_S1_leccalc_sample_mean_aep.csv -s output/gul_S1_leccalc_sample_mean_oep.csv -W output/gul_S1_leccalc_wheatsheaf_aep.csv -M output/gul_S1_leccalc_wheatsheaf_mean_aep.csv -m output/gul_S1_leccalc_wheatsheaf_mean_oep.csv -w output/gul_S1_leccalc_wheatsheaf_oep.csv & lpid4=$!
 wait $lpid1 $lpid2 $lpid3 $lpid4
+
+
+set +e
 
 rm fifo/gul_P1
 

--- a/tests/model_execution/kparse_reference/all_calcs_1_output_20_partition.sh
+++ b/tests/model_execution/kparse_reference/all_calcs_1_output_20_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -699,6 +701,9 @@ leccalc -r -Kil_S1_summaryleccalc -F output/il_S1_leccalc_full_uncertainty_aep.c
 aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv & lpid3=$!
 leccalc -r -Kgul_S1_summaryleccalc -F output/gul_S1_leccalc_full_uncertainty_aep.csv -f output/gul_S1_leccalc_full_uncertainty_oep.csv -S output/gul_S1_leccalc_sample_mean_aep.csv -s output/gul_S1_leccalc_sample_mean_oep.csv -W output/gul_S1_leccalc_wheatsheaf_aep.csv -M output/gul_S1_leccalc_wheatsheaf_mean_aep.csv -m output/gul_S1_leccalc_wheatsheaf_mean_oep.csv -w output/gul_S1_leccalc_wheatsheaf_oep.csv & lpid4=$!
 wait $lpid1 $lpid2 $lpid3 $lpid4
+
+
+set +e
 
 rm fifo/gul_P1
 

--- a/tests/model_execution/kparse_reference/all_calcs_1_output_40_partition.sh
+++ b/tests/model_execution/kparse_reference/all_calcs_1_output_40_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -1359,6 +1361,9 @@ leccalc -r -Kil_S1_summaryleccalc -F output/il_S1_leccalc_full_uncertainty_aep.c
 aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv & lpid3=$!
 leccalc -r -Kgul_S1_summaryleccalc -F output/gul_S1_leccalc_full_uncertainty_aep.csv -f output/gul_S1_leccalc_full_uncertainty_oep.csv -S output/gul_S1_leccalc_sample_mean_aep.csv -s output/gul_S1_leccalc_sample_mean_oep.csv -W output/gul_S1_leccalc_wheatsheaf_aep.csv -M output/gul_S1_leccalc_wheatsheaf_mean_aep.csv -m output/gul_S1_leccalc_wheatsheaf_mean_oep.csv -w output/gul_S1_leccalc_wheatsheaf_oep.csv & lpid4=$!
 wait $lpid1 $lpid2 $lpid3 $lpid4
+
+
+set +e
 
 rm fifo/gul_P1
 

--- a/tests/model_execution/kparse_reference/analysis_settings_1_1_partition.sh
+++ b/tests/model_execution/kparse_reference/analysis_settings_1_1_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -41,6 +43,9 @@ wait $kpid1 $kpid2 $kpid3
 
 aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv & lpid1=$!
 wait $lpid1
+
+
+set +e
 
 rm fifo/gul_P1
 

--- a/tests/model_execution/kparse_reference/analysis_settings_2_1_partition.sh
+++ b/tests/model_execution/kparse_reference/analysis_settings_2_1_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -41,6 +43,9 @@ wait $kpid1 $kpid2 $kpid3
 
 aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv & lpid1=$!
 wait $lpid1
+
+
+set +e
 
 rm fifo/gul_P1
 

--- a/tests/model_execution/kparse_reference/analysis_settings_3_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/kparse_reference/analysis_settings_3_1_reins_layer_1_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -96,6 +98,9 @@ aalcalc -Kri_S1_summaryaalcalc > output/ri_S1_aalcalc.csv & lpid1=$!
 aalcalc -Kil_S1_summaryaalcalc > output/il_S1_aalcalc.csv & lpid2=$!
 aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv & lpid3=$!
 wait $lpid1 $lpid2 $lpid3
+
+
+set +e
 
 rm fifo/gul_P1
 

--- a/tests/model_execution/kparse_reference/analysis_settings_4_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/kparse_reference/analysis_settings_4_1_reins_layer_1_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -98,6 +100,9 @@ leccalc -r -Kri_S1_summaryleccalc -F output/ri_S1_leccalc_full_uncertainty_aep.c
 aalcalc -Kil_S1_summaryaalcalc > output/il_S1_aalcalc.csv & lpid3=$!
 aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv & lpid4=$!
 wait $lpid1 $lpid2 $lpid3 $lpid4
+
+
+set +e
 
 rm fifo/gul_P1
 

--- a/tests/model_execution/kparse_reference/analysis_settings_tmpfifo_3_1_reins_layer_1_partition.template
+++ b/tests/model_execution/kparse_reference/analysis_settings_tmpfifo_3_1_reins_layer_1_partition.template
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f work/*
 
@@ -96,6 +98,9 @@ aalcalc -Kri_S1_summaryaalcalc > output/ri_S1_aalcalc.csv & lpid1=$!
 aalcalc -Kil_S1_summaryaalcalc > output/il_S1_aalcalc.csv & lpid2=$!
 aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv & lpid3=$!
 wait $lpid1 $lpid2 $lpid3
+
+
+set +e
 
 rm /tmp/%FIFO_DIR%/fifo/gul_P1
 

--- a/tests/model_execution/kparse_reference/analysis_settings_tmpfifo_memlim_4_1_reins_layer_1_partition.template
+++ b/tests/model_execution/kparse_reference/analysis_settings_tmpfifo_memlim_4_1_reins_layer_1_partition.template
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f work/*
 
@@ -106,6 +108,9 @@ leccalc -r -Kri_S1_summaryleccalc -F output/ri_S1_leccalc_full_uncertainty_aep.c
 aalcalc -Kil_S1_summaryaalcalc > output/il_S1_aalcalc.csv & lpid3=$!
 aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv & lpid4=$!
 wait $lpid1 $lpid2 $lpid3 $lpid4
+
+
+set +e
 
 rm /tmp/%FIFO_DIR%/fifo/gul_P1
 

--- a/tests/model_execution/kparse_reference/gul_aalcalc_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_aalcalc_1_output_1_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -27,6 +29,9 @@ wait $pid1
 
 aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv & lpid1=$!
 wait $lpid1
+
+
+set +e
 
 rm fifo/gul_P1
 

--- a/tests/model_execution/kparse_reference/gul_aalcalc_1_output_20_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_aalcalc_1_output_20_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -179,6 +181,9 @@ wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 
 
 aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv & lpid1=$!
 wait $lpid1
+
+
+set +e
 
 rm fifo/gul_P1
 

--- a/tests/model_execution/kparse_reference/gul_agg_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_agg_fu_lec_1_output_1_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -27,6 +29,9 @@ wait $pid1
 
 leccalc -r -Kgul_S1_summaryleccalc -F output/gul_S1_leccalc_full_uncertainty_aep.csv & lpid1=$!
 wait $lpid1
+
+
+set +e
 
 rm fifo/gul_P1
 

--- a/tests/model_execution/kparse_reference/gul_agg_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_agg_fu_lec_1_output_20_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -179,6 +181,9 @@ wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 
 
 leccalc -r -Kgul_S1_summaryleccalc -F output/gul_S1_leccalc_full_uncertainty_aep.csv & lpid1=$!
 wait $lpid1
+
+
+set +e
 
 rm fifo/gul_P1
 

--- a/tests/model_execution/kparse_reference/gul_agg_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_agg_ws_lec_1_output_1_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -27,6 +29,9 @@ wait $pid1
 
 leccalc -r -Kgul_S1_summaryleccalc -W output/gul_S1_leccalc_wheatsheaf_aep.csv & lpid1=$!
 wait $lpid1
+
+
+set +e
 
 rm fifo/gul_P1
 

--- a/tests/model_execution/kparse_reference/gul_agg_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_agg_ws_lec_1_output_20_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -179,6 +181,9 @@ wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 
 
 leccalc -r -Kgul_S1_summaryleccalc -W output/gul_S1_leccalc_wheatsheaf_aep.csv & lpid1=$!
 wait $lpid1
+
+
+set +e
 
 rm fifo/gul_P1
 

--- a/tests/model_execution/kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -27,6 +29,9 @@ wait $pid1
 
 leccalc -r -Kgul_S1_summaryleccalc -M output/gul_S1_leccalc_wheatsheaf_mean_aep.csv & lpid1=$!
 wait $lpid1
+
+
+set +e
 
 rm fifo/gul_P1
 

--- a/tests/model_execution/kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -179,6 +181,9 @@ wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 
 
 leccalc -r -Kgul_S1_summaryleccalc -M output/gul_S1_leccalc_wheatsheaf_mean_aep.csv & lpid1=$!
 wait $lpid1
+
+
+set +e
 
 rm fifo/gul_P1
 

--- a/tests/model_execution/kparse_reference/gul_agg_ws_mean_lec_1_tmpfifo_memlim_output_20_partition.template
+++ b/tests/model_execution/kparse_reference/gul_agg_ws_mean_lec_1_tmpfifo_memlim_output_20_partition.template
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f work/*
 
@@ -187,6 +189,9 @@ ulimit -v $(ktgetmem 1)
 
 leccalc -r -Kgul_S1_summaryleccalc -M output/gul_S1_leccalc_wheatsheaf_mean_aep.csv & lpid1=$!
 wait $lpid1
+
+
+set +e
 
 rm /tmp/%FIFO_DIR%/fifo/gul_P1
 

--- a/tests/model_execution/kparse_reference/gul_eltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_eltcalc_1_output_1_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -29,6 +31,9 @@ wait $pid1 $pid2
 kat work/kat/gul_S1_eltcalc_P1 > output/gul_S1_eltcalc.csv & kpid1=$!
 wait $kpid1
 
+
+
+set +e
 
 rm fifo/gul_P1
 

--- a/tests/model_execution/kparse_reference/gul_eltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_eltcalc_1_output_20_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -238,6 +240,9 @@ wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 
 kat work/kat/gul_S1_eltcalc_P1 work/kat/gul_S1_eltcalc_P2 work/kat/gul_S1_eltcalc_P3 work/kat/gul_S1_eltcalc_P4 work/kat/gul_S1_eltcalc_P5 work/kat/gul_S1_eltcalc_P6 work/kat/gul_S1_eltcalc_P7 work/kat/gul_S1_eltcalc_P8 work/kat/gul_S1_eltcalc_P9 work/kat/gul_S1_eltcalc_P10 work/kat/gul_S1_eltcalc_P11 work/kat/gul_S1_eltcalc_P12 work/kat/gul_S1_eltcalc_P13 work/kat/gul_S1_eltcalc_P14 work/kat/gul_S1_eltcalc_P15 work/kat/gul_S1_eltcalc_P16 work/kat/gul_S1_eltcalc_P17 work/kat/gul_S1_eltcalc_P18 work/kat/gul_S1_eltcalc_P19 work/kat/gul_S1_eltcalc_P20 > output/gul_S1_eltcalc.csv & kpid1=$!
 wait $kpid1
 
+
+
+set +e
 
 rm fifo/gul_P1
 

--- a/tests/model_execution/kparse_reference/gul_il_lec_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_il_lec_1_output_1_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -72,6 +74,9 @@ leccalc -r -Kil_S1_summaryleccalc -F output/il_S1_leccalc_full_uncertainty_aep.c
 aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv & lpid3=$!
 leccalc -r -Kgul_S1_summaryleccalc -F output/gul_S1_leccalc_full_uncertainty_aep.csv -f output/gul_S1_leccalc_full_uncertainty_oep.csv -S output/gul_S1_leccalc_sample_mean_aep.csv -s output/gul_S1_leccalc_sample_mean_oep.csv -W output/gul_S1_leccalc_wheatsheaf_aep.csv -M output/gul_S1_leccalc_wheatsheaf_mean_aep.csv -m output/gul_S1_leccalc_wheatsheaf_mean_oep.csv -w output/gul_S1_leccalc_wheatsheaf_oep.csv & lpid4=$!
 wait $lpid1 $lpid2 $lpid3 $lpid4
+
+
+set +e
 
 rm fifo/gul_P1
 

--- a/tests/model_execution/kparse_reference/gul_il_lec_1_output_2_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_il_lec_1_output_2_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -105,6 +107,9 @@ leccalc -r -Kil_S1_summaryleccalc -F output/il_S1_leccalc_full_uncertainty_aep.c
 aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv & lpid3=$!
 leccalc -r -Kgul_S1_summaryleccalc -F output/gul_S1_leccalc_full_uncertainty_aep.csv -f output/gul_S1_leccalc_full_uncertainty_oep.csv -S output/gul_S1_leccalc_sample_mean_aep.csv -s output/gul_S1_leccalc_sample_mean_oep.csv -W output/gul_S1_leccalc_wheatsheaf_aep.csv -M output/gul_S1_leccalc_wheatsheaf_mean_aep.csv -m output/gul_S1_leccalc_wheatsheaf_mean_oep.csv -w output/gul_S1_leccalc_wheatsheaf_oep.csv & lpid4=$!
 wait $lpid1 $lpid2 $lpid3 $lpid4
+
+
+set +e
 
 rm fifo/gul_P1
 

--- a/tests/model_execution/kparse_reference/gul_il_lec_2_output_10_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_il_lec_2_output_10_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -623,6 +625,9 @@ leccalc -r -Kgul_S1_summaryleccalc -F output/gul_S1_leccalc_full_uncertainty_aep
 aalcalc -Kgul_S2_summaryaalcalc > output/gul_S2_aalcalc.csv & lpid7=$!
 leccalc -r -Kgul_S2_summaryleccalc -F output/gul_S2_leccalc_full_uncertainty_aep.csv -f output/gul_S2_leccalc_full_uncertainty_oep.csv -S output/gul_S2_leccalc_sample_mean_aep.csv -s output/gul_S2_leccalc_sample_mean_oep.csv -W output/gul_S2_leccalc_wheatsheaf_aep.csv -M output/gul_S2_leccalc_wheatsheaf_mean_aep.csv -m output/gul_S2_leccalc_wheatsheaf_mean_oep.csv -w output/gul_S2_leccalc_wheatsheaf_oep.csv & lpid8=$!
 wait $lpid1 $lpid2 $lpid3 $lpid4 $lpid5 $lpid6 $lpid7 $lpid8
+
+
+set +e
 
 rm fifo/gul_P1
 

--- a/tests/model_execution/kparse_reference/gul_il_lec_2_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_il_lec_2_output_1_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -110,6 +112,9 @@ leccalc -r -Kgul_S1_summaryleccalc -F output/gul_S1_leccalc_full_uncertainty_aep
 aalcalc -Kgul_S2_summaryaalcalc > output/gul_S2_aalcalc.csv & lpid7=$!
 leccalc -r -Kgul_S2_summaryleccalc -F output/gul_S2_leccalc_full_uncertainty_aep.csv -f output/gul_S2_leccalc_full_uncertainty_oep.csv -S output/gul_S2_leccalc_sample_mean_aep.csv -s output/gul_S2_leccalc_sample_mean_oep.csv -W output/gul_S2_leccalc_wheatsheaf_aep.csv -M output/gul_S2_leccalc_wheatsheaf_mean_aep.csv -m output/gul_S2_leccalc_wheatsheaf_mean_oep.csv -w output/gul_S2_leccalc_wheatsheaf_oep.csv & lpid8=$!
 wait $lpid1 $lpid2 $lpid3 $lpid4 $lpid5 $lpid6 $lpid7 $lpid8
+
+
+set +e
 
 rm fifo/gul_P1
 

--- a/tests/model_execution/kparse_reference/gul_il_lec_2_output_2_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_il_lec_2_output_2_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -167,6 +169,9 @@ leccalc -r -Kgul_S1_summaryleccalc -F output/gul_S1_leccalc_full_uncertainty_aep
 aalcalc -Kgul_S2_summaryaalcalc > output/gul_S2_aalcalc.csv & lpid7=$!
 leccalc -r -Kgul_S2_summaryleccalc -F output/gul_S2_leccalc_full_uncertainty_aep.csv -f output/gul_S2_leccalc_full_uncertainty_oep.csv -S output/gul_S2_leccalc_sample_mean_aep.csv -s output/gul_S2_leccalc_sample_mean_oep.csv -W output/gul_S2_leccalc_wheatsheaf_aep.csv -M output/gul_S2_leccalc_wheatsheaf_mean_aep.csv -m output/gul_S2_leccalc_wheatsheaf_mean_oep.csv -w output/gul_S2_leccalc_wheatsheaf_oep.csv & lpid8=$!
 wait $lpid1 $lpid2 $lpid3 $lpid4 $lpid5 $lpid6 $lpid7 $lpid8
+
+
+set +e
 
 rm fifo/gul_P1
 

--- a/tests/model_execution/kparse_reference/gul_il_lec_2_tmpfifo_output_10_partition.template
+++ b/tests/model_execution/kparse_reference/gul_il_lec_2_tmpfifo_output_10_partition.template
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f work/*
 
@@ -623,6 +625,9 @@ leccalc -r -Kgul_S1_summaryleccalc -F output/gul_S1_leccalc_full_uncertainty_aep
 aalcalc -Kgul_S2_summaryaalcalc > output/gul_S2_aalcalc.csv & lpid7=$!
 leccalc -r -Kgul_S2_summaryleccalc -F output/gul_S2_leccalc_full_uncertainty_aep.csv -f output/gul_S2_leccalc_full_uncertainty_oep.csv -S output/gul_S2_leccalc_sample_mean_aep.csv -s output/gul_S2_leccalc_sample_mean_oep.csv -W output/gul_S2_leccalc_wheatsheaf_aep.csv -M output/gul_S2_leccalc_wheatsheaf_mean_aep.csv -m output/gul_S2_leccalc_wheatsheaf_mean_oep.csv -w output/gul_S2_leccalc_wheatsheaf_oep.csv & lpid8=$!
 wait $lpid1 $lpid2 $lpid3 $lpid4 $lpid5 $lpid6 $lpid7 $lpid8
+
+
+set +e
 
 rm /tmp/%FIFO_DIR%/fifo/gul_P1
 

--- a/tests/model_execution/kparse_reference/gul_il_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_il_no_lec_1_output_1_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -68,6 +70,9 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 aalcalc -Kil_S1_summaryaalcalc > output/il_S1_aalcalc.csv & lpid1=$!
 aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv & lpid2=$!
 wait $lpid1 $lpid2
+
+
+set +e
 
 rm fifo/gul_P1
 

--- a/tests/model_execution/kparse_reference/gul_il_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_il_no_lec_1_output_2_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -101,6 +103,9 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 aalcalc -Kil_S1_summaryaalcalc > output/il_S1_aalcalc.csv & lpid1=$!
 aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv & lpid2=$!
 wait $lpid1 $lpid2
+
+
+set +e
 
 rm fifo/gul_P1
 

--- a/tests/model_execution/kparse_reference/gul_il_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_il_no_lec_2_output_1_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -102,6 +104,9 @@ aalcalc -Kil_S2_summaryaalcalc > output/il_S2_aalcalc.csv & lpid2=$!
 aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv & lpid3=$!
 aalcalc -Kgul_S2_summaryaalcalc > output/gul_S2_aalcalc.csv & lpid4=$!
 wait $lpid1 $lpid2 $lpid3 $lpid4
+
+
+set +e
 
 rm fifo/gul_P1
 

--- a/tests/model_execution/kparse_reference/gul_il_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_il_no_lec_2_output_2_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -159,6 +161,9 @@ aalcalc -Kil_S2_summaryaalcalc > output/il_S2_aalcalc.csv & lpid2=$!
 aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv & lpid3=$!
 aalcalc -Kgul_S2_summaryaalcalc > output/gul_S2_aalcalc.csv & lpid4=$!
 wait $lpid1 $lpid2 $lpid3 $lpid4
+
+
+set +e
 
 rm fifo/gul_P1
 

--- a/tests/model_execution/kparse_reference/gul_lec_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_lec_1_output_1_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -43,6 +45,9 @@ wait $kpid1 $kpid2 $kpid3
 aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv & lpid1=$!
 leccalc -r -Kgul_S1_summaryleccalc -F output/gul_S1_leccalc_full_uncertainty_aep.csv -f output/gul_S1_leccalc_full_uncertainty_oep.csv -S output/gul_S1_leccalc_sample_mean_aep.csv -s output/gul_S1_leccalc_sample_mean_oep.csv -W output/gul_S1_leccalc_wheatsheaf_aep.csv -M output/gul_S1_leccalc_wheatsheaf_mean_aep.csv -m output/gul_S1_leccalc_wheatsheaf_mean_oep.csv -w output/gul_S1_leccalc_wheatsheaf_oep.csv & lpid2=$!
 wait $lpid1 $lpid2
+
+
+set +e
 
 rm fifo/gul_P1
 

--- a/tests/model_execution/kparse_reference/gul_lec_1_output_2_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_lec_1_output_2_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -60,6 +62,9 @@ wait $kpid1 $kpid2 $kpid3
 aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv & lpid1=$!
 leccalc -r -Kgul_S1_summaryleccalc -F output/gul_S1_leccalc_full_uncertainty_aep.csv -f output/gul_S1_leccalc_full_uncertainty_oep.csv -S output/gul_S1_leccalc_sample_mean_aep.csv -s output/gul_S1_leccalc_sample_mean_oep.csv -W output/gul_S1_leccalc_wheatsheaf_aep.csv -M output/gul_S1_leccalc_wheatsheaf_mean_aep.csv -m output/gul_S1_leccalc_wheatsheaf_mean_oep.csv -w output/gul_S1_leccalc_wheatsheaf_oep.csv & lpid2=$!
 wait $lpid1 $lpid2
+
+
+set +e
 
 rm fifo/gul_P1
 

--- a/tests/model_execution/kparse_reference/gul_lec_2_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_lec_2_output_1_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -62,6 +64,9 @@ leccalc -r -Kgul_S1_summaryleccalc -F output/gul_S1_leccalc_full_uncertainty_aep
 aalcalc -Kgul_S2_summaryaalcalc > output/gul_S2_aalcalc.csv & lpid3=$!
 leccalc -r -Kgul_S2_summaryleccalc -F output/gul_S2_leccalc_full_uncertainty_aep.csv -f output/gul_S2_leccalc_full_uncertainty_oep.csv -S output/gul_S2_leccalc_sample_mean_aep.csv -s output/gul_S2_leccalc_sample_mean_oep.csv -W output/gul_S2_leccalc_wheatsheaf_aep.csv -M output/gul_S2_leccalc_wheatsheaf_mean_aep.csv -m output/gul_S2_leccalc_wheatsheaf_mean_oep.csv -w output/gul_S2_leccalc_wheatsheaf_oep.csv & lpid4=$!
 wait $lpid1 $lpid2 $lpid3 $lpid4
+
+
+set +e
 
 rm fifo/gul_P1
 

--- a/tests/model_execution/kparse_reference/gul_lec_2_output_2_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_lec_2_output_2_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -91,6 +93,9 @@ leccalc -r -Kgul_S1_summaryleccalc -F output/gul_S1_leccalc_full_uncertainty_aep
 aalcalc -Kgul_S2_summaryaalcalc > output/gul_S2_aalcalc.csv & lpid3=$!
 leccalc -r -Kgul_S2_summaryleccalc -F output/gul_S2_leccalc_full_uncertainty_aep.csv -f output/gul_S2_leccalc_full_uncertainty_oep.csv -S output/gul_S2_leccalc_sample_mean_aep.csv -s output/gul_S2_leccalc_sample_mean_oep.csv -W output/gul_S2_leccalc_wheatsheaf_aep.csv -M output/gul_S2_leccalc_wheatsheaf_mean_aep.csv -m output/gul_S2_leccalc_wheatsheaf_mean_oep.csv -w output/gul_S2_leccalc_wheatsheaf_oep.csv & lpid4=$!
 wait $lpid1 $lpid2 $lpid3 $lpid4
+
+
+set +e
 
 rm fifo/gul_P1
 

--- a/tests/model_execution/kparse_reference/gul_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_no_lec_1_output_1_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -41,6 +43,9 @@ wait $kpid1 $kpid2 $kpid3
 
 aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv & lpid1=$!
 wait $lpid1
+
+
+set +e
 
 rm fifo/gul_P1
 

--- a/tests/model_execution/kparse_reference/gul_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_no_lec_1_output_2_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -58,6 +60,9 @@ wait $kpid1 $kpid2 $kpid3
 
 aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv & lpid1=$!
 wait $lpid1
+
+
+set +e
 
 rm fifo/gul_P1
 

--- a/tests/model_execution/kparse_reference/gul_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_no_lec_2_output_1_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -58,6 +60,9 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv & lpid1=$!
 aalcalc -Kgul_S2_summaryaalcalc > output/gul_S2_aalcalc.csv & lpid2=$!
 wait $lpid1 $lpid2
+
+
+set +e
 
 rm fifo/gul_P1
 

--- a/tests/model_execution/kparse_reference/gul_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_no_lec_2_output_2_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -87,6 +89,9 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv & lpid1=$!
 aalcalc -Kgul_S2_summaryaalcalc > output/gul_S2_aalcalc.csv & lpid2=$!
 wait $lpid1 $lpid2
+
+
+set +e
 
 rm fifo/gul_P1
 

--- a/tests/model_execution/kparse_reference/gul_occ_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_occ_fu_lec_1_output_1_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -27,6 +29,9 @@ wait $pid1
 
 leccalc -r -Kgul_S1_summaryleccalc -f output/gul_S1_leccalc_full_uncertainty_oep.csv & lpid1=$!
 wait $lpid1
+
+
+set +e
 
 rm fifo/gul_P1
 

--- a/tests/model_execution/kparse_reference/gul_occ_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_occ_fu_lec_1_output_20_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -179,6 +181,9 @@ wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 
 
 leccalc -r -Kgul_S1_summaryleccalc -f output/gul_S1_leccalc_full_uncertainty_oep.csv & lpid1=$!
 wait $lpid1
+
+
+set +e
 
 rm fifo/gul_P1
 

--- a/tests/model_execution/kparse_reference/gul_occ_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_occ_ws_lec_1_output_1_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -27,6 +29,9 @@ wait $pid1
 
 leccalc -r -Kgul_S1_summaryleccalc -w output/gul_S1_leccalc_wheatsheaf_oep.csv & lpid1=$!
 wait $lpid1
+
+
+set +e
 
 rm fifo/gul_P1
 

--- a/tests/model_execution/kparse_reference/gul_occ_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_occ_ws_lec_1_output_20_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -179,6 +181,9 @@ wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 
 
 leccalc -r -Kgul_S1_summaryleccalc -w output/gul_S1_leccalc_wheatsheaf_oep.csv & lpid1=$!
 wait $lpid1
+
+
+set +e
 
 rm fifo/gul_P1
 

--- a/tests/model_execution/kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -27,6 +29,9 @@ wait $pid1
 
 leccalc -r -Kgul_S1_summaryleccalc -m output/gul_S1_leccalc_wheatsheaf_mean_oep.csv & lpid1=$!
 wait $lpid1
+
+
+set +e
 
 rm fifo/gul_P1
 

--- a/tests/model_execution/kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -179,6 +181,9 @@ wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 
 
 leccalc -r -Kgul_S1_summaryleccalc -m output/gul_S1_leccalc_wheatsheaf_mean_oep.csv & lpid1=$!
 wait $lpid1
+
+
+set +e
 
 rm fifo/gul_P1
 

--- a/tests/model_execution/kparse_reference/gul_pltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_pltcalc_1_output_1_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -29,6 +31,9 @@ wait $pid1 $pid2
 kat work/kat/gul_S1_pltcalc_P1 > output/gul_S1_pltcalc.csv & kpid1=$!
 wait $kpid1
 
+
+
+set +e
 
 rm fifo/gul_P1
 

--- a/tests/model_execution/kparse_reference/gul_pltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_pltcalc_1_output_20_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -238,6 +240,9 @@ wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 
 kat work/kat/gul_S1_pltcalc_P1 work/kat/gul_S1_pltcalc_P2 work/kat/gul_S1_pltcalc_P3 work/kat/gul_S1_pltcalc_P4 work/kat/gul_S1_pltcalc_P5 work/kat/gul_S1_pltcalc_P6 work/kat/gul_S1_pltcalc_P7 work/kat/gul_S1_pltcalc_P8 work/kat/gul_S1_pltcalc_P9 work/kat/gul_S1_pltcalc_P10 work/kat/gul_S1_pltcalc_P11 work/kat/gul_S1_pltcalc_P12 work/kat/gul_S1_pltcalc_P13 work/kat/gul_S1_pltcalc_P14 work/kat/gul_S1_pltcalc_P15 work/kat/gul_S1_pltcalc_P16 work/kat/gul_S1_pltcalc_P17 work/kat/gul_S1_pltcalc_P18 work/kat/gul_S1_pltcalc_P19 work/kat/gul_S1_pltcalc_P20 > output/gul_S1_pltcalc.csv & kpid1=$!
 wait $kpid1
 
+
+
+set +e
 
 rm fifo/gul_P1
 

--- a/tests/model_execution/kparse_reference/gul_summarycalc_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_summarycalc_1_output_1_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -29,6 +31,9 @@ wait $pid1 $pid2
 kat work/kat/gul_S1_summarycalc_P1 > output/gul_S1_summarycalc.csv & kpid1=$!
 wait $kpid1
 
+
+
+set +e
 
 rm fifo/gul_P1
 

--- a/tests/model_execution/kparse_reference/gul_summarycalc_1_output_20_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_summarycalc_1_output_20_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -238,6 +240,9 @@ wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 
 kat work/kat/gul_S1_summarycalc_P1 work/kat/gul_S1_summarycalc_P2 work/kat/gul_S1_summarycalc_P3 work/kat/gul_S1_summarycalc_P4 work/kat/gul_S1_summarycalc_P5 work/kat/gul_S1_summarycalc_P6 work/kat/gul_S1_summarycalc_P7 work/kat/gul_S1_summarycalc_P8 work/kat/gul_S1_summarycalc_P9 work/kat/gul_S1_summarycalc_P10 work/kat/gul_S1_summarycalc_P11 work/kat/gul_S1_summarycalc_P12 work/kat/gul_S1_summarycalc_P13 work/kat/gul_S1_summarycalc_P14 work/kat/gul_S1_summarycalc_P15 work/kat/gul_S1_summarycalc_P16 work/kat/gul_S1_summarycalc_P17 work/kat/gul_S1_summarycalc_P18 work/kat/gul_S1_summarycalc_P19 work/kat/gul_S1_summarycalc_P20 > output/gul_S1_summarycalc.csv & kpid1=$!
 wait $kpid1
 
+
+
+set +e
 
 rm fifo/gul_P1
 

--- a/tests/model_execution/kparse_reference/il_aalcalc_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/il_aalcalc_1_output_1_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -27,6 +29,9 @@ wait $pid1
 
 aalcalc -Kil_S1_summaryaalcalc > output/il_S1_aalcalc.csv & lpid1=$!
 wait $lpid1
+
+
+set +e
 
 
 rm fifo/il_P1

--- a/tests/model_execution/kparse_reference/il_aalcalc_1_output_20_partition.sh
+++ b/tests/model_execution/kparse_reference/il_aalcalc_1_output_20_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -179,6 +181,9 @@ wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 
 
 aalcalc -Kil_S1_summaryaalcalc > output/il_S1_aalcalc.csv & lpid1=$!
 wait $lpid1
+
+
+set +e
 
 
 rm fifo/il_P1

--- a/tests/model_execution/kparse_reference/il_agg_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/il_agg_fu_lec_1_output_1_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -27,6 +29,9 @@ wait $pid1
 
 leccalc -r -Kil_S1_summaryleccalc -F output/il_S1_leccalc_full_uncertainty_aep.csv & lpid1=$!
 wait $lpid1
+
+
+set +e
 
 
 rm fifo/il_P1

--- a/tests/model_execution/kparse_reference/il_agg_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/kparse_reference/il_agg_fu_lec_1_output_20_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -179,6 +181,9 @@ wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 
 
 leccalc -r -Kil_S1_summaryleccalc -F output/il_S1_leccalc_full_uncertainty_aep.csv & lpid1=$!
 wait $lpid1
+
+
+set +e
 
 
 rm fifo/il_P1

--- a/tests/model_execution/kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -27,6 +29,9 @@ wait $pid1
 
 leccalc -r -Kil_S1_summaryleccalc -S output/il_S1_leccalc_sample_mean_aep.csv & lpid1=$!
 wait $lpid1
+
+
+set +e
 
 
 rm fifo/il_P1

--- a/tests/model_execution/kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -179,6 +181,9 @@ wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 
 
 leccalc -r -Kil_S1_summaryleccalc -S output/il_S1_leccalc_sample_mean_aep.csv & lpid1=$!
 wait $lpid1
+
+
+set +e
 
 
 rm fifo/il_P1

--- a/tests/model_execution/kparse_reference/il_agg_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/il_agg_ws_lec_1_output_1_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -27,6 +29,9 @@ wait $pid1
 
 leccalc -r -Kil_S1_summaryleccalc -W output/il_S1_leccalc_wheatsheaf_aep.csv & lpid1=$!
 wait $lpid1
+
+
+set +e
 
 
 rm fifo/il_P1

--- a/tests/model_execution/kparse_reference/il_agg_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/kparse_reference/il_agg_ws_lec_1_output_20_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -179,6 +181,9 @@ wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 
 
 leccalc -r -Kil_S1_summaryleccalc -W output/il_S1_leccalc_wheatsheaf_aep.csv & lpid1=$!
 wait $lpid1
+
+
+set +e
 
 
 rm fifo/il_P1

--- a/tests/model_execution/kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -27,6 +29,9 @@ wait $pid1
 
 leccalc -r -Kil_S1_summaryleccalc -M output/il_S1_leccalc_wheatsheaf_mean_aep.csv & lpid1=$!
 wait $lpid1
+
+
+set +e
 
 
 rm fifo/il_P1

--- a/tests/model_execution/kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -179,6 +181,9 @@ wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 
 
 leccalc -r -Kil_S1_summaryleccalc -M output/il_S1_leccalc_wheatsheaf_mean_aep.csv & lpid1=$!
 wait $lpid1
+
+
+set +e
 
 
 rm fifo/il_P1

--- a/tests/model_execution/kparse_reference/il_eltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/il_eltcalc_1_output_1_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -29,6 +31,9 @@ wait $pid1 $pid2
 kat work/kat/il_S1_eltcalc_P1 > output/il_S1_eltcalc.csv & kpid1=$!
 wait $kpid1
 
+
+
+set +e
 
 
 rm fifo/il_P1

--- a/tests/model_execution/kparse_reference/il_eltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/kparse_reference/il_eltcalc_1_output_20_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -238,6 +240,9 @@ wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 
 kat work/kat/il_S1_eltcalc_P1 work/kat/il_S1_eltcalc_P2 work/kat/il_S1_eltcalc_P3 work/kat/il_S1_eltcalc_P4 work/kat/il_S1_eltcalc_P5 work/kat/il_S1_eltcalc_P6 work/kat/il_S1_eltcalc_P7 work/kat/il_S1_eltcalc_P8 work/kat/il_S1_eltcalc_P9 work/kat/il_S1_eltcalc_P10 work/kat/il_S1_eltcalc_P11 work/kat/il_S1_eltcalc_P12 work/kat/il_S1_eltcalc_P13 work/kat/il_S1_eltcalc_P14 work/kat/il_S1_eltcalc_P15 work/kat/il_S1_eltcalc_P16 work/kat/il_S1_eltcalc_P17 work/kat/il_S1_eltcalc_P18 work/kat/il_S1_eltcalc_P19 work/kat/il_S1_eltcalc_P20 > output/il_S1_eltcalc.csv & kpid1=$!
 wait $kpid1
 
+
+
+set +e
 
 
 rm fifo/il_P1

--- a/tests/model_execution/kparse_reference/il_lec_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/il_lec_1_output_1_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -43,6 +45,9 @@ wait $kpid1 $kpid2 $kpid3
 aalcalc -Kil_S1_summaryaalcalc > output/il_S1_aalcalc.csv & lpid1=$!
 leccalc -r -Kil_S1_summaryleccalc -F output/il_S1_leccalc_full_uncertainty_aep.csv -f output/il_S1_leccalc_full_uncertainty_oep.csv -S output/il_S1_leccalc_sample_mean_aep.csv -s output/il_S1_leccalc_sample_mean_oep.csv -W output/il_S1_leccalc_wheatsheaf_aep.csv -M output/il_S1_leccalc_wheatsheaf_mean_aep.csv -m output/il_S1_leccalc_wheatsheaf_mean_oep.csv -w output/il_S1_leccalc_wheatsheaf_oep.csv & lpid2=$!
 wait $lpid1 $lpid2
+
+
+set +e
 
 
 rm fifo/il_P1

--- a/tests/model_execution/kparse_reference/il_lec_1_output_2_partition.sh
+++ b/tests/model_execution/kparse_reference/il_lec_1_output_2_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -60,6 +62,9 @@ wait $kpid1 $kpid2 $kpid3
 aalcalc -Kil_S1_summaryaalcalc > output/il_S1_aalcalc.csv & lpid1=$!
 leccalc -r -Kil_S1_summaryleccalc -F output/il_S1_leccalc_full_uncertainty_aep.csv -f output/il_S1_leccalc_full_uncertainty_oep.csv -S output/il_S1_leccalc_sample_mean_aep.csv -s output/il_S1_leccalc_sample_mean_oep.csv -W output/il_S1_leccalc_wheatsheaf_aep.csv -M output/il_S1_leccalc_wheatsheaf_mean_aep.csv -m output/il_S1_leccalc_wheatsheaf_mean_oep.csv -w output/il_S1_leccalc_wheatsheaf_oep.csv & lpid2=$!
 wait $lpid1 $lpid2
+
+
+set +e
 
 
 rm fifo/il_P1

--- a/tests/model_execution/kparse_reference/il_lec_2_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/il_lec_2_output_1_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -62,6 +64,9 @@ leccalc -r -Kil_S1_summaryleccalc -F output/il_S1_leccalc_full_uncertainty_aep.c
 aalcalc -Kil_S2_summaryaalcalc > output/il_S2_aalcalc.csv & lpid3=$!
 leccalc -r -Kil_S2_summaryleccalc -F output/il_S2_leccalc_full_uncertainty_aep.csv -f output/il_S2_leccalc_full_uncertainty_oep.csv -S output/il_S2_leccalc_sample_mean_aep.csv -s output/il_S2_leccalc_sample_mean_oep.csv -W output/il_S2_leccalc_wheatsheaf_aep.csv -M output/il_S2_leccalc_wheatsheaf_mean_aep.csv -m output/il_S2_leccalc_wheatsheaf_mean_oep.csv -w output/il_S2_leccalc_wheatsheaf_oep.csv & lpid4=$!
 wait $lpid1 $lpid2 $lpid3 $lpid4
+
+
+set +e
 
 
 rm fifo/il_P1

--- a/tests/model_execution/kparse_reference/il_lec_2_output_2_partition.sh
+++ b/tests/model_execution/kparse_reference/il_lec_2_output_2_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -91,6 +93,9 @@ leccalc -r -Kil_S1_summaryleccalc -F output/il_S1_leccalc_full_uncertainty_aep.c
 aalcalc -Kil_S2_summaryaalcalc > output/il_S2_aalcalc.csv & lpid3=$!
 leccalc -r -Kil_S2_summaryleccalc -F output/il_S2_leccalc_full_uncertainty_aep.csv -f output/il_S2_leccalc_full_uncertainty_oep.csv -S output/il_S2_leccalc_sample_mean_aep.csv -s output/il_S2_leccalc_sample_mean_oep.csv -W output/il_S2_leccalc_wheatsheaf_aep.csv -M output/il_S2_leccalc_wheatsheaf_mean_aep.csv -m output/il_S2_leccalc_wheatsheaf_mean_oep.csv -w output/il_S2_leccalc_wheatsheaf_oep.csv & lpid4=$!
 wait $lpid1 $lpid2 $lpid3 $lpid4
+
+
+set +e
 
 
 rm fifo/il_P1

--- a/tests/model_execution/kparse_reference/il_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/il_no_lec_1_output_1_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -47,6 +49,9 @@ wait $kpid1 $kpid2 $kpid3
 
 aalcalc -Kil_S1_summaryaalcalc > output/il_S1_aalcalc.csv & lpid1=$!
 wait $lpid1
+
+
+set +e
 
 rm -rf work/kat
 

--- a/tests/model_execution/kparse_reference/il_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/kparse_reference/il_no_lec_1_output_2_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -64,6 +66,9 @@ wait $kpid1 $kpid2 $kpid3
 
 aalcalc -Kil_S1_summaryaalcalc > output/il_S1_aalcalc.csv & lpid1=$!
 wait $lpid1
+
+
+set +e
 
 rm -rf work/kat
 

--- a/tests/model_execution/kparse_reference/il_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/il_no_lec_2_output_1_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -64,6 +66,9 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 aalcalc -Kil_S1_summaryaalcalc > output/il_S1_aalcalc.csv & lpid1=$!
 aalcalc -Kil_S2_summaryaalcalc > output/il_S2_aalcalc.csv & lpid2=$!
 wait $lpid1 $lpid2
+
+
+set +e
 
 rm -rf work/kat
 

--- a/tests/model_execution/kparse_reference/il_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/kparse_reference/il_no_lec_2_output_2_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -93,6 +95,9 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 aalcalc -Kil_S1_summaryaalcalc > output/il_S1_aalcalc.csv & lpid1=$!
 aalcalc -Kil_S2_summaryaalcalc > output/il_S2_aalcalc.csv & lpid2=$!
 wait $lpid1 $lpid2
+
+
+set +e
 
 rm -rf work/kat
 

--- a/tests/model_execution/kparse_reference/il_occ_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/il_occ_fu_lec_1_output_1_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -27,6 +29,9 @@ wait $pid1
 
 leccalc -r -Kil_S1_summaryleccalc -f output/il_S1_leccalc_full_uncertainty_oep.csv & lpid1=$!
 wait $lpid1
+
+
+set +e
 
 
 rm fifo/il_P1

--- a/tests/model_execution/kparse_reference/il_occ_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/kparse_reference/il_occ_fu_lec_1_output_20_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -179,6 +181,9 @@ wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 
 
 leccalc -r -Kil_S1_summaryleccalc -f output/il_S1_leccalc_full_uncertainty_oep.csv & lpid1=$!
 wait $lpid1
+
+
+set +e
 
 
 rm fifo/il_P1

--- a/tests/model_execution/kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -27,6 +29,9 @@ wait $pid1
 
 leccalc -r -Kil_S1_summaryleccalc -s output/il_S1_leccalc_sample_mean_oep.csv & lpid1=$!
 wait $lpid1
+
+
+set +e
 
 
 rm fifo/il_P1

--- a/tests/model_execution/kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -179,6 +181,9 @@ wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 
 
 leccalc -r -Kil_S1_summaryleccalc -s output/il_S1_leccalc_sample_mean_oep.csv & lpid1=$!
 wait $lpid1
+
+
+set +e
 
 
 rm fifo/il_P1

--- a/tests/model_execution/kparse_reference/il_occ_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/il_occ_ws_lec_1_output_1_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -27,6 +29,9 @@ wait $pid1
 
 leccalc -r -Kil_S1_summaryleccalc -w output/il_S1_leccalc_wheatsheaf_oep.csv & lpid1=$!
 wait $lpid1
+
+
+set +e
 
 
 rm fifo/il_P1

--- a/tests/model_execution/kparse_reference/il_occ_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/kparse_reference/il_occ_ws_lec_1_output_20_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -179,6 +181,9 @@ wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 
 
 leccalc -r -Kil_S1_summaryleccalc -w output/il_S1_leccalc_wheatsheaf_oep.csv & lpid1=$!
 wait $lpid1
+
+
+set +e
 
 
 rm fifo/il_P1

--- a/tests/model_execution/kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -27,6 +29,9 @@ wait $pid1
 
 leccalc -r -Kil_S1_summaryleccalc -m output/il_S1_leccalc_wheatsheaf_mean_oep.csv & lpid1=$!
 wait $lpid1
+
+
+set +e
 
 
 rm fifo/il_P1

--- a/tests/model_execution/kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -179,6 +181,9 @@ wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 
 
 leccalc -r -Kil_S1_summaryleccalc -m output/il_S1_leccalc_wheatsheaf_mean_oep.csv & lpid1=$!
 wait $lpid1
+
+
+set +e
 
 
 rm fifo/il_P1

--- a/tests/model_execution/kparse_reference/il_pltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/il_pltcalc_1_output_1_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -29,6 +31,9 @@ wait $pid1 $pid2
 kat work/kat/il_S1_pltcalc_P1 > output/il_S1_pltcalc.csv & kpid1=$!
 wait $kpid1
 
+
+
+set +e
 
 
 rm fifo/il_P1

--- a/tests/model_execution/kparse_reference/il_pltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/kparse_reference/il_pltcalc_1_output_20_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -238,6 +240,9 @@ wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 
 kat work/kat/il_S1_pltcalc_P1 work/kat/il_S1_pltcalc_P2 work/kat/il_S1_pltcalc_P3 work/kat/il_S1_pltcalc_P4 work/kat/il_S1_pltcalc_P5 work/kat/il_S1_pltcalc_P6 work/kat/il_S1_pltcalc_P7 work/kat/il_S1_pltcalc_P8 work/kat/il_S1_pltcalc_P9 work/kat/il_S1_pltcalc_P10 work/kat/il_S1_pltcalc_P11 work/kat/il_S1_pltcalc_P12 work/kat/il_S1_pltcalc_P13 work/kat/il_S1_pltcalc_P14 work/kat/il_S1_pltcalc_P15 work/kat/il_S1_pltcalc_P16 work/kat/il_S1_pltcalc_P17 work/kat/il_S1_pltcalc_P18 work/kat/il_S1_pltcalc_P19 work/kat/il_S1_pltcalc_P20 > output/il_S1_pltcalc.csv & kpid1=$!
 wait $kpid1
 
+
+
+set +e
 
 
 rm fifo/il_P1

--- a/tests/model_execution/kparse_reference/il_summarycalc_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/il_summarycalc_1_output_1_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -29,6 +31,9 @@ wait $pid1 $pid2
 kat work/kat/il_S1_summarycalc_P1 > output/il_S1_summarycalc.csv & kpid1=$!
 wait $kpid1
 
+
+
+set +e
 
 
 rm fifo/il_P1

--- a/tests/model_execution/kparse_reference/il_summarycalc_1_output_20_partition.sh
+++ b/tests/model_execution/kparse_reference/il_summarycalc_1_output_20_partition.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -R -f output/*
 rm -R -f fifo/*
 rm -R -f work/*
@@ -238,6 +240,9 @@ wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 
 kat work/kat/il_S1_summarycalc_P1 work/kat/il_S1_summarycalc_P2 work/kat/il_S1_summarycalc_P3 work/kat/il_S1_summarycalc_P4 work/kat/il_S1_summarycalc_P5 work/kat/il_S1_summarycalc_P6 work/kat/il_S1_summarycalc_P7 work/kat/il_S1_summarycalc_P8 work/kat/il_S1_summarycalc_P9 work/kat/il_S1_summarycalc_P10 work/kat/il_S1_summarycalc_P11 work/kat/il_S1_summarycalc_P12 work/kat/il_S1_summarycalc_P13 work/kat/il_S1_summarycalc_P14 work/kat/il_S1_summarycalc_P15 work/kat/il_S1_summarycalc_P16 work/kat/il_S1_summarycalc_P17 work/kat/il_S1_summarycalc_P18 work/kat/il_S1_summarycalc_P19 work/kat/il_S1_summarycalc_P20 > output/il_S1_summarycalc.csv & kpid1=$!
 wait $kpid1
 
+
+
+set +e
 
 
 rm fifo/il_P1

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ skipsdist = true
 
 [testenv]
 deps = -r{toxinidir}/requirements.txt
-commands = pytest -p no:flaky --cov=oasislmf
+commands = pytest -p no:flaky --cov=oasislmf {posargs}
 setenv =
     COV_CORE_SOURCE={toxinidir}/oasislmf
     COV_CORE_CONFIG={toxinidir}/setup.cfg


### PR DESCRIPTION
A number of small improvements that make debugging, testing, etc. a bit easier:
- When running in Verbose mode, full exception tracebacks are logged/printed to screen, rather than just the exception message.
- Now that OasisLMF is Python 3 only, use the `raise ... from ...` syntax.
- In the bash script generation, use `set -e` to ensure that failures in the bash script (either by the custom loss module or ktools) cause a CalledProcessError to be raised. This fixes the strange behaviour where error messages from those commands would appear in the output, but OasisLMF would claim the run completed successfully (#205)
- Add `{posargs}` to tox.ini, which allows arguments to be passed through to the test runner.

With the last change, one can now run a specific file with:
`tox -- tests/some_test_file.py`
Or even a specific test with:
`tox -- tests/some_test_file.py::TestClass::test_task`