### PR TITLE
Update (zlib) compression utils module + tests

### DIFF
--- a/oasislmf/utils/compress.py
+++ b/oasislmf/utils/compress.py
@@ -1,6 +1,7 @@
 __all__ = [
-    'compress_data',
-    'CHUNK_SIZE'
+    'compress_string',
+    'decompress_string',
+    'CHUNK_SIZE',
 ]
 
 import zlib
@@ -11,24 +12,30 @@ from .exceptions import OasisException
 CHUNK_SIZE = 5 * 10 ** 8  # 500 Mb
 
 
-def compress_data(s):
+def compress_string(st: str) -> bytes:
     """
-    Compress large data strings.
+    Compresses strings using the zlib library.
 
     Adapted from a StackOverflow.com solution by Dmitry Skryabin
 
         https://stackoverflow.com/a/36056646/7556955
 
     with a modification to set block/chunk size to 500 Mb (5 x 10^8 bytes).
-    """
 
+    :param s: Input string to be compressed
+    :type s: str
+
+    :return: Compressed string as bytes
+    :rtype: bytes
+    """
+    _st = ''.join(st).encode('utf-8')
     compressed = b''
     begin = 0
     compressor = zlib.compressobj()
 
     try:
-        while begin < len(s):
-            compressed += compressor.compress(s[begin:begin + CHUNK_SIZE])
+        while begin < len(_st):
+            compressed += compressor.compress(_st[begin:begin + CHUNK_SIZE])
             begin += CHUNK_SIZE
 
         compressed += compressor.flush()
@@ -36,3 +43,18 @@ def compress_data(s):
         raise OasisException from e
 
     return compressed
+
+
+def decompress_string(bt: bytes) -> str:
+    """
+    Decompresses zlib-compressed strings
+
+    :param bt: zlib-compressed string
+    :type bt: bytes
+
+    :return: Decompressed (Unicode) string
+    :rtype: str
+    """
+    decompressor = zlib.decompressobj()
+
+    return decompressor.decompress(bt).decode('utf-8')

--- a/tests/utils/test_compress.py
+++ b/tests/utils/test_compress.py
@@ -7,10 +7,10 @@ from hypothesis import (
     HealthCheck,
     settings,
 )
-from hypothesis.strategies import binary
+from hypothesis.strategies import binary, text
 from mock import patch, Mock
 
-from oasislmf.utils.compress import compress_data
+from oasislmf.utils.compress import compress_string
 from oasislmf.utils.exceptions import OasisException
 
 MOCKED_CHUNK_SIZE = 100
@@ -19,32 +19,32 @@ MOCKED_CHUNK_SIZE = 100
 @patch('oasislmf.utils.compress.CHUNK_SIZE', MOCKED_CHUNK_SIZE)
 class CompressData(TestCase):
     @settings(suppress_health_check=[HealthCheck.too_slow])
-    @given(binary(min_size=0, max_size=MOCKED_CHUNK_SIZE - 1))
+    @given(data=text(min_size=0, max_size=MOCKED_CHUNK_SIZE - 1))
     def test_data_is_less_than_than_the_chunk_size___result_is_the_compressed_version_of_the_full_data(self, data):
         compressor = zlib.compressobj()
-        expected = compressor.compress(data) + compressor.flush()
+        expected = compressor.compress(data.encode('utf-8')) + compressor.flush()
 
-        result = compress_data(data)
+        result = compress_string(data)
 
         self.assertEqual(expected, result)
 
     @settings(suppress_health_check=[HealthCheck.too_slow])
-    @given(binary(min_size=MOCKED_CHUNK_SIZE, max_size=MOCKED_CHUNK_SIZE))
+    @given(data=text(min_size=MOCKED_CHUNK_SIZE, max_size=MOCKED_CHUNK_SIZE))
     def test_data_is_equal_to_the_the_chunk_size___result_is_the_compressed_version_of_the_full_data(self, data):
         compressor = zlib.compressobj()
-        expected = compressor.compress(data) + compressor.flush()
+        expected = compressor.compress(data.encode('utf-8')) + compressor.flush()
 
-        result = compress_data(data)
+        result = compress_string(data)
 
         self.assertEqual(expected, result)
 
     @settings(suppress_health_check=[HealthCheck.too_slow])
-    @given(binary(min_size=MOCKED_CHUNK_SIZE, max_size=MOCKED_CHUNK_SIZE), binary(min_size=0, max_size=MOCKED_CHUNK_SIZE - 1))
+    @given(front=text(min_size=MOCKED_CHUNK_SIZE, max_size=MOCKED_CHUNK_SIZE), overflow=text(min_size=0, max_size=MOCKED_CHUNK_SIZE - 1))
     def test_data_is_larger_than_the_chunk_size___result_is_the_concatenated_compressed_version_of_the_chunks(self, front, overflow):
         compressor = zlib.compressobj()
-        expected = compressor.compress(front) + compressor.compress(overflow) + compressor.flush()
+        expected = compressor.compress(front.encode('utf-8')) + compressor.compress(overflow.encode('utf-8')) + compressor.flush()
 
-        result = compress_data(front + overflow)
+        result = compress_string(front + overflow)
 
         self.assertEqual(expected, result)
 
@@ -54,7 +54,7 @@ class CompressData(TestCase):
                 raise zlib.error()
 
         with patch('zlib.compressobj', Mock(return_value=FakeCompressor())), self.assertRaises(OasisException):
-            compress_data(b'data')
+            compress_string('data')
 
     def test_compress_raises_a_non_zlib_error___error_is_raised_without_converting(self):
         class FakeCompressor(object):
@@ -62,4 +62,4 @@ class CompressData(TestCase):
                 raise ValueError()
 
         with patch('zlib.compressobj', Mock(return_value=FakeCompressor())), self.assertRaises(ValueError):
-            compress_data(b'data')
+            compress_string('data')


### PR DESCRIPTION
* Adapt compression method to Python 3 (input string needs to be converted to bytes before compression)
* Add decompression method `decompress_string`
* Rename compression method: `compress_data` -> `compress_string` 
* Update tests (`tests/utils/test_compress.py`)