### PR TITLE
Minor refactoring in IL inputs generation

### DIFF
--- a/oasislmf/model_preparation/gul_inputs.py
+++ b/oasislmf/model_preparation/gul_inputs.py
@@ -203,8 +203,8 @@ def get_gul_input_items(
         gul_inputs_df[cond_num].fillna(0, inplace=True)
         gul_inputs_df[cond_num] = gul_inputs_df[cond_num].astype('uint32')
 
-        gul_inputs_df = gul_inputs_df[(gul_inputs_df[tiv_cols] != 0).any(axis=1)]
-        gul_inputs_df.loc[:, tiv_cols] = gul_inputs_df[tiv_cols].where(gul_inputs_df.notnull(), 0.0)
+        gul_inputs_df = gul_inputs_df[(gul_inputs_df.loc[:, tiv_cols] != 0).any(axis=1)]
+        gul_inputs_df.loc[:, tiv_cols] = gul_inputs_df.loc[:, tiv_cols].where(gul_inputs_df.notnull(), 0.0)
 
         # Set default values and data types for BI coverage boolean, TIV, deductibles and limit
         gul_inputs_df = gul_inputs_df.assign(
@@ -251,10 +251,10 @@ def get_gul_input_items(
                 get_fm_terms_oed_columns(fm_terms=fm_terms, levels=['site coverage'], term_group_ids=other_cov_types, terms=terms)
             )
             cov_type_group.loc[:, other_cov_type_term_cols] = 0
-            gul_inputs_df.loc[cov_type_group.index, ['tiv', 'is_bi_coverage'] + terms] = cov_type_group[['tiv', 'is_bi_coverage'] + terms]
+            gul_inputs_df.loc[cov_type_group.index, ['tiv', 'is_bi_coverage'] + terms] = cov_type_group.loc[:, ['tiv', 'is_bi_coverage'] + terms]
 
         # Remove any rows with zeros in the ``tiv`` column and reset the index
-        gul_inputs_df = gul_inputs_df[(gul_inputs_df[['tiv']] != 0).any(axis=1)].reset_index()
+        gul_inputs_df = gul_inputs_df[(gul_inputs_df.loc[:, ['tiv']] != 0).any(axis=1)].reset_index()
 
         # Remove the source columns for the TIVs and coverage level financial terms
         gul_inputs_df.drop(tiv_cols + cov_il_cols, axis=1, inplace=True)
@@ -311,7 +311,7 @@ def write_complex_items_file(gul_inputs_df, complex_items_fp, chunksize=100000):
     :rtype: str
     """
     try:
-        gul_inputs_df[['item_id', 'coverage_id', 'model_data', 'group_id']].drop_duplicates().to_csv(
+        gul_inputs_df.loc[:, ['item_id', 'coverage_id', 'model_data', 'group_id']].drop_duplicates().to_csv(
             path_or_buf=complex_items_fp,
             encoding='utf-8',
             mode=('w' if os.path.exists(complex_items_fp) else 'a'),
@@ -337,7 +337,7 @@ def write_items_file(gul_inputs_df, items_fp, chunksize=100000):
     :rtype: str
     """
     try:
-        gul_inputs_df[['item_id', 'coverage_id', 'areaperil_id', 'vulnerability_id', 'group_id']].drop_duplicates().to_csv(
+        gul_inputs_df.loc[:, ['item_id', 'coverage_id', 'areaperil_id', 'vulnerability_id', 'group_id']].drop_duplicates().to_csv(
             path_or_buf=items_fp,
             encoding='utf-8',
             mode=('w' if os.path.exists(items_fp) else 'a'),
@@ -365,7 +365,7 @@ def write_coverages_file(gul_inputs_df, coverages_fp, chunksize=100000):
     :rtype: str
     """
     try:
-        gul_inputs_df[['coverage_id', 'tiv']].drop_duplicates().to_csv(
+        gul_inputs_df.loc[:, ['coverage_id', 'tiv']].drop_duplicates().to_csv(
             path_or_buf=coverages_fp,
             encoding='utf-8',
             mode=('w' if os.path.exists(coverages_fp) else 'a'),
@@ -393,7 +393,7 @@ def write_gulsummaryxref_file(gul_inputs_df, gulsummaryxref_fp, chunksize=100000
     :rtype: str
     """
     try:
-        gul_inputs_df[['coverage_id', 'summary_id', 'summaryset_id']].drop_duplicates().to_csv(
+        gul_inputs_df.loc[:, ['coverage_id', 'summary_id', 'summaryset_id']].drop_duplicates().to_csv(
             path_or_buf=gulsummaryxref_fp,
             encoding='utf-8',
             mode=('w' if os.path.exists(gulsummaryxref_fp) else 'a'),

--- a/oasislmf/model_preparation/il_inputs.py
+++ b/oasislmf/model_preparation/il_inputs.py
@@ -81,7 +81,7 @@ def get_layer_ids(accounts_df, accounts_profile=get_default_accounts_profile()):
     acc_num = hierarchy_terms['accid']
     policy_num = hierarchy_terms['polid']
 
-    _accounts_df = accounts_df[[portfolio_num, acc_num, policy_num]]
+    _accounts_df = accounts_df.loc[:, [portfolio_num, acc_num, policy_num]]
     _accounts_df.columns = _accounts_df.columns.str.lower()
 
     portfolio_nums = _accounts_df[portfolio_num].values
@@ -383,7 +383,7 @@ def get_il_input_items(
             level_df['level_id'] = level_id
 
             agg_key = [v['field'].lower() for v in fmap[level_id]['FMAggKey'].values()]
-            level_df['agg_id'] = factorize_ndarray(level_df[agg_key].values, col_idxs=range(len(agg_key)))[0]
+            level_df['agg_id'] = factorize_ndarray(level_df.loc[:, agg_key].values, col_idxs=range(len(agg_key)))[0]
 
             if level == 'cond all':
                 level_df.loc[:, term_cols] = level_df.loc[:, term_cols].fillna(0)
@@ -448,7 +448,7 @@ def get_il_input_items(
         # Set the layer level, layer IDs and agg. IDs
         layer_df['level_id'] = layer_level_id
         agg_key = [v['field'].lower() for v in fmap[layer_level_id]['FMAggKey'].values()]
-        layer_df['agg_id'] = factorize_ndarray(layer_df[agg_key].values, col_idxs=range(len(agg_key)))[0]
+        layer_df['agg_id'] = factorize_ndarray(layer_df.loc[:, agg_key].values, col_idxs=range(len(agg_key)))[0]
 
         # The layer level financial terms
         terms = ['deductible', 'limit', 'share']
@@ -471,7 +471,7 @@ def get_il_input_items(
         # Resequence the level IDs and item IDs, but also store the "original"
         # FM level IDs (before the resequencing)
         il_inputs_df['orig_level_id'] = il_inputs_df['level_id']
-        il_inputs_df['level_id'] = factorize_ndarray(il_inputs_df[['level_id']].values, col_idxs=[0])[0]
+        il_inputs_df['level_id'] = factorize_ndarray(il_inputs_df.loc[:, ['level_id']].values, col_idxs=[0])[0]
         il_inputs_df['item_id'] = il_inputs_df.index + 1
 
         # Set the calc. rule IDs
@@ -485,14 +485,28 @@ def get_il_input_items(
         il_inputs_calc_rules_df = il_inputs_df.loc[:, ['item_id'] + terms + terms_indicators + types_and_codes + ['calcrule_id']]
         il_inputs_calc_rules_df.loc[:, terms_indicators] = np.where(il_inputs_calc_rules_df[terms] > 0, 1, 0)
         il_inputs_calc_rules_df.loc[:, types_and_codes] = 0
-        il_inputs_calc_rules_df['id_key'] = [t for t in fast_zip_arrays(*il_inputs_calc_rules_df[terms_indicators + types_and_codes].transpose().values)]
+        il_inputs_calc_rules_df['id_key'] = [t for t in fast_zip_arrays(*il_inputs_calc_rules_df.loc[:, terms_indicators + types_and_codes].transpose().values)]
         il_inputs_calc_rules_df = merge_dataframes(il_inputs_calc_rules_df, calc_rules, how='left', on='id_key')
         il_inputs_df['calcrule_id'] = il_inputs_calc_rules_df['calcrule_id']
 
         del il_inputs_calc_rules_df
 
+        # The policy TC ID calculation
+        policytc_cols = [
+            'layer_id', 'level_id', 'agg_id', 'calcrule_id', 'limit',
+            'deductible', 'deductible_min', 'deductible_max', 'attachment',
+            'share'
+        ]
+        fm_policytc_df = il_inputs_df.loc[:, ['item_id'] + policytc_cols].drop_duplicates()
+        fm_policytc_df = fm_policytc_df[
+            (fm_policytc_df['layer_id'] == 1) |
+            (fm_policytc_df['level_id'] == fm_policytc_df['level_id'].max())
+        ]
+        il_inputs_df['policytc_id'] = factorize_ndarray(fm_policytc_df.loc[:, policytc_cols[3:]].values, col_idxs=range(len(policytc_cols[3:])))[0]
+
+        # Final setting of data types before returning the IL input items
         dtypes = {
-            **{t: 'uint32' for t in [cond_num, 'agg_id', 'item_id', 'layer_id', 'level_id', 'orig_level_id', 'calcrule_id']},
+            **{t: 'uint32' for t in [cond_num, 'agg_id', 'item_id', 'layer_id', 'level_id', 'orig_level_id', 'calcrule_id', 'policytc_id']},
             **{t: 'float32' for t in [_t for _t in terms if _t != 'limit'] + ['attachment', 'deductible_min', 'deductible_max']},
             **{'limit': 'float64'}
         }
@@ -519,15 +533,8 @@ def write_fm_policytc_file(il_inputs_df, fm_policytc_fp, chunksize=100000):
     :rtype: str
     """
     try:
-        cols = ['layer_id', 'level_id', 'agg_id', 'calcrule_id', 'limit', 'deductible', 'deductible_min', 'deductible_max', 'attachment', 'share']
-        fm_policytc_df = il_inputs_df[cols].drop_duplicates()
-        fm_policytc_df = fm_policytc_df[
-            (fm_policytc_df['layer_id'] == 1) |
-            (fm_policytc_df['level_id'] == fm_policytc_df['level_id'].max())
-        ]
-        fm_policytc_df['policytc_id'] = factorize_ndarray(fm_policytc_df[cols[3:]].values, col_idxs=range(len(cols[3:])))[0]
-
-        fm_policytc_df[cols[:3] + ['policytc_id']].to_csv(
+        fm_policytc_df = il_inputs_df.loc[:, ['layer_id', 'level_id', 'agg_id', 'policytc_id']].drop_duplicates()
+        fm_policytc_df.to_csv(
             path_or_buf=fm_policytc_fp,
             encoding='utf-8',
             mode=('w' if os.path.exists(fm_policytc_fp) else 'a'),
@@ -556,9 +563,7 @@ def write_fm_profile_file(il_inputs_df, fm_profile_fp, chunksize=100000):
     """
     try:
         cols = ['policytc_id', 'calcrule_id', 'deductible', 'deductible_min', 'deductible_max', 'attachment', 'limit', 'share']
-        fm_profile_df = il_inputs_df[cols].drop_duplicates()
-
-        fm_profile_df['policytc_id'] = factorize_ndarray(fm_profile_df[cols].values, col_idxs=range(len(cols)))[0]
+        fm_profile_df = il_inputs_df.loc[:, cols].drop_duplicates()
 
         fm_profile_df.rename(
             columns={
@@ -604,8 +609,8 @@ def write_fm_programme_file(il_inputs_df, fm_programme_fp, chunksize=100000):
     try:
         fm_programme_df = pd.concat(
             [
-                il_inputs_df[il_inputs_df['level_id'] == il_inputs_df['level_id'].min()][['agg_id']].assign(level_id=0),
-                il_inputs_df[['level_id', 'agg_id']]
+                il_inputs_df[il_inputs_df['level_id'] == il_inputs_df['level_id'].min()].loc[:, ['agg_id']].assign(level_id=0),
+                il_inputs_df.loc[:, ['level_id', 'agg_id']]
             ]
         ).reset_index(drop=True)
 
@@ -616,7 +621,7 @@ def write_fm_programme_file(il_inputs_df, fm_programme_fp, chunksize=100000):
                 'from_agg_id': fm_programme_df[fm_programme_df['level_id'] < max_level]['agg_id'],
                 'level_id': fm_programme_df[fm_programme_df['level_id'] > min_level]['level_id'].reset_index(drop=True),
                 'to_agg_id': fm_programme_df[fm_programme_df['level_id'] > min_level]['agg_id'].reset_index(drop=True)
-            },
+            }
         ).dropna(axis=0).drop_duplicates()
 
         dtypes = {t: 'uint32' for t in fm_programme_df.columns}
@@ -653,7 +658,7 @@ def write_fm_xref_file(il_inputs_df, fm_xref_fp, chunksize=100000):
         cov_level_layers_df = il_inputs_df[il_inputs_df['level_id'] == il_inputs_df['level_id'].max()]
         pd.DataFrame(
             {
-                'output': factorize_ndarray(cov_level_layers_df[['gul_input_id', 'layer_id']].values, col_idxs=range(2))[0],
+                'output': factorize_ndarray(cov_level_layers_df.loc[:, ['gul_input_id', 'layer_id']].values, col_idxs=range(2))[0],
                 'agg_id': cov_level_layers_df['gul_input_id'],
                 'layer_id': cov_level_layers_df['layer_id']
             }
@@ -688,7 +693,7 @@ def write_fmsummaryxref_file(il_inputs_df, fmsummaryxref_fp, chunksize=100000):
         cov_level_layers_df = il_inputs_df[il_inputs_df['level_id'] == il_inputs_df['level_id'].max()]
         pd.DataFrame(
             {
-                'output': factorize_ndarray(cov_level_layers_df[['gul_input_id', 'layer_id']].values, col_idxs=range(2))[0],
+                'output': factorize_ndarray(cov_level_layers_df.loc[:, ['gul_input_id', 'layer_id']].values, col_idxs=range(2))[0],
                 'summary_id': 1,
                 'summaryset_id': 1
             }


### PR DESCRIPTION
* Create separate module-level method for generating calc. rule IDs and policy TC IDs for use in main IL input items generator
* Factor out the policy TC ID generation from the FM policy TC and FM profile file writers and move it to the IL input items generator
* Clean up processing of layer level terms - set deductible column to 0 after populating the attachment column