### PR TITLE
Add flag to make exposure summary generation optional

### DIFF
--- a/oasislmf/cli/config.py
+++ b/oasislmf/cli/config.py
@@ -16,6 +16,7 @@ class ConfigCmd(OasisBaseCommand):
     with appropriate values, but can be overridden by providing a runtime flag.
 
     :analysis_settings_file_path: Analysis settings (JSON) file path
+    :exposure_summary_report: Whether to generate exposure summary report
     :keys_data_path: Model lookup/keys data path (optional)
     :lookup_config_file_path: Model built-in lookup config. (JSON) file path (optional)
     :lookup_package_path: Model custom lookup package path (optional)

--- a/oasislmf/cli/config.py
+++ b/oasislmf/cli/config.py
@@ -16,7 +16,6 @@ class ConfigCmd(OasisBaseCommand):
     with appropriate values, but can be overridden by providing a runtime flag.
 
     :analysis_settings_file_path: Analysis settings (JSON) file path
-    :exposure_summary_report: Whether to generate exposure summary report
     :keys_data_path: Model lookup/keys data path (optional)
     :lookup_config_file_path: Model built-in lookup config. (JSON) file path (optional)
     :lookup_package_path: Model custom lookup package path (optional)
@@ -30,6 +29,7 @@ class ConfigCmd(OasisBaseCommand):
     :source_accounts_profile_path: Source OED accouns (JSON) profile describing the financial terms contained in the source accounts file (optional)
     :source_exposure_file_path: Source OED exposure (CSV) file path
     :source_exposure_profile_path: Source OED exposure (JSON) profile describing the financial terms contained in the source exposure file (optional)
+    :summarise_exposure: Whether to generate exposure summary report
     :ktools_num_processes: The number of concurrent processes used by ktools during model execution - default is ``2``
     :ktools_mem_limit: Whether to force exec. failure if ktools hits the system memory limit - default is ``False``
     :ktools_fifo_relative: Whether to create ktools FIFO queues under the ``./fifo`` subfolder (in the model run directory)

--- a/oasislmf/cli/config.py
+++ b/oasislmf/cli/config.py
@@ -29,7 +29,7 @@ class ConfigCmd(OasisBaseCommand):
     :source_accounts_profile_path: Source OED accouns (JSON) profile describing the financial terms contained in the source accounts file (optional)
     :source_exposure_file_path: Source OED exposure (CSV) file path
     :source_exposure_profile_path: Source OED exposure (JSON) profile describing the financial terms contained in the source exposure file (optional)
-    :summarise_exposure: Whether to generate exposure summary report
+    :summarise_exposure: Generates an exposure summary report in JSON
     :ktools_num_processes: The number of concurrent processes used by ktools during model execution - default is ``2``
     :ktools_mem_limit: Whether to force exec. failure if ktools hits the system memory limit - default is ``False``
     :ktools_fifo_relative: Whether to create ktools FIFO queues under the ``./fifo`` subfolder (in the model run directory)

--- a/oasislmf/cli/model.py
+++ b/oasislmf/cli/model.py
@@ -235,7 +235,7 @@ class GenerateOasisFilesCmd(OasisBaseCommand):
         parser.add_argument('-g', '--fm-aggregation-profile-path', default=None, help='FM (OED) aggregation profile path')
         parser.add_argument('-i', '--ri-info-file-path', default=None, help='Reinsurance info. file path')
         parser.add_argument('-s', '--ri-scope-file-path', default=None, help='Reinsurance scope file path')
-        parser.add_argument('-S', '--exposure-summary-report', default=False, help='Create exposure summary report', action='store_true')
+        parser.add_argument('-S', '--summarise-exposure', default=False, help='Create exposure summary report', action='store_true')
 
     def action(self, args):
         """
@@ -286,7 +286,7 @@ class GenerateOasisFilesCmd(OasisBaseCommand):
             inputs.get('user_data_path', required=False, is_path=True),
             'Directory containing additional user-supplied model data files', preexists=False
         )
-        exposure_summary_report = inputs.get('exposure_summary_report', default=False, required=False)
+        summarise_exposure = inputs.get('summarise_exposure', default=False, required=False)
 
         if not (keys_fp or lookup_config_fp or (keys_data_fp and model_version_fp and lookup_package_fp)):
             raise OasisException(
@@ -352,7 +352,7 @@ class GenerateOasisFilesCmd(OasisBaseCommand):
             ri_info_fp=ri_info_fp,
             ri_scope_fp=ri_scope_fp,
             user_data_dir=user_data_dir,
-            exposure_summary_report=exposure_summary_report
+            summarise_exposure=summarise_exposure
         )
 
         self.logger.info('\nOasis files generated: {}'.format(oasis_files))
@@ -539,7 +539,7 @@ class RunCmd(OasisBaseCommand):
         parser.add_argument('-m', '--ktools-mem-limit', default=False, help='Force exec failure if Ktools hits memory the system  memory limit', action='store_true')
         parser.add_argument('-f', '--ktools-fifo-relative', default=False, help='Create ktools fifo queues under the ./fifo dir', action='store_true')
         parser.add_argument('-u', '--ktools-alloc-rule', default=2, help='Override the allocation used in fmcalc', type=int)
-        parser.add_argument('-S', '--exposure-summary-report', default=False, help='Create exposure summary report', action='store_true')
+        parser.add_argument('-S', '--summarise-exposure', default=False, help='Create exposure summary report', action='store_true')
 
     def action(self, args):
         """

--- a/oasislmf/cli/model.py
+++ b/oasislmf/cli/model.py
@@ -351,7 +351,7 @@ class GenerateOasisFilesCmd(OasisBaseCommand):
             fm_aggregation_profile_fp=aggregation_profile_fp,
             ri_info_fp=ri_info_fp,
             ri_scope_fp=ri_scope_fp,
-            user_data_dir=user_data_dir
+            user_data_dir=user_data_dir,
             exposure_summary_report=exposure_summary_report
         )
 

--- a/oasislmf/cli/model.py
+++ b/oasislmf/cli/model.py
@@ -235,6 +235,7 @@ class GenerateOasisFilesCmd(OasisBaseCommand):
         parser.add_argument('-g', '--fm-aggregation-profile-path', default=None, help='FM (OED) aggregation profile path')
         parser.add_argument('-i', '--ri-info-file-path', default=None, help='Reinsurance info. file path')
         parser.add_argument('-s', '--ri-scope-file-path', default=None, help='Reinsurance scope file path')
+        parser.add_argument('-S', '--exposure-summary-report', default=False, help='Create exposure summary report', action='store_true')
 
     def action(self, args):
         """
@@ -285,6 +286,7 @@ class GenerateOasisFilesCmd(OasisBaseCommand):
             inputs.get('user_data_path', required=False, is_path=True),
             'Directory containing additional user-supplied model data files', preexists=False
         )
+        exposure_summary_report = inputs.get('exposure_summary_report', default=False, required=False)
 
         if not (keys_fp or lookup_config_fp or (keys_data_fp and model_version_fp and lookup_package_fp)):
             raise OasisException(
@@ -350,6 +352,7 @@ class GenerateOasisFilesCmd(OasisBaseCommand):
             ri_info_fp=ri_info_fp,
             ri_scope_fp=ri_scope_fp,
             user_data_dir=user_data_dir
+            exposure_summary_report=exposure_summary_report
         )
 
         self.logger.info('\nOasis files generated: {}'.format(oasis_files))
@@ -536,6 +539,7 @@ class RunCmd(OasisBaseCommand):
         parser.add_argument('-m', '--ktools-mem-limit', default=False, help='Force exec failure if Ktools hits memory the system  memory limit', action='store_true')
         parser.add_argument('-f', '--ktools-fifo-relative', default=False, help='Create ktools fifo queues under the ./fifo dir', action='store_true')
         parser.add_argument('-u', '--ktools-alloc-rule', default=2, help='Override the allocation used in fmcalc', type=int)
+        parser.add_argument('-S', '--exposure-summary-report', default=False, help='Create exposure summary report', action='store_true')
 
     def action(self, args):
         """

--- a/oasislmf/cli/model.py
+++ b/oasislmf/cli/model.py
@@ -235,7 +235,7 @@ class GenerateOasisFilesCmd(OasisBaseCommand):
         parser.add_argument('-g', '--fm-aggregation-profile-path', default=None, help='FM (OED) aggregation profile path')
         parser.add_argument('-i', '--ri-info-file-path', default=None, help='Reinsurance info. file path')
         parser.add_argument('-s', '--ri-scope-file-path', default=None, help='Reinsurance scope file path')
-        parser.add_argument('-S', '--summarise-exposure', default=False, help='Create exposure summary report', action='store_true')
+        parser.add_argument('-S', '--summarise-exposure', default=None, help='Create exposure summary report', action='store_true')
 
     def action(self, args):
         """
@@ -539,7 +539,7 @@ class RunCmd(OasisBaseCommand):
         parser.add_argument('-m', '--ktools-mem-limit', default=False, help='Force exec failure if Ktools hits memory the system  memory limit', action='store_true')
         parser.add_argument('-f', '--ktools-fifo-relative', default=False, help='Create ktools fifo queues under the ./fifo dir', action='store_true')
         parser.add_argument('-u', '--ktools-alloc-rule', default=2, help='Override the allocation used in fmcalc', type=int)
-        parser.add_argument('-S', '--summarise-exposure', default=False, help='Create exposure summary report', action='store_true')
+        parser.add_argument('-S', '--summarise-exposure', default=None, help='Create exposure summary report', action='store_true')
 
     def action(self, args):
         """

--- a/oasislmf/manager.py
+++ b/oasislmf/manager.py
@@ -308,7 +308,6 @@ class OasisManager(object):
         exposure_fp,
         exposure_profile=None,
         exposure_profile_fp=None,
-        exposure_summary_report=None,
         keys_fp=None,
         lookup_config=None,
         lookup_config_fp=None,
@@ -318,6 +317,7 @@ class OasisManager(object):
         complex_lookup_config_fp=None,
         user_data_dir=None,
         supported_oed_coverage_types=None,
+        summarise_exposure=None,
         accounts_fp=None,
         accounts_profile=None,
         accounts_profile_fp=None,
@@ -423,7 +423,7 @@ class OasisManager(object):
         )
 
         # If not in det. loss gen. scenario, write exposure summary file
-        if not deterministic and exposure_summary_report:
+        if not deterministic and summarise_exposure:
             write_exposure_summary(
                 target_dir,
                 gul_inputs_df,

--- a/oasislmf/manager.py
+++ b/oasislmf/manager.py
@@ -308,6 +308,7 @@ class OasisManager(object):
         exposure_fp,
         exposure_profile=None,
         exposure_profile_fp=None,
+        exposure_summary_report=None,
         keys_fp=None,
         lookup_config=None,
         lookup_config_fp=None,
@@ -422,7 +423,7 @@ class OasisManager(object):
         )
 
         # If not in det. loss gen. scenario, write exposure summary file
-        if not deterministic:
+        if not deterministic and exposure_summary_report:
             write_exposure_summary(
                 target_dir,
                 gul_inputs_df,

--- a/oasislmf/manager.py
+++ b/oasislmf/manager.py
@@ -423,7 +423,7 @@ class OasisManager(object):
         )
 
         # If not in det. loss gen. scenario, write exposure summary file
-        if not deterministic and summarise_exposure:
+        if summarise_exposure and not deterministic:
             write_exposure_summary(
                 target_dir,
                 gul_inputs_df,


### PR DESCRIPTION
Added flags `-S` and `--summarise-exposure` to generate exposure summary report. Default value is set to `None`, so flag must be specified for report to be generated. Flag can also be set to `true` in MDK config file.