### PR TITLE
Keys dataframe processing in GUL inputs generation

### DIFF
--- a/oasislmf/model_preparation/gul_inputs.py
+++ b/oasislmf/model_preparation/gul_inputs.py
@@ -186,7 +186,7 @@ def get_gul_input_items(
     # is the convention used for the GUL and IL inputs dataframes in the MDK
     keys_df.rename(
         columns={
-            'locid': 'loc_id',
+            'locid': 'loc_id' if 'loc_id' not in keys_df else 'locid',
             'perilid': 'peril_id',
             'coveragetypeid': 'coverage_type_id',
             'areaperilid': 'areaperil_id',


### PR DESCRIPTION
* In GUL inputs generation, rename `locid` column in keys dataframe to `loc_id` only if no `loc_id` column is already present (we assume the lookup generates keys items using `locid` as an alias for `loc_id`, not OED loc. number). As loc. IDs are integers merges with the exposure dataframe on loc. ID are faster.