### PR TITLE
Write summary_id mappings to the output dir

### DIFF
--- a/oasislmf/model_execution/bash.py
+++ b/oasislmf/model_execution/bash.py
@@ -584,7 +584,8 @@ def genbash(
     print_command(filename, 'set -o pipefail')
     print_command(filename, '')
 
-    print_command(filename, 'rm -R -f output/*')
+    #print_command(filename, 'rm -R -f output/*')
+    print_command(filename, "find output/* ! -name '*summary-info*' -type f -exec rm -f {} +")
     if not fifo_tmp_dir:
         print_command(filename, 'rm -R -f fifo/*')
     print_command(filename, 'rm -R -f work/*')

--- a/tests/model_execution/kparse_reference/all_calcs_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/all_calcs_1_output_1_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/all_calcs_1_output_20_partition.sh
+++ b/tests/model_execution/kparse_reference/all_calcs_1_output_20_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/all_calcs_1_output_40_partition.sh
+++ b/tests/model_execution/kparse_reference/all_calcs_1_output_40_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/analysis_settings_1_1_partition.sh
+++ b/tests/model_execution/kparse_reference/analysis_settings_1_1_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/analysis_settings_2_1_partition.sh
+++ b/tests/model_execution/kparse_reference/analysis_settings_2_1_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/analysis_settings_3_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/kparse_reference/analysis_settings_3_1_reins_layer_1_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/analysis_settings_4_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/kparse_reference/analysis_settings_4_1_reins_layer_1_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/analysis_settings_tmpfifo_3_1_reins_layer_1_partition.template
+++ b/tests/model_execution/kparse_reference/analysis_settings_tmpfifo_3_1_reins_layer_1_partition.template
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f work/*
 
 mkdir work/kat

--- a/tests/model_execution/kparse_reference/analysis_settings_tmpfifo_memlim_4_1_reins_layer_1_partition.template
+++ b/tests/model_execution/kparse_reference/analysis_settings_tmpfifo_memlim_4_1_reins_layer_1_partition.template
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f work/*
 
 mkdir work/kat

--- a/tests/model_execution/kparse_reference/gul_aalcalc_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_aalcalc_1_output_1_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/gul_aalcalc_1_output_20_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_aalcalc_1_output_20_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/gul_agg_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_agg_fu_lec_1_output_1_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/gul_agg_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_agg_fu_lec_1_output_20_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/gul_agg_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_agg_ws_lec_1_output_1_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/gul_agg_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_agg_ws_lec_1_output_20_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/gul_agg_ws_mean_lec_1_tmpfifo_memlim_output_20_partition.template
+++ b/tests/model_execution/kparse_reference/gul_agg_ws_mean_lec_1_tmpfifo_memlim_output_20_partition.template
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f work/*
 
 mkdir work/kat

--- a/tests/model_execution/kparse_reference/gul_eltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_eltcalc_1_output_1_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/gul_eltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_eltcalc_1_output_20_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/gul_il_lec_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_il_lec_1_output_1_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/gul_il_lec_1_output_2_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_il_lec_1_output_2_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/gul_il_lec_2_output_10_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_il_lec_2_output_10_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/gul_il_lec_2_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_il_lec_2_output_1_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/gul_il_lec_2_output_2_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_il_lec_2_output_2_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/gul_il_lec_2_tmpfifo_output_10_partition.template
+++ b/tests/model_execution/kparse_reference/gul_il_lec_2_tmpfifo_output_10_partition.template
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f work/*
 
 mkdir work/kat

--- a/tests/model_execution/kparse_reference/gul_il_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_il_no_lec_1_output_1_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/gul_il_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_il_no_lec_1_output_2_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/gul_il_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_il_no_lec_2_output_1_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/gul_il_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_il_no_lec_2_output_2_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/gul_lec_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_lec_1_output_1_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/gul_lec_1_output_2_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_lec_1_output_2_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/gul_lec_2_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_lec_2_output_1_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/gul_lec_2_output_2_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_lec_2_output_2_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/gul_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_no_lec_1_output_1_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/gul_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_no_lec_1_output_2_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/gul_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_no_lec_2_output_1_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/gul_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_no_lec_2_output_2_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/gul_occ_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_occ_fu_lec_1_output_1_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/gul_occ_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_occ_fu_lec_1_output_20_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/gul_occ_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_occ_ws_lec_1_output_1_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/gul_occ_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_occ_ws_lec_1_output_20_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/gul_pltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_pltcalc_1_output_1_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/gul_pltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_pltcalc_1_output_20_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/gul_summarycalc_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_summarycalc_1_output_1_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/gul_summarycalc_1_output_20_partition.sh
+++ b/tests/model_execution/kparse_reference/gul_summarycalc_1_output_20_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/il_aalcalc_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/il_aalcalc_1_output_1_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/il_aalcalc_1_output_20_partition.sh
+++ b/tests/model_execution/kparse_reference/il_aalcalc_1_output_20_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/il_agg_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/il_agg_fu_lec_1_output_1_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/il_agg_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/kparse_reference/il_agg_fu_lec_1_output_20_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/il_agg_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/il_agg_ws_lec_1_output_1_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/il_agg_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/kparse_reference/il_agg_ws_lec_1_output_20_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/il_eltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/il_eltcalc_1_output_1_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/il_eltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/kparse_reference/il_eltcalc_1_output_20_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/il_lec_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/il_lec_1_output_1_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/il_lec_1_output_2_partition.sh
+++ b/tests/model_execution/kparse_reference/il_lec_1_output_2_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/il_lec_2_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/il_lec_2_output_1_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/il_lec_2_output_2_partition.sh
+++ b/tests/model_execution/kparse_reference/il_lec_2_output_2_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/il_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/il_no_lec_1_output_1_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/il_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/kparse_reference/il_no_lec_1_output_2_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/il_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/il_no_lec_2_output_1_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/il_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/kparse_reference/il_no_lec_2_output_2_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/il_occ_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/il_occ_fu_lec_1_output_1_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/il_occ_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/kparse_reference/il_occ_fu_lec_1_output_20_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/il_occ_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/il_occ_ws_lec_1_output_1_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/il_occ_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/kparse_reference/il_occ_ws_lec_1_output_20_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/il_pltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/il_pltcalc_1_output_1_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/il_pltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/kparse_reference/il_pltcalc_1_output_20_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/il_summarycalc_1_output_1_partition.sh
+++ b/tests/model_execution/kparse_reference/il_summarycalc_1_output_1_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 

--- a/tests/model_execution/kparse_reference/il_summarycalc_1_output_20_partition.sh
+++ b/tests/model_execution/kparse_reference/il_summarycalc_1_output_20_partition.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-rm -R -f output/*
+find output/* ! -name '*summary-info*' -type f -exec rm -f {} +
 rm -R -f fifo/*
 rm -R -f work/*
 


### PR DESCRIPTION
* First pass at summary_desc.json, needs tidy
* Move summary_id to seperate csv files
* write summary-info to ouput dir
* replace bash rm -rf output, with seletive delete
* First pass at summary_desc.json, needs tidy
* Move summary_id to seperate csv files

type = [`gul`, `il`, `ri`]
summaryset_id = [1..9]

files are storded as:
`{type}_S{summaryset_id}-summary-info.csv`

write summary-info to ouput dir

replace bash rm -rf output, with seletive delete