### PR TITLE
[WIP] Add multiprocessing to Keys Lookup

### DIFF
--- a/oasislmf/manager.py
+++ b/oasislmf/manager.py
@@ -289,6 +289,11 @@ class OasisManager(object):
             output_directory=lookup_extra_outputs_dir
         )
 
+        location_df = olf.get_exposure(
+            lookup=lookup,
+            source_exposure_fp=exposure_fp,
+        ) 
+
         utcnow = get_utctimestamp(fmt='%Y%m%d%H%M%S')
 
         keys_fp = keys_fp or '{}-keys.csv'.format(utcnow)
@@ -296,9 +301,9 @@ class OasisManager(object):
 
         return olf.save_results(
             lookup,
+            location_df=location_df,
             successes_fp=keys_fp,
             errors_fp=keys_errors_fp,
-            source_exposure_fp=exposure_fp,
             format=keys_format
         )
 
@@ -412,11 +417,16 @@ class OasisManager(object):
                     user_data_dir=user_data_dir,
                     output_directory=target_dir
                 )
+                # TODO: exposure_df is loaded twice, Elimilate step in `get_gul_input_items` if done here
+                location_df = olf.get_exposure(
+                    lookup=lookup,
+                    source_exposure_fp=exposure_fp,
+                ) 
                 f1, _, f2, _ = olf.save_results(
                     lookup,
+                    location_df=location_df,
                     successes_fp=_keys_fp,
-                    errors_fp=_keys_errors_fp,
-                    source_exposure_fp=exposure_fp
+                    errors_fp=_keys_errors_fp
                 )
         else:
             _keys_fp = os.path.join(target_dir, os.path.basename(keys_fp))

--- a/requirements-package.in
+++ b/requirements-package.in
@@ -1,6 +1,7 @@
 anytree>=2.4.3
 argparsetree>=0.0.5
 backports.tempfile
+billiard
 certifi
 chainmap
 cookiecutter>=1.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ babel==2.5.3              # via sphinx
 backcall==0.1.0           # via ipython
 backports.tempfile==1.0
 backports.weakref==1.0.post1
+billiard
 binaryornot==0.4.4        # via cookiecutter
 certifi==2017.11.5        # via requests
 chainmap==1.0.2


### PR DESCRIPTION
* Refactor lookup class to accept dataframes instead of filepaths
* Implement multi-process for built-in lookup
* Chunk dataframes at 2x workers
* Added to Builtin / custom lookup
* Added new method `process_locations_multiproc()` to run under worker pools

 to run a multiprocessing based lookup model developers should define a method
    `process_locations_multiproc` which accepts a Pandas dataframe of OED Locations
    and returns a list of lookup results.

    This method should not be a generator (avoid using **yeild**)

```
def process_locations_multiproc(location_dataframe)

    ... run lookup ...

    return [{result_1},
               ...
            {result_n}]
```

Todo:
- [x] Integration with CL Lookup class (Port Bind issue)
- [x] Update Unittests
  