### PR TITLE
Add check for CalcRule match

### DIFF
--- a/oasislmf/model_preparation/il_inputs.py
+++ b/oasislmf/model_preparation/il_inputs.py
@@ -77,6 +77,17 @@ def get_calc_rule_ids(il_inputs_df):
     il_inputs_calc_rules_df = merge_dataframes(il_inputs_calc_rules_df, calc_rules, how='left', on='id_key').fillna(0)
     il_inputs_calc_rules_df['calcrule_id'] = il_inputs_calc_rules_df['calcrule_id'].astype('uint32')
 
+    if 0 in il_inputs_calc_rules_df.calcrule_id.unique():
+        err_msg = 'Calculation Rule mapping error, non-matching keys:\n'
+        no_match_keys = il_inputs_calc_rules_df.loc[
+                        il_inputs_calc_rules_df.calcrule_id == 0
+                        ].id_key.unique()
+
+        err_msg += '   {}\n'.format(tuple(terms_indicators + types_and_codes))
+        for key_id in no_match_keys:
+            err_msg += '   {}\n'.format(key_id)
+        raise OasisException(err_msg)
+
     return il_inputs_calc_rules_df['calcrule_id'].values
 
 


### PR DESCRIPTION
Added check for when CalcRule mapping fails in `il_inputs_df`, raise an exception if true 

**Example**
```
Processing arguments

Running deterministic losses (GUL=True, IL=True, RIL=False)

STARTED: oasislmf.manager.__init__
COMPLETED: oasislmf.manager.__init__ in 0.0s
STARTED: oasislmf.manager.run_deterministic
STARTED: oasislmf.manager.generate_oasis_files
STARTED: oasislmf.model_preparation.gul_inputs.get_gul_input_items
COMPLETED: oasislmf.model_preparation.gul_inputs.get_gul_input_items in 0.24s
STARTED: oasislmf.model_preparation.gul_inputs.write_gul_input_files
STARTED: oasislmf.model_preparation.gul_inputs.write_items_file
COMPLETED: oasislmf.model_preparation.gul_inputs.write_items_file in 0.0s
STARTED: oasislmf.model_preparation.gul_inputs.write_coverages_file
COMPLETED: oasislmf.model_preparation.gul_inputs.write_coverages_file in 0.0s
COMPLETED: oasislmf.model_preparation.gul_inputs.write_gul_input_files in 0.13s
STARTED: oasislmf.model_preparation.summaries.get_summary_mapping
COMPLETED: oasislmf.model_preparation.summaries.get_summary_mapping in 0.0s
STARTED: oasislmf.model_preparation.summaries.write_mapping_file
COMPLETED: oasislmf.model_preparation.summaries.write_mapping_file in 0.01s
STARTED: oasislmf.model_preparation.il_inputs.get_il_input_items
Calculation Rule mapping error, non-matching keys:
   ('deductible_gt_0', 'deductible_min_gt_0', 'deductible_max_gt_0', 'limit_gt_0', 'share_gt_0', 'attachment_gt_0', 'ded_type', 'ded_code', 'lim_type', 'lim_code')
   (0, 0, 0, 0, 0, 0, 2, 0, 0, 0)
   (0, 0, 0, 0, 0, 0, 1, 0, 0, 0)
```

Where the `id_key`'s ` (0, 0, 0, 0, 0, 0, 2, 0, 0, 0)` and `(0, 0, 0, 0, 0, 0, 1, 0, 0, 0)` don't exist in 
https://github.com/OasisLMF/OasisLMF/blob/develop/oasislmf/_data/calc_rules.csv