### PR TITLE
Fix/407 fix leccalc

### DIFF
--- a/oasislmf/model_execution/bash.py
+++ b/oasislmf/model_execution/bash.py
@@ -1,7 +1,6 @@
 import io
 import os
 import random
-import re
 import string
 
 from collections import Counter
@@ -54,7 +53,7 @@ def leccalc_enabled(lec_options):
         lec_options = lec_options["outputs"]
 
     for option in lec_options:
-        if option in WAIT_PROCESSING_SWITCHES  and lec_options[option]:
+        if option in WAIT_PROCESSING_SWITCHES and lec_options[option]:
             return True
     return False
 
@@ -277,7 +276,7 @@ def do_tees(runtype, analysis_settings, process_id, filename, process_counter, f
     summaries = analysis_settings.get('{}_summaries'.format(runtype))
     if not summaries:
         return
-        
+
     if process_id == 1:
         print_command(filename, '')
 
@@ -355,7 +354,6 @@ def do_any(runtype, analysis_settings, process_id, filename, process_counter, fi
                         runtype, summary_set, process_id, cmd, process_counter['pid_monitor_count'], fifo_dir
                     )
                 )
-
 
 
 def ri(analysis_settings, max_process_id, filename, process_counter, num_reinsurance_iterations, fifo_dir='', stderr_abort=True):
@@ -600,7 +598,7 @@ def genbash(
     process_counter = Counter()
 
     use_random_number_file = False
-    stderr_abort = stderr_guard if stderr_guard != None else (not bash_trace)
+    stderr_abort = stderr_guard if stderr_guard is not None else (not bash_trace)
     gul_item_stream = (gul_alloc_rule and isinstance(gul_alloc_rule, int))
     gul_output = False
     il_output = False
@@ -656,7 +654,6 @@ def genbash(
         print_command(filename, 'touch log/stderror.err')
         print_command(filename, 'ktools_monitor.sh $$ & pid0=$!')
         print_command(filename, '')
-
 
     print_command(filename, '# --- Setup run dirs ---')
     print_command(filename, '')
@@ -752,7 +749,8 @@ def genbash(
             getmodel_cmd = _get_getmodel_cmd(**getmodel_args)
             fm_cmd = '{2} | fmcalc -a{3} > {4}fifo/il_P{0} '
 
-            main_cmd = fm_cmd.format( process_id,
+            main_cmd = fm_cmd.format(
+                process_id,
                 max_process_id,
                 getmodel_cmd,
                 il_alloc_rule,

--- a/tests/model_execution/kparse_input/all_calcs_1_output.json
+++ b/tests/model_execution/kparse_input/all_calcs_1_output.json
@@ -20,8 +20,7 @@
         "lec_output": true,
         "leccalc": {
             "return_period_file": true,
-            "outputs": {
-	    "full_uncertainty_aep": true,
+            "full_uncertainty_aep": true,
             "full_uncertainty_oep": true,
             "wheatsheaf_aep": true,
             "wheatsheaf_oep": true,
@@ -29,7 +28,6 @@
             "wheatsheaf_mean_oep": true,
             "sample_mean_aep": true,
             "sample_mean_oep": true
-		}
         }
       }
     ],
@@ -44,7 +42,6 @@
         "lec_output": true,
         "leccalc": {
             "return_period_file": true,
-	    "outputs": {
             "full_uncertainty_aep": true,
             "full_uncertainty_oep": true,
             "wheatsheaf_aep": true,
@@ -53,7 +50,6 @@
             "wheatsheaf_mean_oep": true,
             "sample_mean_aep": true,
             "sample_mean_oep": true
-		}
         }
       }
     ]

--- a/tests/model_execution/kparse_input/analysis_settings_4.json
+++ b/tests/model_execution/kparse_input/analysis_settings_4.json
@@ -42,17 +42,14 @@
         "lec_output":true,
         "leccalc": {
             "return_period_file": true,
-            "outputs":
-            {
-              "full_uncertainty_aep": true,
-              "full_uncertainty_oep": true,
-              "wheatsheaf_aep": true,
-              "wheatsheaf_oep": true,
-              "wheatsheaf_mean_aep": true,
-              "wheatsheaf_mean_oep": true,
-              "sample_mean_aep": true,
-              "sample_mean_oep": true
-            }
+            "full_uncertainty_aep": true,
+            "full_uncertainty_oep": true,
+            "wheatsheaf_aep": true,
+            "wheatsheaf_oep": true,
+            "wheatsheaf_mean_aep": true,
+            "wheatsheaf_mean_oep": true,
+            "sample_mean_aep": true,
+            "sample_mean_oep": true
         }
       }
     ]

--- a/tests/model_execution/kparse_input/analysis_settings_tmpfifo_memlim_4.json
+++ b/tests/model_execution/kparse_input/analysis_settings_tmpfifo_memlim_4.json
@@ -42,17 +42,14 @@
         "lec_output":true,
         "leccalc": {
             "return_period_file": true,
-            "outputs":
-            {
-              "full_uncertainty_aep": true,
-              "full_uncertainty_oep": true,
-              "wheatsheaf_aep": true,
-              "wheatsheaf_oep": true,
-              "wheatsheaf_mean_aep": true,
-              "wheatsheaf_mean_oep": true,
-              "sample_mean_aep": true,
-              "sample_mean_oep": true
-            }
+            "full_uncertainty_aep": true,
+            "full_uncertainty_oep": true,
+            "wheatsheaf_aep": true,
+            "wheatsheaf_oep": true,
+            "wheatsheaf_mean_aep": true,
+            "wheatsheaf_mean_oep": true,
+            "sample_mean_aep": true,
+            "sample_mean_oep": true
         }
       }
     ]

--- a/tests/model_execution/kparse_input/gul_aalcalc_1_output.json
+++ b/tests/model_execution/kparse_input/gul_aalcalc_1_output.json
@@ -20,8 +20,7 @@
         "lec_output": false,
         "leccalc": {
             "return_period_file": true,
-            "outputs": {
-	    "full_uncertainty_aep": false,
+            "full_uncertainty_aep": false,
             "full_uncertainty_oep": false,
             "wheatsheaf_aep": false,
             "wheatsheaf_oep": false,
@@ -29,7 +28,6 @@
             "wheatsheaf_mean_oep": false,
             "sample_mean_aep": false,
             "sample_mean_oep": false
-		}
         }
       }
     ],
@@ -44,7 +42,6 @@
         "lec_output": false,
         "leccalc": {
             "return_period_file": false,
-	    "outputs": {
             "full_uncertainty_aep": false,
             "full_uncertainty_oep": false,
             "wheatsheaf_aep": false,
@@ -53,7 +50,6 @@
             "wheatsheaf_mean_oep": false,
             "sample_mean_aep": false,
             "sample_mean_oep": false
-		}
         }
       }
     ]

--- a/tests/model_execution/kparse_input/gul_agg_fu_lec_1_output.json
+++ b/tests/model_execution/kparse_input/gul_agg_fu_lec_1_output.json
@@ -11,16 +11,15 @@
     },
     "gul_output": true,
     "gul_summaries": [
-      {
-        "id": 1,
-        "summarycalc": false,
-        "eltcalc": false,
-        "aalcalc": false,
-        "pltcalc": false,
-        "lec_output": true,
-        "leccalc": {
-            "return_period_file": true,
-            "outputs": {
+        {
+          "id": 1,
+          "summarycalc": false,
+          "eltcalc": false,
+          "aalcalc": false,
+          "pltcalc": false,
+          "lec_output": true,
+          "leccalc": {
+              "return_period_file": true,
               "full_uncertainty_aep": true,
               "full_uncertainty_oep": false,
               "wheatsheaf_aep": false,
@@ -29,9 +28,8 @@
               "wheatsheaf_mean_oep": false,
               "sample_mean_aep": false,
               "sample_mean_oep": false
-            }
           }
-      }
+        }
     ],
     "il_output": false,
     "il_summaries": [
@@ -44,7 +42,6 @@
         "lec_output": false,
         "leccalc": {
             "return_period_file": false,
-	    "outputs": {
             "full_uncertainty_aep": false,
             "full_uncertainty_oep": false,
             "wheatsheaf_aep": false,
@@ -53,7 +50,6 @@
             "wheatsheaf_mean_oep": false,
             "sample_mean_aep": false,
             "sample_mean_oep": false
-		}
         }
       }
     ]

--- a/tests/model_execution/kparse_input/gul_agg_sample_mean_lec_1_output.json
+++ b/tests/model_execution/kparse_input/gul_agg_sample_mean_lec_1_output.json
@@ -20,8 +20,7 @@
         "lec_output": true,
         "leccalc": {
             "return_period_file": true,
-            "outputs": {
-	    "full_uncertainty_aep": false,
+            "full_uncertainty_aep": false,
             "full_uncertainty_oep": false,
             "wheatsheaf_aep": false,
             "wheatsheaf_oep": false,
@@ -29,7 +28,6 @@
             "wheatsheaf_mean_oep": false,
             "sample_mean_aep": true,
             "sample_mean_oep": false
-		}
         }
       }
     ],
@@ -44,7 +42,6 @@
         "lec_output": false,
         "leccalc": {
             "return_period_file": false,
-	    "outputs": {
             "full_uncertainty_aep": false,
             "full_uncertainty_oep": false,
             "wheatsheaf_aep": false,
@@ -53,7 +50,6 @@
             "wheatsheaf_mean_oep": false,
             "sample_mean_aep": false,
             "sample_mean_oep": false
-		}
         }
       }
     ]

--- a/tests/model_execution/kparse_input/gul_agg_ws_lec_1_output.json
+++ b/tests/model_execution/kparse_input/gul_agg_ws_lec_1_output.json
@@ -20,8 +20,7 @@
         "lec_output": true,
         "leccalc": {
             "return_period_file": true,
-            "outputs": {
-	    "full_uncertainty_aep": false,
+            "full_uncertainty_aep": false,
             "full_uncertainty_oep": false,
             "wheatsheaf_aep": true,
             "wheatsheaf_oep": false,
@@ -29,7 +28,6 @@
             "wheatsheaf_mean_oep": false,
             "sample_mean_aep": false,
             "sample_mean_oep": false
-		}
         }
       }
     ],
@@ -44,7 +42,6 @@
         "lec_output": false,
         "leccalc": {
             "return_period_file": false,
-	    "outputs": {
             "full_uncertainty_aep": false,
             "full_uncertainty_oep": false,
             "wheatsheaf_aep": false,
@@ -53,7 +50,6 @@
             "wheatsheaf_mean_oep": false,
             "sample_mean_aep": false,
             "sample_mean_oep": false
-		}
         }
       }
     ]

--- a/tests/model_execution/kparse_input/gul_agg_ws_mean_lec_1_output.json
+++ b/tests/model_execution/kparse_input/gul_agg_ws_mean_lec_1_output.json
@@ -20,8 +20,7 @@
         "lec_output": true,
         "leccalc": {
             "return_period_file": true,
-            "outputs": {
-	    "full_uncertainty_aep": false,
+            "full_uncertainty_aep": false,
             "full_uncertainty_oep": false,
             "wheatsheaf_aep": false,
             "wheatsheaf_oep": false,
@@ -30,7 +29,6 @@
             "sample_mean_aep": false,
             "sample_mean_oep": false
 		}
-        }
       }
     ],
     "il_output": false,
@@ -44,7 +42,6 @@
         "lec_output": false,
         "leccalc": {
             "return_period_file": false,
-	    "outputs": {
             "full_uncertainty_aep": false,
             "full_uncertainty_oep": false,
             "wheatsheaf_aep": false,
@@ -53,7 +50,6 @@
             "wheatsheaf_mean_oep": false,
             "sample_mean_aep": false,
             "sample_mean_oep": false
-		}
         }
       }
     ]

--- a/tests/model_execution/kparse_input/gul_agg_ws_mean_lec_1_tmpfifo_memlim_output.json
+++ b/tests/model_execution/kparse_input/gul_agg_ws_mean_lec_1_tmpfifo_memlim_output.json
@@ -20,8 +20,7 @@
         "lec_output": true,
         "leccalc": {
             "return_period_file": true,
-            "outputs": {
-	    "full_uncertainty_aep": false,
+            "full_uncertainty_aep": false,
             "full_uncertainty_oep": false,
             "wheatsheaf_aep": false,
             "wheatsheaf_oep": false,
@@ -29,7 +28,6 @@
             "wheatsheaf_mean_oep": false,
             "sample_mean_aep": false,
             "sample_mean_oep": false
-		}
         }
       }
     ],
@@ -44,7 +42,6 @@
         "lec_output": false,
         "leccalc": {
             "return_period_file": false,
-	    "outputs": {
             "full_uncertainty_aep": false,
             "full_uncertainty_oep": false,
             "wheatsheaf_aep": false,
@@ -53,7 +50,6 @@
             "wheatsheaf_mean_oep": false,
             "sample_mean_aep": false,
             "sample_mean_oep": false
-		}
         }
       }
     ]

--- a/tests/model_execution/kparse_input/gul_eltcalc_1_output.json
+++ b/tests/model_execution/kparse_input/gul_eltcalc_1_output.json
@@ -20,8 +20,7 @@
         "lec_output": false,
         "leccalc": {
             "return_period_file": true,
-            "outputs": {
-	    "full_uncertainty_aep": false,
+            "full_uncertainty_aep": false,
             "full_uncertainty_oep": false,
             "wheatsheaf_aep": false,
             "wheatsheaf_oep": false,
@@ -29,7 +28,6 @@
             "wheatsheaf_mean_oep": false,
             "sample_mean_aep": false,
             "sample_mean_oep": false
-		}
         }
       }
     ],
@@ -44,7 +42,6 @@
         "lec_output": false,
         "leccalc": {
             "return_period_file": false,
-	    "outputs": {
             "full_uncertainty_aep": false,
             "full_uncertainty_oep": false,
             "wheatsheaf_aep": false,
@@ -53,7 +50,6 @@
             "wheatsheaf_mean_oep": false,
             "sample_mean_aep": false,
             "sample_mean_oep": false
-		}
         }
       }
     ]

--- a/tests/model_execution/kparse_input/gul_il_lec_1_output.json
+++ b/tests/model_execution/kparse_input/gul_il_lec_1_output.json
@@ -21,17 +21,14 @@
         "lec_output":true,
         "leccalc": {
             "return_period_file": true,
-            "outputs":
-            {
-              "full_uncertainty_aep": true,
-              "full_uncertainty_oep": true,
-              "wheatsheaf_aep": true,
-              "wheatsheaf_oep": true,
-              "wheatsheaf_mean_aep": true,
-              "wheatsheaf_mean_oep": true,
-              "sample_mean_aep": true,
-              "sample_mean_oep": true
-            }
+            "full_uncertainty_aep": true,
+            "full_uncertainty_oep": true,
+            "wheatsheaf_aep": true,
+            "wheatsheaf_oep": true,
+            "wheatsheaf_mean_aep": true,
+            "wheatsheaf_mean_oep": true,
+            "sample_mean_aep": true,
+            "sample_mean_oep": true
         }        
       }
     ],
@@ -46,16 +43,14 @@
         "lec_output":true,
         "leccalc": {
             "return_period_file": true,
-            "outputs":{
-              "full_uncertainty_aep": true,
-              "full_uncertainty_oep": true,
-              "wheatsheaf_aep": true,
-              "wheatsheaf_oep": true,
-              "wheatsheaf_mean_aep": true,
-              "wheatsheaf_mean_oep": true,
-              "sample_mean_aep": true,
-              "sample_mean_oep": true
-            }
+            "full_uncertainty_aep": true,
+            "full_uncertainty_oep": true,
+            "wheatsheaf_aep": true,
+            "wheatsheaf_oep": true,
+            "wheatsheaf_mean_aep": true,
+            "wheatsheaf_mean_oep": true,
+            "sample_mean_aep": true,
+            "sample_mean_oep": true
         }        
       }
     ]    

--- a/tests/model_execution/kparse_input/gul_il_lec_2_output.json
+++ b/tests/model_execution/kparse_input/gul_il_lec_2_output.json
@@ -21,17 +21,14 @@
         "lec_output":true,
         "leccalc": {
             "return_period_file": true,
-            "outputs":
-            {
-              "full_uncertainty_aep": true,
-              "full_uncertainty_oep": true,
-              "wheatsheaf_aep": true,
-              "wheatsheaf_oep": true,
-              "wheatsheaf_mean_aep": true,
-              "wheatsheaf_mean_oep": true,
-              "sample_mean_aep": true,
-              "sample_mean_oep": true
-            }
+            "full_uncertainty_aep": true,
+            "full_uncertainty_oep": true,
+            "wheatsheaf_aep": true,
+            "wheatsheaf_oep": true,
+            "wheatsheaf_mean_aep": true,
+            "wheatsheaf_mean_oep": true,
+            "sample_mean_aep": true,
+            "sample_mean_oep": true
         }
       },
       {
@@ -43,17 +40,14 @@
         "lec_output":true,
         "leccalc": {
             "return_period_file": true,
-            "outputs":
-            {
-              "full_uncertainty_aep": true,
-              "full_uncertainty_oep": true,
-              "wheatsheaf_aep": true,
-              "wheatsheaf_oep": true,
-              "wheatsheaf_mean_aep": true,
-              "wheatsheaf_mean_oep": true,
-              "sample_mean_aep": true,
-              "sample_mean_oep": true
-            }
+            "full_uncertainty_aep": true,
+            "full_uncertainty_oep": true,
+            "wheatsheaf_aep": true,
+            "wheatsheaf_oep": true,
+            "wheatsheaf_mean_aep": true,
+            "wheatsheaf_mean_oep": true,
+            "sample_mean_aep": true,
+            "sample_mean_oep": true
         }        
       }
     ],
@@ -68,17 +62,15 @@
         "lec_output":true,
         "leccalc": {
             "return_period_file": true,
-            "outputs":
-            {
-              "full_uncertainty_aep": true,
-              "full_uncertainty_oep": true,
-              "wheatsheaf_aep": true,
-              "wheatsheaf_oep": true,
-              "wheatsheaf_mean_aep": true,
-              "wheatsheaf_mean_oep": true,
-              "sample_mean_aep": true,
-              "sample_mean_oep": true
-            }        }
+            "full_uncertainty_aep": true,
+            "full_uncertainty_oep": true,
+            "wheatsheaf_aep": true,
+            "wheatsheaf_oep": true,
+            "wheatsheaf_mean_aep": true,
+            "wheatsheaf_mean_oep": true,
+            "sample_mean_aep": true,
+            "sample_mean_oep": true
+         }     
       },
       {
         "id": 2,
@@ -89,17 +81,14 @@
         "lec_output":true,
         "leccalc": {
             "return_period_file": true,
-            "outputs":
-            {
-              "full_uncertainty_aep": true,
-              "full_uncertainty_oep": true,
-              "wheatsheaf_aep": true,
-              "wheatsheaf_oep": true,
-              "wheatsheaf_mean_aep": true,
-              "wheatsheaf_mean_oep": true,
-              "sample_mean_aep": true,
-              "sample_mean_oep": true
-            }
+            "full_uncertainty_aep": true,
+            "full_uncertainty_oep": true,
+            "wheatsheaf_aep": true,
+            "wheatsheaf_oep": true,
+            "wheatsheaf_mean_aep": true,
+            "wheatsheaf_mean_oep": true,
+            "sample_mean_aep": true,
+            "sample_mean_oep": true
         }        
       }
     ]

--- a/tests/model_execution/kparse_input/gul_il_lec_2_tmpfifo_output.json
+++ b/tests/model_execution/kparse_input/gul_il_lec_2_tmpfifo_output.json
@@ -21,17 +21,14 @@
         "lec_output":true,
         "leccalc": {
             "return_period_file": true,
-            "outputs":
-            {
-              "full_uncertainty_aep": true,
-              "full_uncertainty_oep": true,
-              "wheatsheaf_aep": true,
-              "wheatsheaf_oep": true,
-              "wheatsheaf_mean_aep": true,
-              "wheatsheaf_mean_oep": true,
-              "sample_mean_aep": true,
-              "sample_mean_oep": true
-            }
+            "full_uncertainty_aep": true,
+            "full_uncertainty_oep": true,
+            "wheatsheaf_aep": true,
+            "wheatsheaf_oep": true,
+            "wheatsheaf_mean_aep": true,
+            "wheatsheaf_mean_oep": true,
+            "sample_mean_aep": true,
+            "sample_mean_oep": true
         }
       },
       {
@@ -43,17 +40,14 @@
         "lec_output":true,
         "leccalc": {
             "return_period_file": true,
-            "outputs":
-            {
-              "full_uncertainty_aep": true,
-              "full_uncertainty_oep": true,
-              "wheatsheaf_aep": true,
-              "wheatsheaf_oep": true,
-              "wheatsheaf_mean_aep": true,
-              "wheatsheaf_mean_oep": true,
-              "sample_mean_aep": true,
-              "sample_mean_oep": true
-            }
+            "full_uncertainty_aep": true,
+            "full_uncertainty_oep": true,
+            "wheatsheaf_aep": true,
+            "wheatsheaf_oep": true,
+            "wheatsheaf_mean_aep": true,
+            "wheatsheaf_mean_oep": true,
+            "sample_mean_aep": true,
+            "sample_mean_oep": true
         }        
       }
     ],
@@ -68,17 +62,15 @@
         "lec_output":true,
         "leccalc": {
             "return_period_file": true,
-            "outputs":
-            {
-              "full_uncertainty_aep": true,
-              "full_uncertainty_oep": true,
-              "wheatsheaf_aep": true,
-              "wheatsheaf_oep": true,
-              "wheatsheaf_mean_aep": true,
-              "wheatsheaf_mean_oep": true,
-              "sample_mean_aep": true,
-              "sample_mean_oep": true
-            }        }
+            "full_uncertainty_aep": true,
+            "full_uncertainty_oep": true,
+            "wheatsheaf_aep": true,
+            "wheatsheaf_oep": true,
+            "wheatsheaf_mean_aep": true,
+            "wheatsheaf_mean_oep": true,
+            "sample_mean_aep": true,
+            "sample_mean_oep": true
+         }
       },
       {
         "id": 2,
@@ -89,17 +81,14 @@
         "lec_output":true,
         "leccalc": {
             "return_period_file": true,
-            "outputs":
-            {
-              "full_uncertainty_aep": true,
-              "full_uncertainty_oep": true,
-              "wheatsheaf_aep": true,
-              "wheatsheaf_oep": true,
-              "wheatsheaf_mean_aep": true,
-              "wheatsheaf_mean_oep": true,
-              "sample_mean_aep": true,
-              "sample_mean_oep": true
-            }
+            "full_uncertainty_aep": true,
+            "full_uncertainty_oep": true,
+            "wheatsheaf_aep": true,
+            "wheatsheaf_oep": true,
+            "wheatsheaf_mean_aep": true,
+            "wheatsheaf_mean_oep": true,
+            "sample_mean_aep": true,
+            "sample_mean_oep": true
         }        
       }
     ]

--- a/tests/model_execution/kparse_input/gul_lec_1_output.json
+++ b/tests/model_execution/kparse_input/gul_lec_1_output.json
@@ -21,17 +21,14 @@
         "lec_output":true,
         "leccalc": {
             "return_period_file": true,
-            "outputs":
-            {
-              "full_uncertainty_aep": true,
-              "full_uncertainty_oep": true,
-              "wheatsheaf_aep": true,
-              "wheatsheaf_oep": true,
-              "wheatsheaf_mean_aep": true,
-              "wheatsheaf_mean_oep": true,
-              "sample_mean_aep": true,
-              "sample_mean_oep": true
-            }
+            "full_uncertainty_aep": true,
+            "full_uncertainty_oep": true,
+            "wheatsheaf_aep": true,
+            "wheatsheaf_oep": true,
+            "wheatsheaf_mean_aep": true,
+            "wheatsheaf_mean_oep": true,
+            "sample_mean_aep": true,
+            "sample_mean_oep": true
         }        
       }
     ],

--- a/tests/model_execution/kparse_input/gul_lec_2_output.json
+++ b/tests/model_execution/kparse_input/gul_lec_2_output.json
@@ -21,18 +21,15 @@
         "lec_output":true,
         "leccalc": {
             "return_period_file": true,
-            "outputs":
-            {
-              "full_uncertainty_aep": true,
-              "full_uncertainty_oep": true,
-              "wheatsheaf_aep": true,
-              "wheatsheaf_oep": true,
-              "wheatsheaf_mean_aep": true,
-              "wheatsheaf_mean_oep": true,
-              "sample_mean_aep": true,
-              "sample_mean_oep": true
-            }
-        }
+            "full_uncertainty_aep": true,
+            "full_uncertainty_oep": true,
+            "wheatsheaf_aep": true,
+            "wheatsheaf_oep": true,
+            "wheatsheaf_mean_aep": true,
+            "wheatsheaf_mean_oep": true,
+            "sample_mean_aep": true,
+            "sample_mean_oep": true
+         }
       },
       {
         "id": 2,
@@ -43,18 +40,15 @@
         "lec_output":true,
         "leccalc": {
             "return_period_file": true,
-            "outputs":
-            {
-              "full_uncertainty_aep": true,
-              "full_uncertainty_oep": true,
-              "wheatsheaf_aep": true,
-              "wheatsheaf_oep": true,
-              "wheatsheaf_mean_aep": true,
-              "wheatsheaf_mean_oep": true,
-              "sample_mean_aep": true,
-              "sample_mean_oep": true
-            }
-        }        
+            "full_uncertainty_aep": true,
+            "full_uncertainty_oep": true,
+            "wheatsheaf_aep": true,
+            "wheatsheaf_oep": true,
+            "wheatsheaf_mean_aep": true,
+            "wheatsheaf_mean_oep": true,
+            "sample_mean_aep": true,
+            "sample_mean_oep": true
+         }        
       }
     ],
     "il_output": false

--- a/tests/model_execution/kparse_input/gul_occ_fu_lec_1_output.json
+++ b/tests/model_execution/kparse_input/gul_occ_fu_lec_1_output.json
@@ -20,8 +20,7 @@
         "lec_output": true,
         "leccalc": {
             "return_period_file": true,
-            "outputs": {
-	    "full_uncertainty_aep": false,
+            "full_uncertainty_aep": false,
             "full_uncertainty_oep": true,
             "wheatsheaf_aep": false,
             "wheatsheaf_oep": false,
@@ -29,7 +28,6 @@
             "wheatsheaf_mean_oep": false,
             "sample_mean_aep": false,
             "sample_mean_oep": false
-		}
         }
       }
     ],
@@ -44,7 +42,6 @@
         "lec_output": false,
         "leccalc": {
             "return_period_file": false,
-	    "outputs": {
             "full_uncertainty_aep": false,
             "full_uncertainty_oep": false,
             "wheatsheaf_aep": false,
@@ -53,7 +50,6 @@
             "wheatsheaf_mean_oep": false,
             "sample_mean_aep": false,
             "sample_mean_oep": false
-		}
         }
       }
     ]

--- a/tests/model_execution/kparse_input/gul_occ_sample_mean_lec_1_output.json
+++ b/tests/model_execution/kparse_input/gul_occ_sample_mean_lec_1_output.json
@@ -20,8 +20,7 @@
         "lec_output": true,
         "leccalc": {
             "return_period_file": true,
-            "outputs": {
-	    "full_uncertainty_aep": false,
+            "full_uncertainty_aep": false,
             "full_uncertainty_oep": false,
             "wheatsheaf_aep": false,
             "wheatsheaf_oep": false,
@@ -29,7 +28,6 @@
             "wheatsheaf_mean_oep": false,
             "sample_mean_aep": false,
             "sample_mean_oep": true
-		}
         }
       }
     ],
@@ -44,7 +42,6 @@
         "lec_output": false,
         "leccalc": {
             "return_period_file": false,
-	    "outputs": {
             "full_uncertainty_aep": false,
             "full_uncertainty_oep": false,
             "wheatsheaf_aep": false,
@@ -53,7 +50,6 @@
             "wheatsheaf_mean_oep": false,
             "sample_mean_aep": false,
             "sample_mean_oep": false
-		}
         }
       }
     ]

--- a/tests/model_execution/kparse_input/gul_occ_ws_lec_1_output.json
+++ b/tests/model_execution/kparse_input/gul_occ_ws_lec_1_output.json
@@ -20,8 +20,7 @@
         "lec_output": true,
         "leccalc": {
             "return_period_file": true,
-            "outputs": {
-	    "full_uncertainty_aep": false,
+            "full_uncertainty_aep": false,
             "full_uncertainty_oep": false,
             "wheatsheaf_aep": false,
             "wheatsheaf_oep": true,
@@ -29,7 +28,6 @@
             "wheatsheaf_mean_oep": false,
             "sample_mean_aep": false,
             "sample_mean_oep": false
-		}
         }
       }
     ],
@@ -44,7 +42,6 @@
         "lec_output": false,
         "leccalc": {
             "return_period_file": false,
-	    "outputs": {
             "full_uncertainty_aep": false,
             "full_uncertainty_oep": false,
             "wheatsheaf_aep": false,
@@ -53,7 +50,6 @@
             "wheatsheaf_mean_oep": false,
             "sample_mean_aep": false,
             "sample_mean_oep": false
-		}
         }
       }
     ]

--- a/tests/model_execution/kparse_input/gul_occ_ws_mean_lec_1_output.json
+++ b/tests/model_execution/kparse_input/gul_occ_ws_mean_lec_1_output.json
@@ -20,8 +20,7 @@
         "lec_output": true,
         "leccalc": {
             "return_period_file": true,
-            "outputs": {
-	    "full_uncertainty_aep": false,
+            "full_uncertainty_aep": false,
             "full_uncertainty_oep": false,
             "wheatsheaf_aep": false,
             "wheatsheaf_oep": false,
@@ -29,7 +28,6 @@
             "wheatsheaf_mean_oep": true,
             "sample_mean_aep": false,
             "sample_mean_oep": false
-		}
         }
       }
     ],
@@ -44,7 +42,6 @@
         "lec_output": false,
         "leccalc": {
             "return_period_file": false,
-	    "outputs": {
             "full_uncertainty_aep": false,
             "full_uncertainty_oep": false,
             "wheatsheaf_aep": false,
@@ -53,7 +50,6 @@
             "wheatsheaf_mean_oep": false,
             "sample_mean_aep": false,
             "sample_mean_oep": false
-		}
         }
       }
     ]

--- a/tests/model_execution/kparse_input/gul_pltcalc_1_output.json
+++ b/tests/model_execution/kparse_input/gul_pltcalc_1_output.json
@@ -20,8 +20,7 @@
         "lec_output": false,
         "leccalc": {
             "return_period_file": true,
-            "outputs": {
-	    "full_uncertainty_aep": false,
+            "full_uncertainty_aep": false,
             "full_uncertainty_oep": false,
             "wheatsheaf_aep": false,
             "wheatsheaf_oep": false,
@@ -29,7 +28,6 @@
             "wheatsheaf_mean_oep": false,
             "sample_mean_aep": false,
             "sample_mean_oep": false
-		}
         }
       }
     ],
@@ -44,7 +42,6 @@
         "lec_output": false,
         "leccalc": {
             "return_period_file": false,
-	    "outputs": {
             "full_uncertainty_aep": false,
             "full_uncertainty_oep": false,
             "wheatsheaf_aep": false,
@@ -53,7 +50,6 @@
             "wheatsheaf_mean_oep": false,
             "sample_mean_aep": false,
             "sample_mean_oep": false
-		}
         }
       }
     ]

--- a/tests/model_execution/kparse_input/gul_summarycalc_1_output.json
+++ b/tests/model_execution/kparse_input/gul_summarycalc_1_output.json
@@ -20,8 +20,7 @@
         "lec_output": false,
         "leccalc": {
             "return_period_file": true,
-            "outputs": {
-	    "full_uncertainty_aep": false,
+            "full_uncertainty_aep": false,
             "full_uncertainty_oep": false,
             "wheatsheaf_aep": false,
             "wheatsheaf_oep": false,
@@ -29,7 +28,6 @@
             "wheatsheaf_mean_oep": false,
             "sample_mean_aep": false,
             "sample_mean_oep": false
-		}
         }
       }
     ],
@@ -44,7 +42,6 @@
         "lec_output": false,
         "leccalc": {
             "return_period_file": false,
-	    "outputs": {
             "full_uncertainty_aep": false,
             "full_uncertainty_oep": false,
             "wheatsheaf_aep": false,
@@ -53,7 +50,6 @@
             "wheatsheaf_mean_oep": false,
             "sample_mean_aep": false,
             "sample_mean_oep": false
-		}
         }
       }
     ]

--- a/tests/model_execution/kparse_input/il_aalcalc_1_output.json
+++ b/tests/model_execution/kparse_input/il_aalcalc_1_output.json
@@ -20,8 +20,7 @@
         "lec_output": true,
         "leccalc": {
             "return_period_file": true,
-            "outputs": {
-	    "full_uncertainty_aep": false,
+            "full_uncertainty_aep": false,
             "full_uncertainty_oep": false,
             "wheatsheaf_aep": false,
             "wheatsheaf_oep": false,
@@ -29,7 +28,6 @@
             "wheatsheaf_mean_oep": false,
             "sample_mean_aep": false,
             "sample_mean_oep": false
-		}
         }
       }
     ],
@@ -44,7 +42,6 @@
         "lec_output": false,
         "leccalc": {
             "return_period_file": false,
-	    "outputs": {
             "full_uncertainty_aep": false,
             "full_uncertainty_oep": false,
             "wheatsheaf_aep": false,
@@ -53,7 +50,6 @@
             "wheatsheaf_mean_oep": false,
             "sample_mean_aep": false,
             "sample_mean_oep": false
-		}
         }
       }
     ]

--- a/tests/model_execution/kparse_input/il_agg_fu_lec_1_output.json
+++ b/tests/model_execution/kparse_input/il_agg_fu_lec_1_output.json
@@ -20,8 +20,7 @@
         "lec_output": true,
         "leccalc": {
             "return_period_file": true,
-            "outputs": {
-	    "full_uncertainty_aep": false,
+            "full_uncertainty_aep": false,
             "full_uncertainty_oep": false,
             "wheatsheaf_aep": false,
             "wheatsheaf_oep": false,
@@ -29,7 +28,6 @@
             "wheatsheaf_mean_oep": false,
             "sample_mean_aep": false,
             "sample_mean_oep": false
-		}
         }
       }
     ],
@@ -44,7 +42,6 @@
         "lec_output": true,
         "leccalc": {
             "return_period_file": true,
-	    "outputs": {
             "full_uncertainty_aep": true,
             "full_uncertainty_oep": false,
             "wheatsheaf_aep": false,
@@ -53,7 +50,6 @@
             "wheatsheaf_mean_oep": false,
             "sample_mean_aep": false,
             "sample_mean_oep": false
-		}
         }
       }
     ]

--- a/tests/model_execution/kparse_input/il_agg_sample_mean_lec_1_output.json
+++ b/tests/model_execution/kparse_input/il_agg_sample_mean_lec_1_output.json
@@ -20,8 +20,7 @@
         "lec_output": true,
         "leccalc": {
             "return_period_file": true,
-            "outputs": {
-	    "full_uncertainty_aep": false,
+            "full_uncertainty_aep": false,
             "full_uncertainty_oep": false,
             "wheatsheaf_aep": false,
             "wheatsheaf_oep": false,
@@ -29,7 +28,6 @@
             "wheatsheaf_mean_oep": false,
             "sample_mean_aep": false,
             "sample_mean_oep": false
-		}
         }
       }
     ],
@@ -44,7 +42,6 @@
         "lec_output": true,
         "leccalc": {
             "return_period_file": true,
-	    "outputs": {
             "full_uncertainty_aep": false,
             "full_uncertainty_oep": false,
             "wheatsheaf_aep": false,
@@ -53,7 +50,6 @@
             "wheatsheaf_mean_oep": false,
             "sample_mean_aep": true,
             "sample_mean_oep": false
-		}
         }
       }
     ]

--- a/tests/model_execution/kparse_input/il_agg_ws_lec_1_output.json
+++ b/tests/model_execution/kparse_input/il_agg_ws_lec_1_output.json
@@ -20,8 +20,7 @@
         "lec_output": true,
         "leccalc": {
             "return_period_file": true,
-            "outputs": {
-	    "full_uncertainty_aep": false,
+            "full_uncertainty_aep": false,
             "full_uncertainty_oep": false,
             "wheatsheaf_aep": false,
             "wheatsheaf_oep": false,
@@ -29,7 +28,6 @@
             "wheatsheaf_mean_oep": false,
             "sample_mean_aep": false,
             "sample_mean_oep": false
-		}
         }
       }
     ],
@@ -44,7 +42,6 @@
         "lec_output": true,
         "leccalc": {
             "return_period_file": true,
-	    "outputs": {
             "full_uncertainty_aep": false,
             "full_uncertainty_oep": false,
             "wheatsheaf_aep": true,
@@ -53,7 +50,6 @@
             "wheatsheaf_mean_oep": false,
             "sample_mean_aep": false,
             "sample_mean_oep": false
-		}
         }
       }
     ]

--- a/tests/model_execution/kparse_input/il_agg_ws_mean_lec_1_output.json
+++ b/tests/model_execution/kparse_input/il_agg_ws_mean_lec_1_output.json
@@ -20,8 +20,7 @@
         "lec_output": true,
         "leccalc": {
             "return_period_file": true,
-            "outputs": {
-	    "full_uncertainty_aep": false,
+            "full_uncertainty_aep": false,
             "full_uncertainty_oep": false,
             "wheatsheaf_aep": false,
             "wheatsheaf_oep": false,
@@ -29,7 +28,6 @@
             "wheatsheaf_mean_oep": false,
             "sample_mean_aep": false,
             "sample_mean_oep": false
-		}
         }
       }
     ],
@@ -44,7 +42,6 @@
         "lec_output": true,
         "leccalc": {
             "return_period_file": true,
-	    "outputs": {
             "full_uncertainty_aep": false,
             "full_uncertainty_oep": false,
             "wheatsheaf_aep": false,
@@ -53,7 +50,6 @@
             "wheatsheaf_mean_oep": false,
             "sample_mean_aep": false,
             "sample_mean_oep": false
-		}
         }
       }
     ]

--- a/tests/model_execution/kparse_input/il_eltcalc_1_output.json
+++ b/tests/model_execution/kparse_input/il_eltcalc_1_output.json
@@ -20,8 +20,7 @@
         "lec_output": true,
         "leccalc": {
             "return_period_file": true,
-            "outputs": {
-	    "full_uncertainty_aep": false,
+            "full_uncertainty_aep": false,
             "full_uncertainty_oep": false,
             "wheatsheaf_aep": false,
             "wheatsheaf_oep": false,
@@ -29,7 +28,6 @@
             "wheatsheaf_mean_oep": false,
             "sample_mean_aep": false,
             "sample_mean_oep": false
-		}
         }
       }
     ],
@@ -44,7 +42,6 @@
         "lec_output": false,
         "leccalc": {
             "return_period_file": false,
-	    "outputs": {
             "full_uncertainty_aep": false,
             "full_uncertainty_oep": false,
             "wheatsheaf_aep": false,
@@ -53,7 +50,6 @@
             "wheatsheaf_mean_oep": false,
             "sample_mean_aep": false,
             "sample_mean_oep": false
-		}
         }
       }
     ]

--- a/tests/model_execution/kparse_input/il_lec_1_output.json
+++ b/tests/model_execution/kparse_input/il_lec_1_output.json
@@ -22,18 +22,15 @@
         "lec_output":true,
         "leccalc": {
             "return_period_file": true,
-            "outputs":
-            {
-              "full_uncertainty_aep": true,
-              "full_uncertainty_oep": true,
-              "wheatsheaf_aep": true,
-              "wheatsheaf_oep": true,
-              "wheatsheaf_mean_aep": true,
-              "wheatsheaf_mean_oep": true,
-              "sample_mean_aep": true,
-              "sample_mean_oep": true
-            }
-          }
+            "full_uncertainty_aep": true,
+            "full_uncertainty_oep": true,
+            "wheatsheaf_aep": true,
+            "wheatsheaf_oep": true,
+            "wheatsheaf_mean_aep": true,
+            "wheatsheaf_mean_oep": true,
+            "sample_mean_aep": true,
+            "sample_mean_oep": true
+         }
       }
     ]
   }

--- a/tests/model_execution/kparse_input/il_lec_2_output.json
+++ b/tests/model_execution/kparse_input/il_lec_2_output.json
@@ -22,17 +22,14 @@
         "lec_output":true,
         "leccalc": {
             "return_period_file": true,
-            "outputs":
-            {
-              "full_uncertainty_aep": true,
-              "full_uncertainty_oep": true,
-              "wheatsheaf_aep": true,
-              "wheatsheaf_oep": true,
-              "wheatsheaf_mean_aep": true,
-              "wheatsheaf_mean_oep": true,
-              "sample_mean_aep": true,
-              "sample_mean_oep": true
-            }
+            "full_uncertainty_aep": true,
+            "full_uncertainty_oep": true,
+            "wheatsheaf_aep": true,
+            "wheatsheaf_oep": true,
+            "wheatsheaf_mean_aep": true,
+            "wheatsheaf_mean_oep": true,
+            "sample_mean_aep": true,
+            "sample_mean_oep": true
         }
       },
       {
@@ -44,17 +41,14 @@
         "lec_output":true,
         "leccalc": {
             "return_period_file": true,
-            "outputs":
-            {
-              "full_uncertainty_aep": true,
-              "full_uncertainty_oep": true,
-              "wheatsheaf_aep": true,
-              "wheatsheaf_oep": true,
-              "wheatsheaf_mean_aep": true,
-              "wheatsheaf_mean_oep": true,
-              "sample_mean_aep": true,
-              "sample_mean_oep": true
-            }
+            "full_uncertainty_aep": true,
+            "full_uncertainty_oep": true,
+            "wheatsheaf_aep": true,
+            "wheatsheaf_oep": true,
+            "wheatsheaf_mean_aep": true,
+            "wheatsheaf_mean_oep": true,
+            "sample_mean_aep": true,
+            "sample_mean_oep": true
         }        
       }
     ]

--- a/tests/model_execution/kparse_input/il_occ_fu_lec_1_output.json
+++ b/tests/model_execution/kparse_input/il_occ_fu_lec_1_output.json
@@ -20,8 +20,7 @@
         "lec_output": true,
         "leccalc": {
             "return_period_file": true,
-            "outputs": {
-	    "full_uncertainty_aep": false,
+            "full_uncertainty_aep": false,
             "full_uncertainty_oep": false,
             "wheatsheaf_aep": false,
             "wheatsheaf_oep": false,
@@ -29,7 +28,6 @@
             "wheatsheaf_mean_oep": false,
             "sample_mean_aep": false,
             "sample_mean_oep": false
-		}
         }
       }
     ],
@@ -44,7 +42,6 @@
         "lec_output": true,
         "leccalc": {
             "return_period_file": true,
-	    "outputs": {
             "full_uncertainty_aep": false,
             "full_uncertainty_oep": true,
             "wheatsheaf_aep": false,
@@ -53,7 +50,6 @@
             "wheatsheaf_mean_oep": false,
             "sample_mean_aep": false,
             "sample_mean_oep": false
-		}
         }
       }
     ]

--- a/tests/model_execution/kparse_input/il_occ_sample_mean_lec_1_output.json
+++ b/tests/model_execution/kparse_input/il_occ_sample_mean_lec_1_output.json
@@ -20,8 +20,7 @@
         "lec_output": true,
         "leccalc": {
             "return_period_file": true,
-            "outputs": {
-	    "full_uncertainty_aep": false,
+            "full_uncertainty_aep": false,
             "full_uncertainty_oep": false,
             "wheatsheaf_aep": false,
             "wheatsheaf_oep": false,
@@ -29,7 +28,6 @@
             "wheatsheaf_mean_oep": false,
             "sample_mean_aep": false,
             "sample_mean_oep": false
-		}
         }
       }
     ],
@@ -44,7 +42,6 @@
         "lec_output": true,
         "leccalc": {
             "return_period_file": true,
-	    "outputs": {
             "full_uncertainty_aep": false,
             "full_uncertainty_oep": false,
             "wheatsheaf_aep": false,
@@ -53,7 +50,6 @@
             "wheatsheaf_mean_oep": false,
             "sample_mean_aep": false,
             "sample_mean_oep": true
-		}
         }
       }
     ]

--- a/tests/model_execution/kparse_input/il_occ_ws_lec_1_output.json
+++ b/tests/model_execution/kparse_input/il_occ_ws_lec_1_output.json
@@ -20,8 +20,7 @@
         "lec_output": true,
         "leccalc": {
             "return_period_file": true,
-            "outputs": {
-	    "full_uncertainty_aep": false,
+            "full_uncertainty_aep": false,
             "full_uncertainty_oep": false,
             "wheatsheaf_aep": false,
             "wheatsheaf_oep": false,
@@ -29,7 +28,6 @@
             "wheatsheaf_mean_oep": false,
             "sample_mean_aep": false,
             "sample_mean_oep": false
-		}
         }
       }
     ],
@@ -44,7 +42,6 @@
         "lec_output": true,
         "leccalc": {
             "return_period_file": true,
-	    "outputs": {
             "full_uncertainty_aep": false,
             "full_uncertainty_oep": false,
             "wheatsheaf_aep": false,
@@ -53,7 +50,6 @@
             "wheatsheaf_mean_oep": false,
             "sample_mean_aep": false,
             "sample_mean_oep": false
-		}
         }
       }
     ]

--- a/tests/model_execution/kparse_input/il_occ_ws_mean_lec_1_output.json
+++ b/tests/model_execution/kparse_input/il_occ_ws_mean_lec_1_output.json
@@ -20,8 +20,7 @@
         "lec_output": true,
         "leccalc": {
             "return_period_file": true,
-            "outputs": {
-	    "full_uncertainty_aep": false,
+            "full_uncertainty_aep": false,
             "full_uncertainty_oep": false,
             "wheatsheaf_aep": false,
             "wheatsheaf_oep": false,
@@ -29,7 +28,6 @@
             "wheatsheaf_mean_oep": false,
             "sample_mean_aep": false,
             "sample_mean_oep": false
-		}
         }
       }
     ],
@@ -44,7 +42,6 @@
         "lec_output": true,
         "leccalc": {
             "return_period_file": true,
-	    "outputs": {
             "full_uncertainty_aep": false,
             "full_uncertainty_oep": false,
             "wheatsheaf_aep": false,
@@ -53,7 +50,6 @@
             "wheatsheaf_mean_oep": true,
             "sample_mean_aep": false,
             "sample_mean_oep": false
-		}
         }
       }
     ]

--- a/tests/model_execution/kparse_input/il_pltcalc_1_output.json
+++ b/tests/model_execution/kparse_input/il_pltcalc_1_output.json
@@ -20,8 +20,7 @@
         "lec_output": true,
         "leccalc": {
             "return_period_file": true,
-            "outputs": {
-	    "full_uncertainty_aep": false,
+            "full_uncertainty_aep": false,
             "full_uncertainty_oep": false,
             "wheatsheaf_aep": false,
             "wheatsheaf_oep": false,
@@ -29,7 +28,6 @@
             "wheatsheaf_mean_oep": false,
             "sample_mean_aep": false,
             "sample_mean_oep": false
-		}
         }
       }
     ],
@@ -44,7 +42,6 @@
         "lec_output": false,
         "leccalc": {
             "return_period_file": false,
-	    "outputs": {
             "full_uncertainty_aep": false,
             "full_uncertainty_oep": false,
             "wheatsheaf_aep": false,
@@ -53,7 +50,6 @@
             "wheatsheaf_mean_oep": false,
             "sample_mean_aep": false,
             "sample_mean_oep": false
-		}
         }
       }
     ]

--- a/tests/model_execution/kparse_input/il_summarycalc_1_output.json
+++ b/tests/model_execution/kparse_input/il_summarycalc_1_output.json
@@ -20,8 +20,7 @@
         "lec_output": true,
         "leccalc": {
             "return_period_file": true,
-            "outputs": {
-	    "full_uncertainty_aep": false,
+            "full_uncertainty_aep": false,
             "full_uncertainty_oep": false,
             "wheatsheaf_aep": false,
             "wheatsheaf_oep": false,
@@ -29,7 +28,6 @@
             "wheatsheaf_mean_oep": false,
             "sample_mean_aep": false,
             "sample_mean_oep": false
-		}
         }
       }
     ],
@@ -44,7 +42,6 @@
         "lec_output": false,
         "leccalc": {
             "return_period_file": false,
-	    "outputs": {
             "full_uncertainty_aep": false,
             "full_uncertainty_oep": false,
             "wheatsheaf_aep": false,
@@ -53,7 +50,6 @@
             "wheatsheaf_mean_oep": false,
             "sample_mean_aep": false,
             "sample_mean_oep": false
-		}
         }
       }
     ]


### PR DESCRIPTION
* remove "outputs" from leccalc  (but keep backward compatibility)

**Update**
```
        "leccalc": {
            "return_period_file": true,
            "full_uncertainty_aep": true,
            "full_uncertainty_oep": true,
            "wheatsheaf_aep": true,
            "wheatsheaf_oep": true,
            "wheatsheaf_mean_aep": true,
            "wheatsheaf_mean_oep": true,
            "sample_mean_aep": true,
            "sample_mean_oep": true
        }  
```

**Previous**
```
      "leccalc": {
            "return_period_file": true,
            "outputs": {
                "full_uncertainty_aep": true,                                                                                                   
                "full_uncertainty_oep": true,
                "wheatsheaf_aep": true,
                "wheatsheaf_oep": true,
                "wheatsheaf_mean_aep": true,
                "wheatsheaf_mean_oep": true,
                "sample_mean_aep": true,
                "sample_mean_oep": true
            }
        }

```