### PR TITLE
Reduce memory use in GUL inputs generation

### DIFF
--- a/oasislmf/model_preparation/gul_inputs.py
+++ b/oasislmf/model_preparation/gul_inputs.py
@@ -209,7 +209,7 @@ def get_gul_input_items(
         # Select only the columns required. This reduces memory use significantly for portfolios
         # that include many OED columns.
         exposure_df_gul_inputs_cols = [
-            'loc_id', loc_num, acc_num, portfolio_num, cond_num
+            'loc_id', portfolio_num, acc_num, loc_num, cond_num
         ] + term_cols + tiv_cols
         if SOURCE_IDX['loc'] in exposure_df:
             exposure_df_gul_inputs_cols += [SOURCE_IDX['loc']]

--- a/oasislmf/model_preparation/gul_inputs.py
+++ b/oasislmf/model_preparation/gul_inputs.py
@@ -206,7 +206,20 @@ def get_gul_input_items(
         # cond.num. and TIV columns with zeros
         exposure_df[SOURCE_IDX['loc']] = exposure_df.index
 
-        gul_inputs_df = merge_dataframes(exposure_df, keys_df, join_on='loc_id', how='inner')
+        # Select only the columns required. This reduces memory use significantly for portfolios
+        # that include many OED columns.
+        exposure_df_gul_inputs_cols = [
+            'loc_id', loc_num, acc_num, portfolio_num, cond_num
+        ] + term_cols + tiv_cols
+        if SOURCE_IDX['loc'] in exposure_df:
+            exposure_df_gul_inputs_cols += [SOURCE_IDX['loc']]
+
+        gul_inputs_df = merge_dataframes(
+            exposure_df[exposure_df_gul_inputs_cols],
+            keys_df,
+            join_on='loc_id',
+            how='inner'
+        )
         if gul_inputs_df.empty:
             raise OasisException(
                 'Inner merge of the exposure file dataframe ({}) '

--- a/validation/examples/fm3/expected/gul_summary_map.csv
+++ b/validation/examples/fm3/expected/gul_summary_map.csv
@@ -1,4 +1,4 @@
-loc_id,accnumber,portnumber,locnumber,loc_idx,peril_id,coverage_type_id,tiv,coverage_id,item_id,layer_id,agg_id
+loc_id,portnumber,accnumber,locnumber,loc_idx,peril_id,coverage_type_id,tiv,coverage_id,item_id,layer_id,agg_id
 1,1,1,1,0,1,1,1000000.0,1,1,1,1
 1,1,1,1,0,1,2,100000.0,2,2,1,2
 1,1,1,1,0,1,3,50000.0,3,3,1,3

--- a/validation/examples/fm4/expected/gul_summary_map.csv
+++ b/validation/examples/fm4/expected/gul_summary_map.csv
@@ -1,4 +1,4 @@
-loc_id,accnumber,portnumber,locnumber,loc_idx,peril_id,coverage_type_id,tiv,coverage_id,item_id,layer_id,agg_id
+loc_id,portnumber,accnumber,locnumber,loc_idx,peril_id,coverage_type_id,tiv,coverage_id,item_id,layer_id,agg_id
 1,1,1,1,0,1,1,1000000.0,1,1,1,1
 1,1,1,1,0,1,2,100000.0,2,2,1,2
 1,1,1,1,0,1,3,50000.0,3,3,1,3

--- a/validation/examples/fm5/expected/gul_summary_map.csv
+++ b/validation/examples/fm5/expected/gul_summary_map.csv
@@ -1,4 +1,4 @@
-loc_id,accnumber,portnumber,locnumber,loc_idx,peril_id,coverage_type_id,tiv,coverage_id,item_id,layer_id,agg_id
+loc_id,portnumber,accnumber,locnumber,loc_idx,peril_id,coverage_type_id,tiv,coverage_id,item_id,layer_id,agg_id
 1,1,1,1,0,1,1,1000000.0,1,1,1,1
 1,1,1,1,0,1,2,100000.0,2,2,1,2
 1,1,1,1,0,1,3,50000.0,3,3,1,3

--- a/validation/examples/fm6/expected/gul_summary_map.csv
+++ b/validation/examples/fm6/expected/gul_summary_map.csv
@@ -1,4 +1,4 @@
-loc_id,accnumber,portnumber,locnumber,loc_idx,peril_id,coverage_type_id,tiv,coverage_id,item_id,layer_id,agg_id
+loc_id,portnumber,accnumber,locnumber,loc_idx,peril_id,coverage_type_id,tiv,coverage_id,item_id,layer_id,agg_id
 1,1,1,L1,0,1,1,1000000.0,1,1,1,1
 1,1,1,L1,0,1,2,100000.0,2,2,1,2
 1,1,1,L1,0,1,3,50000.0,3,3,1,3

--- a/validation/examples/fm7/expected/gul_summary_map.csv
+++ b/validation/examples/fm7/expected/gul_summary_map.csv
@@ -1,4 +1,4 @@
-loc_id,accnumber,portnumber,locnumber,loc_idx,peril_id,coverage_type_id,tiv,coverage_id,item_id,layer_id,agg_id
+loc_id,portnumber,accnumber,locnumber,loc_idx,peril_id,coverage_type_id,tiv,coverage_id,item_id,layer_id,agg_id
 1,1,1,1,0,1,1,1000000.0,1,1,1,1
 1,1,1,1,0,1,2,100000.0,2,2,1,2
 1,1,1,1,0,1,3,50000.0,3,3,1,3


### PR DESCRIPTION
We have encountered OasisLMF failing due to memory exhaustion at the inputs generation stage when fed a 2.8 million row portfolio. The portfolio contains 3/4 coverages per exposure and 201 columns (which may well be all the columns defined in the OED spec), which was further multiplied by two perils.

The changes are:
* Avoid unconditional deep copying of DataFrames when merging; Pandas is able to handle this itself.
* When merging the exposures with the keys, use only the required columns, rather than every column in the exposure file.

The inputs generation now uses ~40GB of RAM for the original portfolio, rather than gobbling up 64GB RAM+64GB Swap before failing.