### PR TITLE
Fix/451 complex model guard

### DIFF
--- a/bin/ktools_monitor.sh
+++ b/bin/ktools_monitor.sh
@@ -6,7 +6,6 @@ STATUS_LINES=15
 POLL_RATE=2
 script_pid=$1
 
-
 run_ktools_kill(){
      set -e
      FMCALC=`ps -C fmcalc -o pmem | grep -v MEM | sort -n -r | head -1`
@@ -22,30 +21,16 @@ run_ktools_kill(){
      fi 
 }
 
-if hash inotifywait 2>/dev/null; then
-    while inotifywait -e close_write $ERR_FILE; do
-        # check monitored process is running 
-        if [ $(ps xao pid | grep -c $script_pid) -eq 0 ]; then
-            echo "PID ($script_pid) is not running, exiting"
-            exit 0
-        fi    
-        # trigger kill on stderr output
-        if [ -s $ERR_FILE ]; then
-            run_ktools_kill $script_pid
-        fi
-    done
-else
-    while : 
-    do
-        sleep $POLL_RATE
-        # check monitored process is running 
-        if [ $(ps xao pid | grep -c $script_pid) -eq 0 ]; then
-            echo "PID ($script_pid) is not running, exiting"
-            exit 0
-        fi    
-        # trigger kill on stderr output
-        if [ -s $ERR_FILE ]; then
-            run_ktools_kill $script_pid
-        fi
-    done
-fi
+# trigger kill on stderr output
+while : 
+do
+    sleep $POLL_RATE
+    # check monitored process is running 
+    if [ $(ps xao pid | grep -c $script_pid) -eq 0 ]; then
+        echo "PID ($script_pid) is not running, exiting"
+        exit 0
+    fi    
+    if [ -s $ERR_FILE ]; then
+        run_ktools_kill $script_pid
+    fi
+done

--- a/oasislmf/manager.py
+++ b/oasislmf/manager.py
@@ -748,6 +748,12 @@ class OasisManager(object):
                     with io.open(stderror_fp, 'r', encoding='utf-8') as f:
                         self.logger.info('STDERR:\n' + "".join(f.readlines()))
 
+                gul_stderror_fp = os.path.join(model_run_fp, 'log', 'gul_stderror.err')
+                if os.path.isfile(gul_stderror_fp):
+                    with io.open(gul_stderror_fp, 'r', encoding='utf-8') as f:
+                        self.logger.info('GUL_STDERR:\n' + "".join(f.readlines()))
+
+
                 self.logger.info('STDOUT:\n' + e.output.decode('utf-8').strip())
 
                 raise OasisException(

--- a/oasislmf/model_execution/bash.py
+++ b/oasislmf/model_execution/bash.py
@@ -1100,7 +1100,8 @@ def genbash(
             'gul_alloc_rule': gul_alloc_rule,
             'process_id': process_id,
             'max_process_id': max_process_id,
-            'correlated_output': correlated_output_file
+            'correlated_output': correlated_output_file,
+            'stderr_guard': stderr_guard 
         }
 
         # GUL coverage & item stream (Older)

--- a/oasislmf/model_execution/runner.py
+++ b/oasislmf/model_execution/runner.py
@@ -47,6 +47,7 @@ def run(
             process_id,
             max_process_id,
             gul_alloc_rule,
+            stderr_guard,
             **kwargs
         ):
 
@@ -61,6 +62,9 @@ def run(
             if item_output != '':
                 cmd = '{} -i {}'.format(cmd, item_output)
 
+            if stderr_guard:
+                cmd = '{} 2> log/gul-stderror.err'
+            
             return cmd
 
         genbash(

--- a/oasislmf/model_execution/runner.py
+++ b/oasislmf/model_execution/runner.py
@@ -61,10 +61,9 @@ def run(
                 cmd = '{} -c {}'.format(cmd, coverage_output)
             if item_output != '':
                 cmd = '{} -i {}'.format(cmd, item_output)
-
             if stderr_guard:
-                cmd = '{} 2> log/gul-stderror.err'
-            
+                cmd = '{} 2> log/gul_stderror.err'.format(cmd)
+
             return cmd
 
         genbash(


### PR DESCRIPTION
flag `--ktools-disable-guard` works with complex models by redirecting the stderr stream of custom component to `<rundir>/log/gul_stderror.err`

```
(<custom_gul> -m 1 -n 2 -a analysis_settings.json -p . -S10 -c fifo/gul_P1 -i - 2> log/gul_stderror.err | fmcalc -a2 > fifo/il_P1  ) 2>> log/stderror.err &
(<custom_gul> -m 2 -n 2 -a analysis_settings.json -p . -S10 -c fifo/gul_P2 -i - 2> log/gul_stderror.err | fmcalc -a2 > fifo/il_P2  ) 2>> log/stderror.err &

```