### PR TITLE
Move case conversion of group ID columns to manager

### DIFF
--- a/oasislmf/cli/model.py
+++ b/oasislmf/cli/model.py
@@ -229,7 +229,6 @@ class GenerateOasisFilesCmd(OasisBaseCommand):
         ri_info_fp = inputs.get('oed_info_csv', required=False, is_path=True)
         ri_scope_fp = inputs.get('oed_scope_csv', required=False, is_path=True)
         group_id_cols = inputs.get('group_id_cols', required=False, default=['loc_id'])
-        group_id_cols = list(map(lambda col: col.lower(), group_id_cols))
 
         if not (keys_fp or lookup_config_fp or (keys_data_fp and model_version_fp and lookup_package_fp)):
             raise OasisException(

--- a/oasislmf/manager.py
+++ b/oasislmf/manager.py
@@ -515,6 +515,7 @@ class OasisManager(object):
 
         # Columns from loc file to assign group_id
         group_id_cols = group_id_cols or self.group_id_cols
+        group_id_cols = list(map(lambda col: col.lower(), group_id_cols))
 
         # Get the GUL input items and exposure dataframes
         gul_inputs_df, exposure_df = get_gul_input_items(


### PR DESCRIPTION
Lower case conversion of user selected columns from loc file to set group ID performed in `oasislmf.manager` rather than CLI. This should allow user call `oasislmf.manager` directly without having to go through the CLI in order to perform case conversion.

This refers to https://github.com/OasisLMF/OasisLMF/issues/453.