### PR TITLE
Add option to set gulcalc command - raises an error if not in path

### DIFF
--- a/oasislmf/cli/model.py
+++ b/oasislmf/cli/model.py
@@ -316,6 +316,7 @@ class GenerateLossesCmd(OasisBaseCommand):
         parser.add_argument('-d', '--model-data-dir', default=None, help='Model data directory path')
         parser.add_argument('-r', '--model-run-dir', default=None, help='Model run directory path')
         parser.add_argument('-p', '--model-package-dir', default=None, help='Path containing model specific package')
+        parser.add_argument('-B', '--model-custom-gulcalc', default=None, help='Callable custom gulcalc component to use as a drop-in replacement', type=str)
         parser.add_argument('-n', '--ktools-num-processes', default=None, help='Number of ktools calculation processes to use', type=int)
         parser.add_argument('-f', '--ktools-fifo-relative', default=None, help='Create ktools fifo queues under the ./fifo dir', action='store_true')
         parser.add_argument('-E', '--ktools-disable-guard', default=None, help='Disables error handling in the ktools run script (abort on non-zero exitcode or output on stderr)', action='store_true')
@@ -343,6 +344,7 @@ class GenerateLossesCmd(OasisBaseCommand):
         analysis_settings_fp = inputs.get('analysis_settings_json', required=True, is_path=True)
         model_data_fp = inputs.get('model_data_dir', required=True, is_path=True)
         model_package_fp = as_path(inputs.get('model_package_dir', required=False, is_path=True), 'Model package path', is_dir=True)
+        model_custom_gulcalc  = inputs.get('model_custom_gulcalc', required=False, is_path=False)
         user_data_dir = inputs.get('user_data_dir', required=False, is_path=True)
 
         ktools_num_processes = inputs.get('ktools_num_processes', default=None, required=False)
@@ -364,6 +366,7 @@ class GenerateLossesCmd(OasisBaseCommand):
             analysis_settings_fp,
             model_data_fp,
             model_package_fp=model_package_fp,
+            model_custom_gulcalc=model_custom_gulcalc,
             ktools_num_processes=ktools_num_processes,
             ktools_fifo_relative=ktools_fifo_relative,
             ktools_error_guard=ktools_error_guard,
@@ -371,7 +374,7 @@ class GenerateLossesCmd(OasisBaseCommand):
             ktools_alloc_rule_il=ktools_alloc_rule_il,
             ktools_alloc_rule_ri=ktools_alloc_rule_ri,
             ktools_debug=verbose_output,
-            user_data_dir=user_data_dir
+            user_data_dir=user_data_dir,
         )
 
         self.logger.info('\nLosses generated in {}'.format(model_run_fp))
@@ -418,6 +421,7 @@ class RunCmd(OasisBaseCommand):
         parser.add_argument('-d', '--model-data-dir', default=None, help='Model data directory path')
         parser.add_argument('-r', '--model-run-dir', default=None, help='Model run directory path')
         parser.add_argument('-p', '--model-package-dir', default=None, help='Path containing model specific package')
+        parser.add_argument('-B', '--model-custom-gulcalc', default=None, help='Callable custom gulcalc component to use as a drop-in replacement', type=str)
 
         parser.add_argument('-n', '--ktools-num-processes', default=None, help='Number of ktools calculation processes to use', type=int)
         parser.add_argument('-f', '--ktools-fifo-relative', default=None, help='Create ktools fifo queues under the ./fifo dir', action='store_true')

--- a/oasislmf/manager.py
+++ b/oasislmf/manager.py
@@ -623,6 +623,7 @@ class OasisManager(object):
         analysis_settings_fp,
         model_data_fp,
         model_package_fp=None,
+        model_custom_gulcalc=None,
         ktools_num_processes=None,
         ktools_fifo_relative=None,
         ktools_alloc_rule_gul=None,
@@ -748,7 +749,8 @@ class OasisManager(object):
                     set_alloc_rule_il=(ktools_alloc_rule_il if isinstance(ktools_alloc_rule_il, int) else self.ktools_alloc_rule_il),
                     run_debug=(ktools_debug if isinstance(ktools_debug, bool) else self.ktools_debug),
                     stderr_guard=(ktools_error_guard if isinstance(ktools_error_guard, bool) else self.ktools_error_guard),
-                    fifo_tmp_dir=(not (ktools_fifo_relative or self.ktools_fifo_relative))
+                    fifo_tmp_dir=(not (ktools_fifo_relative or self.ktools_fifo_relative)),
+                    custom_gulcalc_cmd=model_custom_gulcalc,
                 )
             except CalledProcessError as e:
                 bash_trace_fp = os.path.join(model_run_fp, 'log', 'bash.log')

--- a/oasislmf/model_execution/runner.py
+++ b/oasislmf/model_execution/runner.py
@@ -26,18 +26,29 @@ def run(
     fifo_tmp_dir=True,
     stderr_guard=True,
     run_debug=False,
+    custom_gulcalc_cmd=None,
     filename='run_ktools.sh'
 ):
     if number_of_processes == -1:
         number_of_processes = multiprocessing.cpu_count()
 
-    custom_gulcalc_cmd = "{}_{}_gulcalc".format(
-        analysis_settings.get('module_supplier_id'),
-        analysis_settings.get('model_version_id'))
+    # If `given_gulcalc_cmd` is set then always run as a complex model  
+    # and raise an exception when not found in PATH 
+    if custom_gulcalc_cmd:
+        if not shutil.which(custom_gulcalc_cmd):
+            raise OasisException(
+                'Run error: Custom Gulcalc command "{}" explicitly set but not found in path.'.format(custom_gulcalc_cmd)
+            )
+    # when not set then fallback to previous behaviour: 
+    # Check if a custom binary `<supplier>_<model>_gulcalc` exists in PATH
+    else:
+        inferred_gulcalc_cmd = "{}_{}_gulcalc".format(
+            analysis_settings.get('module_supplier_id'),
+            analysis_settings.get('model_version_id'))
+        if shutil.which(inferred_gulcalc_cmd):
+            custom_gulcalc_cmd = inferred_gulcalc_cmd
 
-    # Check for custom gulcalc
-    if shutil.which(custom_gulcalc_cmd):
-
+    if custom_gulcalc_cmd:
         def custom_get_getmodel_cmd(
             number_of_samples,
             gul_threshold,


### PR DESCRIPTION
Closes https://github.com/OasisLMF/OasisPlatform/issues/274 
### Example: oasislmf.json
```
{
   ...
    "model_custom_gulcalc":  "my_gul_piwind.py",
   ...
}
```

### Run output
```
  ...
COMPLETED: oasislmf.model_execution.bin.csv_to_bin in 0.03s
STARTED: oasislmf.model_execution.bin.prepare_run_inputs
COMPLETED: oasislmf.model_execution.bin.prepare_run_inputs in 0.0s
STARTED: oasislmf.model_execution.runner.run

Run error: Custom Gulcalc command "my_gul_piwind.py" explicitly set but not found in path.
```