### PR TITLE
Replace use of `eval` by `ast.literal_eval` in IL inputs generation

### DIFF
--- a/oasislmf/model_preparation/il_inputs.py
+++ b/oasislmf/model_preparation/il_inputs.py
@@ -21,6 +21,8 @@ import warnings
 import pandas as pd
 import numpy as np
 
+from ast import literal_eval
+
 from ..utils.calc_rules import (
     get_calc_rules,
     get_step_calc_rules
@@ -76,7 +78,10 @@ def get_calc_rule_ids(il_inputs_df):
     :rtype: numpy.ndarray
     """
     calc_rules = get_calc_rules().drop(['desc'], axis=1)
-    calc_rules['id_key'] = calc_rules['id_key'].apply(eval)
+    try:
+        calc_rules['id_key'] = calc_rules['id_key'].apply(literal_eval)
+    except ValueError as e:
+        raise OasisException(e)
 
     terms = ['deductible', 'deductible_min', 'deductible_max', 'limit', 'share', 'attachment']
     terms_indicators = ['{}_gt_0'.format(t) for t in terms]
@@ -119,7 +124,10 @@ def get_step_calc_rule_ids(il_inputs_df, step_trigger_type_cols):
     :rtype: numpy.ndarray
     """
     calc_rules_step = get_step_calc_rules().drop(['desc'], axis=1)
-    calc_rules_step['id_key'] = calc_rules_step['id_key'].apply(eval)
+    try:
+        calc_rules_step['id_key'] = calc_rules_step['id_key'].apply(literal_eval)
+    except ValueError as e:
+        raise OasisException(e)
 
     terms = ['deductible1', 'payout_start', 'payout_end', 'limit1', 'limit2']
     terms_indicators = ['{}_gt_0'.format(t) for t in terms]


### PR DESCRIPTION
* Replace use of `eval` by the much safer `ast.literal_eval` in IL inputs generation - 

Note 1: `eval` is a built-in method that can evaluate invalid and/or potentially unsafe expressions, and `ast.literal_eval` is recommended.

https://docs.python.org/3/library/functions.html#eval
https://docs.python.org/3/library/ast.html#ast.literal_eval

Note 2: `eval` is currently used in the `develop` version of `oasislmf/model_preparation/il_inputs.py` to evaluate the calc. rule mapping ID key values in the calc. rules CSV (https://github.com/OasisLMF/OasisLMF/blob/develop/oasislmf/_data/calc_rules.csv). Although it is unlikely that this column will be amended to contain unsafe expressions, it is possible, so it seems better to remove the possibility.