### PR TITLE
generated loc_id is dropped

### DIFF
--- a/oasislmf/model_preparation/summaries.py
+++ b/oasislmf/model_preparation/summaries.py
@@ -733,11 +733,20 @@ def write_exposure_summary(
         gul_inputs_errors_df, _ = get_gul_input_items(
             exposure_fp, keys_errors_fp, exposure_profile=exposure_profile
         )
-        gul_inputs_errors_df = reduce_df(
-            gul_inputs_errors_df,
-            cols=['peril_id', 'coverage_type_id', 'loc_id', 'tiv', 'status']
+        
+        # Store the gul_input_errors for debugging then reduce
+        store_cols = ['loc_id', 'portnumber', 'accnumber', 'locnumber', 'condnumber']
+        reduce_cols = ['peril_id', 'coverage_type_id', 'loc_id', 'tiv', 'status']
+
+        gul_inputs_errors_df[store_cols + reduce_cols].to_csv(
+            os.path.join(target_dir, 'gul_errors_map.csv'),
+            index=False
         )
 
+        gul_inputs_errors_df = reduce_df(
+            gul_inputs_errors_df,
+            cols=reduce_cols
+        )
     except OasisException:   # Empty dataframe (due to empty keys errors file)
         gul_inputs_errors_df = pd.DataFrame(
             columns=gul_inputs_df.columns.append(pd.Index(['status']))


### PR DESCRIPTION
Fix #520 
* When generating lookup summary store the `gul_inputs_error_df` to inputs directory 

**inputs/gul_errors_map.csv**
```
loc_id  portnumber  accnumber  locnumber    condnumber  peril_id  coverage_type_id  tiv       status                                                 
4       1           A11111     10002082049  0           WTC       1                 30000.0   fail
4       1           A11111     10002082049  0           WSS       1                 30000.0   fail
5       1           A11111     10002082050  0           WTC       1                 250000.0  fail
5       1           A11111     10002082050  0           WSS       1                 250000.0  fail
6       1           A11111     10002082051  0           WTC       1                 700000.0  fail
6       1           A11111     10002082051  0           WSS       1                 700000.0  fail

```