### PR TITLE
Group OED fields from model settings

### DIFF
--- a/oasislmf/cli/model.py
+++ b/oasislmf/cli/model.py
@@ -179,13 +179,13 @@ class GenerateOasisFilesCmd(OasisBaseCommand):
         super(self.__class__, self).add_args(parser)
 
         parser.add_argument('-o', '--oasis-files-dir', default=None, help='Path to the directory in which to generate the Oasis files')
+        parser.add_argument('-a', '--analysis-settings-json', default=None, help='Analysis settings JSON file path')
         parser.add_argument('-z', '--keys-data-csv', default=None, help='Pre-generated keys CSV file path')
         parser.add_argument('-m', '--lookup-config-json', default=None, help='Lookup config JSON file path')
         parser.add_argument('-k', '--lookup-data-dir', default=None, help='Model lookup/keys data directory path')
         parser.add_argument('-l', '--lookup-package-dir', default=None, help='Lookup package path')
         parser.add_argument('-L', '--lookup-complex-config-json', default=None, help='Complex lookup config JSON file path')
         parser.add_argument('-v', '--model-version-csv', default=None, help='Model version CSV file path')
-        parser.add_argument('-d', '--model-data-dir', default=None, help='Model data directory path')
         parser.add_argument('-D', '--user-data-dir', default=None, help='Directory containing additional model data files which varies between analysis runs')
         parser.add_argument('-e', '--profile-loc-json', default=None, help='Source (OED) exposure profile JSON path')
         parser.add_argument('-b', '--profile-acc-json', default=None, help='Source (OED) accounts profile JSON path')
@@ -213,11 +213,11 @@ class GenerateOasisFilesCmd(OasisBaseCommand):
         default_oasis_fp = os.path.join(os.getcwd(), 'runs', 'OasisFiles-{}'.format(utcnow))
 
         oasis_fp = inputs.get('oasis_files_dir', is_path=True, default=default_oasis_fp)
+        analysis_settings_fp = inputs.get('analysis_settings_json', required=False, is_path=True)
         keys_fp = inputs.get('keys_data_csv', required=False, is_path=True)
         lookup_config_fp = inputs.get('lookup_config_json', required=False, is_path=True)
         keys_data_fp = inputs.get('lookup_data_dir', required=False, is_path=True)
         model_version_fp = inputs.get('model_version_csv', required=False, is_path=True)
-        model_data_fp = inputs.get('model_data_dir', required=False, is_path=True)
         lookup_package_fp = inputs.get('lookup_package_dir', required=False, is_path=True)
         complex_lookup_config_fp = inputs.get('lookup_complex_config_json', required=False, is_path=True)
         user_data_dir = inputs.get('user_data_dir', required=False, is_path=True)
@@ -254,8 +254,8 @@ class GenerateOasisFilesCmd(OasisBaseCommand):
             keys_fp=keys_fp,
             lookup_config_fp=lookup_config_fp,
             keys_data_fp=keys_data_fp,
+            analysis_settings_fp=analysis_settings_fp,
             model_version_fp=model_version_fp,
-            model_data_fp=model_data_fp,
             lookup_package_fp=lookup_package_fp,
             complex_lookup_config_fp=complex_lookup_config_fp,
             accounts_fp=accounts_fp,

--- a/oasislmf/cli/model.py
+++ b/oasislmf/cli/model.py
@@ -179,7 +179,6 @@ class GenerateOasisFilesCmd(OasisBaseCommand):
         super(self.__class__, self).add_args(parser)
 
         parser.add_argument('-o', '--oasis-files-dir', default=None, help='Path to the directory in which to generate the Oasis files')
-        parser.add_argument('-a', '--analysis-settings-json', default=None, help='Analysis settings JSON file path')
         parser.add_argument('-z', '--keys-data-csv', default=None, help='Pre-generated keys CSV file path')
         parser.add_argument('-m', '--lookup-config-json', default=None, help='Lookup config JSON file path')
         parser.add_argument('-k', '--lookup-data-dir', default=None, help='Model lookup/keys data directory path')

--- a/oasislmf/cli/model.py
+++ b/oasislmf/cli/model.py
@@ -186,6 +186,7 @@ class GenerateOasisFilesCmd(OasisBaseCommand):
         parser.add_argument('-l', '--lookup-package-dir', default=None, help='Lookup package path')
         parser.add_argument('-L', '--lookup-complex-config-json', default=None, help='Complex lookup config JSON file path')
         parser.add_argument('-v', '--model-version-csv', default=None, help='Model version CSV file path')
+        parser.add_argument('-M', '--model-settings-json', default=None, help='Model settings JSON file path')
         parser.add_argument('-D', '--user-data-dir', default=None, help='Directory containing additional model data files which varies between analysis runs')
         parser.add_argument('-e', '--profile-loc-json', default=None, help='Source (OED) exposure profile JSON path')
         parser.add_argument('-b', '--profile-acc-json', default=None, help='Source (OED) accounts profile JSON path')
@@ -213,11 +214,11 @@ class GenerateOasisFilesCmd(OasisBaseCommand):
         default_oasis_fp = os.path.join(os.getcwd(), 'runs', 'OasisFiles-{}'.format(utcnow))
 
         oasis_fp = inputs.get('oasis_files_dir', is_path=True, default=default_oasis_fp)
-        analysis_settings_fp = inputs.get('analysis_settings_json', required=False, is_path=True)
         keys_fp = inputs.get('keys_data_csv', required=False, is_path=True)
         lookup_config_fp = inputs.get('lookup_config_json', required=False, is_path=True)
         keys_data_fp = inputs.get('lookup_data_dir', required=False, is_path=True)
         model_version_fp = inputs.get('model_version_csv', required=False, is_path=True)
+        model_settings_fp = inputs.get('model_settings_json', required=False, is_path=True)
         lookup_package_fp = inputs.get('lookup_package_dir', required=False, is_path=True)
         complex_lookup_config_fp = inputs.get('lookup_complex_config_json', required=False, is_path=True)
         user_data_dir = inputs.get('user_data_dir', required=False, is_path=True)
@@ -254,8 +255,8 @@ class GenerateOasisFilesCmd(OasisBaseCommand):
             keys_fp=keys_fp,
             lookup_config_fp=lookup_config_fp,
             keys_data_fp=keys_data_fp,
-            analysis_settings_fp=analysis_settings_fp,
             model_version_fp=model_version_fp,
+            model_settings_fp=model_settings_fp,
             lookup_package_fp=lookup_package_fp,
             complex_lookup_config_fp=complex_lookup_config_fp,
             accounts_fp=accounts_fp,
@@ -421,6 +422,7 @@ class RunCmd(OasisBaseCommand):
         parser.add_argument('-D', '--user-data-dir', default=None, help='Directory containing additional model data files which varies between analysis runs')
 
         parser.add_argument('-v', '--model-version-csv', default=None, help='Model version CSV file path')
+        parser.add_argument('-M', '--model-settings-json', default=None, help='Model settings JSON file path')
         parser.add_argument('-d', '--model-data-dir', default=None, help='Model data directory path')
         parser.add_argument('-r', '--model-run-dir', default=None, help='Model run directory path')
         parser.add_argument('-p', '--model-package-dir', default=None, help='Path containing model specific package')

--- a/oasislmf/cli/model.py
+++ b/oasislmf/cli/model.py
@@ -185,6 +185,7 @@ class GenerateOasisFilesCmd(OasisBaseCommand):
         parser.add_argument('-l', '--lookup-package-dir', default=None, help='Lookup package path')
         parser.add_argument('-L', '--lookup-complex-config-json', default=None, help='Complex lookup config JSON file path')
         parser.add_argument('-v', '--model-version-csv', default=None, help='Model version CSV file path')
+        parser.add_argument('-d', '--model-data-dir', default=None, help='Model data directory path')
         parser.add_argument('-D', '--user-data-dir', default=None, help='Directory containing additional model data files which varies between analysis runs')
         parser.add_argument('-e', '--profile-loc-json', default=None, help='Source (OED) exposure profile JSON path')
         parser.add_argument('-b', '--profile-acc-json', default=None, help='Source (OED) accounts profile JSON path')
@@ -216,6 +217,7 @@ class GenerateOasisFilesCmd(OasisBaseCommand):
         lookup_config_fp = inputs.get('lookup_config_json', required=False, is_path=True)
         keys_data_fp = inputs.get('lookup_data_dir', required=False, is_path=True)
         model_version_fp = inputs.get('model_version_csv', required=False, is_path=True)
+        model_data_fp = inputs.get('model_data_dir', required=False, is_path=True)
         lookup_package_fp = inputs.get('lookup_package_dir', required=False, is_path=True)
         complex_lookup_config_fp = inputs.get('lookup_complex_config_json', required=False, is_path=True)
         user_data_dir = inputs.get('user_data_dir', required=False, is_path=True)
@@ -228,7 +230,7 @@ class GenerateOasisFilesCmd(OasisBaseCommand):
         aggregation_profile_fp = inputs.get('profile_fm_agg_json', default=get_default_fm_aggregation_profile(path=True))
         ri_info_fp = inputs.get('oed_info_csv', required=False, is_path=True)
         ri_scope_fp = inputs.get('oed_scope_csv', required=False, is_path=True)
-        group_id_cols = inputs.get('group_id_cols', required=False, default=['loc_id'])
+        group_id_cols = inputs.get('group_id_cols', required=False, default=None)
 
         if not (keys_fp or lookup_config_fp or (keys_data_fp and model_version_fp and lookup_package_fp)):
             raise OasisException(
@@ -253,6 +255,7 @@ class GenerateOasisFilesCmd(OasisBaseCommand):
             lookup_config_fp=lookup_config_fp,
             keys_data_fp=keys_data_fp,
             model_version_fp=model_version_fp,
+            model_data_fp=model_data_fp,
             lookup_package_fp=lookup_package_fp,
             complex_lookup_config_fp=complex_lookup_config_fp,
             accounts_fp=accounts_fp,

--- a/oasislmf/manager.py
+++ b/oasislmf/manager.py
@@ -518,7 +518,9 @@ class OasisManager(object):
 
         # Columns from loc file to assign group_id
         if model_settings_fp:
-            model_group_fields = get_model_settings(model_settings_fp).get('group_fields').get('default')
+            model_group_fields = get_model_settings(
+                model_settings_fp, key='data_settings'
+            ).get('group_fields')
         else:
             model_group_fields = None
         group_id_cols = group_id_cols or model_group_fields or self.group_id_cols

--- a/oasislmf/manager.py
+++ b/oasislmf/manager.py
@@ -382,6 +382,7 @@ class OasisManager(object):
         lookup_config_fp=None,
         keys_data_fp=None,
         model_version_fp=None,
+        model_data_fp=None,
         lookup_package_fp=None,
         complex_lookup_config_fp=None,
         user_data_dir=None,
@@ -407,6 +408,7 @@ class OasisManager(object):
         lookup_config_fp = as_path(lookup_config_fp, 'Lookup config JSON file path', preexists=False)
         keys_data_fp = as_path(keys_data_fp, 'Keys data path', preexists=False)
         model_version_fp = as_path(model_version_fp, 'Model version file path', is_dir=True, preexists=False)
+        model_data_fp = as_path(model_data_fp, 'Model data path', is_dir=True, preexists=True)
         lookup_package_fp = as_path(lookup_package_fp, 'Lookup package path', is_dir=True, preexists=False)
         complex_lookup_config_fp = as_path(complex_lookup_config_fp, 'Complex lookup config JSON file path', preexists=False)
         user_data_dir = as_path(user_data_dir, 'Directory containing additional supplied model data files', preexists=False)
@@ -514,7 +516,18 @@ class OasisManager(object):
             _keys_fp = os.path.join(target_dir, os.path.basename(keys_fp))
 
         # Columns from loc file to assign group_id
-        group_id_cols = group_id_cols or self.group_id_cols
+        model_group_id_cols = None
+        if model_data_fp:
+            model_settings_fp = os.path.join(
+                model_data_fp, 'model_settings.json'
+            )
+            if os.path.isfile(model_settings_fp):
+                model_settings = get_json(model_settings_fp)
+                try:
+                    model_group_id_cols = model_settings['model_settings']['group_fields']
+                except KeyError:
+                    pass
+        group_id_cols = group_id_cols or model_group_id_cols or self.group_id_cols
         group_id_cols = list(map(lambda col: col.lower(), group_id_cols))
 
         # Get the GUL input items and exposure dataframes

--- a/oasislmf/manager.py
+++ b/oasislmf/manager.py
@@ -51,7 +51,7 @@ from .model_preparation.oed import load_oed_dfs
 from .model_preparation.utils import prepare_input_files_directory
 from .model_preparation.reinsurance_layer import write_files_for_reinsurance
 from .utils.data import (
-    get_analysis_settings,
+    get_model_settings,
     get_dataframe,
     get_ids,
     get_json,
@@ -382,8 +382,8 @@ class OasisManager(object):
         lookup_config=None,
         lookup_config_fp=None,
         keys_data_fp=None,
-        analysis_settings_fp=None,
         model_version_fp=None,
+        model_settings_fp=None,
         lookup_package_fp=None,
         complex_lookup_config_fp=None,
         user_data_dir=None,
@@ -408,8 +408,8 @@ class OasisManager(object):
         keys_fp = as_path(keys_fp, 'Pre-generated keys file path', preexists=True)
         lookup_config_fp = as_path(lookup_config_fp, 'Lookup config JSON file path', preexists=False)
         keys_data_fp = as_path(keys_data_fp, 'Keys data path', preexists=False)
-        analysis_settings_fp = as_path(analysis_settings_fp, 'Model analysis settings file path')
         model_version_fp = as_path(model_version_fp, 'Model version file path', is_dir=True, preexists=False)
+        model_settings_fp = as_path(model_settings_fp, 'Model settings file path')
         lookup_package_fp = as_path(lookup_package_fp, 'Lookup package path', is_dir=True, preexists=False)
         complex_lookup_config_fp = as_path(complex_lookup_config_fp, 'Complex lookup config JSON file path', preexists=False)
         user_data_dir = as_path(user_data_dir, 'Directory containing additional supplied model data files', preexists=False)
@@ -517,8 +517,8 @@ class OasisManager(object):
             _keys_fp = os.path.join(target_dir, os.path.basename(keys_fp))
 
         # Columns from loc file to assign group_id
-        if analysis_settings_fp:
-            model_group_fields = get_analysis_settings(analysis_settings_fp).get('model_settings').get('group_fields')
+        if model_settings_fp:
+            model_group_fields = get_model_settings(model_settings_fp).get('group_fields').get('default')
         else:
             model_group_fields = None
         group_id_cols = group_id_cols or model_group_fields or self.group_id_cols

--- a/oasislmf/utils/data.py
+++ b/oasislmf/utils/data.py
@@ -4,7 +4,7 @@ __all__ = [
     'factorize_ndarray',
     'fast_zip_arrays',
     'fast_zip_dataframe_columns',
-    'get_analysis_settings',
+    'get_model_settings',
     'get_dataframe',
     'get_dtypes_and_required_cols',
     'get_ids',
@@ -205,33 +205,24 @@ def fast_zip_dataframe_columns(df, cols):
     return fast_zip_arrays(*(df[col].values for col in cols))
 
 
-def get_analysis_settings(analysis_settings_fp, model_run_fp=None):
+def get_model_settings(model_settings_fp):
     """
-    Get analysis settings from file.
+    Get model settings from file.
 
-    :param analysis_settings_fp: file path for analysis settings file
-    :type analysis_settings_fp: str
+    :param model_settings_fp: file path for model settings file
+    :type model_settings_fp: str
 
-    :param model_run_fp: path for model run directory
-    :type model_run_fp: str
-
-    :return: analysis settings
+    :return: model settings
     :rtype: dict
     """
     try:
-        if model_run_fp:
-            analysis_settings_fn = 'analysis_settings.json'
-            _analysis_settings_fp = os.path.join(model_run_fp, analysis_settings_fn)
-        else:
-            _analysis_settings_fp = analysis_settings_fp
-        with io.open(_analysis_settings_fp, 'r', encoding='utf-8') as f:
-            analysis_settings = json.load(f)
-        if analysis_settings.get('analysis_settings'):
-            analysis_settings = analysis_settings['analysis_settings']
-    except (IOError, TypeError, ValueError):
-        raise OasisException('Invalid analysis settings file or file path: {}'.format(_analysis_settings_fp))
+        with io.open(model_settings_fp) as f:
+            model_settings = json.load(f)
+        model_settings = model_settings['model_settings']
+    except (IOError, TypeError, ValueError, KeyError):
+        raise OasisException('Invalid model settings file or file path: {}'.format(model_settings_fp))
 
-    return analysis_settings
+    return model_settings
 
 
 def get_dataframe(

--- a/oasislmf/utils/data.py
+++ b/oasislmf/utils/data.py
@@ -4,6 +4,7 @@ __all__ = [
     'factorize_ndarray',
     'fast_zip_arrays',
     'fast_zip_dataframe_columns',
+    'get_analysis_settings',
     'get_dataframe',
     'get_dtypes_and_required_cols',
     'get_ids',
@@ -202,6 +203,35 @@ def fast_zip_dataframe_columns(df, cols):
     :rtype: np.array
     """
     return fast_zip_arrays(*(df[col].values for col in cols))
+
+
+def get_analysis_settings(analysis_settings_fp, model_run_fp=None):
+    """
+    Get analysis settings from file.
+
+    :param analysis_settings_fp: file path for analysis settings file
+    :type analysis_settings_fp: str
+
+    :param model_run_fp: path for model run directory
+    :type model_run_fp: str
+
+    :return: analysis settings
+    :rtype: dict
+    """
+    try:
+        if model_run_fp:
+            analysis_settings_fn = 'analysis_settings.json'
+            _analysis_settings_fp = os.path.join(model_run_fp, analysis_settings_fn)
+        else:
+            _analysis_settings_fp = analysis_settings_fp
+        with io.open(_analysis_settings_fp, 'r', encoding='utf-8') as f:
+            analysis_settings = json.load(f)
+        if analysis_settings.get('analysis_settings'):
+            analysis_settings = analysis_settings['analysis_settings']
+    except (IOError, TypeError, ValueError):
+        raise OasisException('Invalid analysis settings file or file path: {}'.format(_analysis_settings_fp))
+
+    return analysis_settings
 
 
 def get_dataframe(

--- a/oasislmf/utils/data.py
+++ b/oasislmf/utils/data.py
@@ -205,7 +205,7 @@ def fast_zip_dataframe_columns(df, cols):
     return fast_zip_arrays(*(df[col].values for col in cols))
 
 
-def get_model_settings(model_settings_fp):
+def get_model_settings(model_settings_fp, key=None):
     """
     Get model settings from file.
 
@@ -218,8 +218,9 @@ def get_model_settings(model_settings_fp):
     try:
         with io.open(model_settings_fp) as f:
             model_settings = json.load(f)
-        model_settings = model_settings['model_settings']
-    except (IOError, TypeError, ValueError, KeyError):
+        if key:
+            model_settings = model_settings.get(key)
+    except (IOError, TypeError, ValueError):
         raise OasisException('Invalid model settings file or file path: {}'.format(model_settings_fp))
 
     return model_settings

--- a/schemas/model_settings.json
+++ b/schemas/model_settings.json
@@ -145,13 +145,29 @@
 		   "description": "List of OED fields from location file to form groups",
 		   "type": "object",
 		   "properties": {
+                       "name": {
+                           "type": "string",
+                           "title": "UI Option",
+                           "description": "UI name for selection",
+                           "minLength": 1
+                       },
+                       "desc": {
+                           "type": "string",
+                           "title": "Short description",
+                           "description": "UI description for selection"
+                       },
+                       "tooltip": {
+                           "type": "string",
+                           "title": "UI tooltip",
+                           "description": "Long description (optional)"
+                       },
 		       "default": {
 			   "type": "array",
 			   "title": "Default group OED fields",
 			   "descripton": "Initial setting for group OED fields"
 		       }
 		   },
-		   "required": ["default"]
+		   "required": ["name", "desc", "default"]
 	       },
                "string_parameters": {
                    "title": "Single string paramters",

--- a/schemas/model_settings.json
+++ b/schemas/model_settings.json
@@ -140,38 +140,6 @@
                    },
                    "required": ["name", "desc", "default", "options"]
                },
-	       "group_fields": {
-		   "title": "Group OED fields",
-		   "description": "List of OED fields from location file to form groups",
-		   "type": "object",
-		   "properties": {
-                       "name": {
-                           "type": "string",
-                           "title": "UI Option",
-                           "description": "UI name for selection",
-                           "minLength": 1
-                       },
-                       "desc": {
-                           "type": "string",
-                           "title": "Short description",
-                           "description": "UI description for selection"
-                       },
-                       "tooltip": {
-                           "type": "string",
-                           "title": "UI tooltip",
-                           "description": "Long description (optional)"
-                       },
-		       "default": {
-			   "type": "array",
-			   "title": "Default group OED fields",
-			   "descripton": "Initial setting for group OED fields",
-			   "items": {
-			       "type": "string"
-			   }
-		       }
-		   },
-		   "required": ["name", "desc", "default"]
-	       },
                "string_parameters": {
                    "title": "Single string paramters",
                    "type":  "array",
@@ -564,6 +532,14 @@
             "title": "Model data settings",
             "description": "Additional data options for a model",
             "properties": {
+	       "group_fields": {
+		   "title": "Group OED fields",
+		   "description": "List of OED fields from location file to form groups",
+		   "type": "array",
+		   "items": {
+		       "type": "string"
+		   }
+	       },
                 "datafile_selectors": {
                     "type": "array",
                     "title": "`Data_files  Selector",

--- a/schemas/model_settings.json
+++ b/schemas/model_settings.json
@@ -164,7 +164,10 @@
 		       "default": {
 			   "type": "array",
 			   "title": "Default group OED fields",
-			   "descripton": "Initial setting for group OED fields"
+			   "descripton": "Initial setting for group OED fields",
+			   "items": {
+			       "type": "string"
+			   }
 		       }
 		   },
 		   "required": ["name", "desc", "default"]

--- a/schemas/model_settings.json
+++ b/schemas/model_settings.json
@@ -146,7 +146,7 @@
 		   "type": "object",
 		   "properties": {
 		       "default": {
-			   "type": "list",
+			   "type": "array",
 			   "title": "Default group OED fields",
 			   "descripton": "Initial setting for group OED fields"
 		       }

--- a/schemas/model_settings.json
+++ b/schemas/model_settings.json
@@ -140,6 +140,19 @@
                    },
                    "required": ["name", "desc", "default", "options"]
                },
+	       "group_fields": {
+		   "title": "Group OED fields",
+		   "description": "List of OED fields from location file to form groups",
+		   "type": "object",
+		   "properties": {
+		       "default": {
+			   "type": "list",
+			   "title": "Default group OED fields",
+			   "descripton": "Initial setting for group OED fields"
+		       }
+		   },
+		   "required": ["default"]
+	       },
                "string_parameters": {
                    "title": "Single string paramters",
                    "type":  "array",


### PR DESCRIPTION
~~Groups can be assigned with OED fields specified in `analysis_settings.json`. The `analysis_settings.json` file is generated when using the UI from `model_settings.json`. The schema for `model_settings.json` has been updated to incorporate this.~~

Command line arguments for group fields take priority, followed by those defined by the model. If neither exist, `loc_id` is used as the fall-through option.

See comment below for changes.