### PR TITLE
ordered arrays for group_id assignemnt

### DIFF
--- a/oasislmf/model_preparation/gul_inputs.py
+++ b/oasislmf/model_preparation/gul_inputs.py
@@ -309,7 +309,7 @@ def get_gul_input_items(
         if len(group_id_cols) > 1:
             gul_inputs_df['group_id'] = factorize_ndarray(
                 gul_inputs_df.loc[:, group_id_cols].values,
-                col_idxs=range(len(group_id_cols))
+                col_idxs=range(len(group_id_cols),sort_opt=True)
             )[0]
         else:
             gul_inputs_df['group_id'] = factorize_array(

--- a/oasislmf/model_preparation/gul_inputs.py
+++ b/oasislmf/model_preparation/gul_inputs.py
@@ -309,7 +309,7 @@ def get_gul_input_items(
         if len(group_id_cols) > 1:
             gul_inputs_df['group_id'] = factorize_ndarray(
                 gul_inputs_df.loc[:, group_id_cols].values,
-                col_idxs=range(len(group_id_cols),sort_opt=True)
+                col_idxs=range(len(group_id_cols)),sort_opt=True
             )[0]
         else:
             gul_inputs_df['group_id'] = factorize_array(

--- a/oasislmf/utils/data.py
+++ b/oasislmf/utils/data.py
@@ -84,7 +84,7 @@ PANDAS_DEFAULT_NULL_VALUES = {
 }
 
 
-def factorize_array(arr):
+def factorize_array(arr,sort_opt=False):
     """
     Groups a 1D Numpy array by item value, and optionally enumerates the
     groups, starting from 1. The default or assumed type is a Nunpy
@@ -96,12 +96,12 @@ def factorize_array(arr):
     :return: A 2-tuple consisting of the enumeration and the value groups
     :rtype: tuple
     """
-    enum, groups = pd.factorize(arr,sort=True)
+    enum, groups = pd.factorize(arr,sort=sort_opt)
 
     return enum + 1, groups
 
 
-def factorize_ndarray(ndarr, row_idxs=[], col_idxs=[]):
+def factorize_ndarray(ndarr, row_idxs=[], col_idxs=[], sort_opt=False):
     """
     Groups an n-D Numpy array by item value, and optionally enumerates the
     groups, starting from 1. The default or assumed type is a Nunpy
@@ -128,7 +128,7 @@ def factorize_ndarray(ndarr, row_idxs=[], col_idxs=[]):
     if rows == 1:
         return factorize_array(_ndarr[0])
 
-    enum, groups = pd.factorize(fast_zip_arrays(*(arr for arr in _ndarr)),sort=True)
+    enum, groups = pd.factorize(fast_zip_arrays(*(arr for arr in _ndarr)),sort=sort_opt)
 
     return enum + 1, groups
 

--- a/oasislmf/utils/data.py
+++ b/oasislmf/utils/data.py
@@ -96,7 +96,7 @@ def factorize_array(arr):
     :return: A 2-tuple consisting of the enumeration and the value groups
     :rtype: tuple
     """
-    enum, groups = pd.factorize(arr)
+    enum, groups = pd.factorize(arr,sort=True)
 
     return enum + 1, groups
 
@@ -128,7 +128,7 @@ def factorize_ndarray(ndarr, row_idxs=[], col_idxs=[]):
     if rows == 1:
         return factorize_array(_ndarr[0])
 
-    enum, groups = pd.factorize(fast_zip_arrays(*(arr for arr in _ndarr)))
+    enum, groups = pd.factorize(fast_zip_arrays(*(arr for arr in _ndarr)),sort=True)
 
     return enum + 1, groups
 


### PR DESCRIPTION
ordered arrays in utils.data.py when factorizing. This will set the group_id in the generated items file to be based on an ordered, distinct list of the fields specified for the model. 