### PR TITLE
Reduce memory use in gul_inputs creation

### DIFF
--- a/oasislmf/cli/base.py
+++ b/oasislmf/cli/base.py
@@ -64,7 +64,7 @@ class OasisBaseCommand(BaseCommand):
                 log_format = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
             else:
                 log_level = logging.INFO
-                log_format = '%(message)s'
+                log_format = '%(asctime)s - %(message)s'
 
             logging.basicConfig(stream=sys.stdout, level=log_level, format=log_format)
             self._logger = logging.getLogger()

--- a/oasislmf/cli/base.py
+++ b/oasislmf/cli/base.py
@@ -64,7 +64,7 @@ class OasisBaseCommand(BaseCommand):
                 log_format = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
             else:
                 log_level = logging.INFO
-                log_format = '%(asctime)s - %(message)s'
+                log_format = '%(message)s'
 
             logging.basicConfig(stream=sys.stdout, level=log_level, format=log_format)
             self._logger = logging.getLogger()

--- a/oasislmf/manager.py
+++ b/oasislmf/manager.py
@@ -15,7 +15,7 @@ import shutil
 
 from itertools import chain
 from filecmp import cmp as compare_files
-                    
+
 from builtins import str
 
 from itertools import (
@@ -461,6 +461,7 @@ class OasisManager(object):
 
         # Prepare the target directory and copy the source files, profiles and
         # model version file into it
+        self.logger.info("Preparing input files directory")
         target_dir = prepare_input_files_directory(
             target_dir,
             exposure_fp,
@@ -478,6 +479,7 @@ class OasisManager(object):
 
         # Get the profiles defining the exposure and accounts files, ID related
         # terms in these files, and FM aggregation hierarchy
+        self.logger.info("Loading OED format definitions")
         exposure_profile = exposure_profile or (get_json(src_fp=exposure_profile_fp) if exposure_profile_fp else self.exposure_profile)
         accounts_profile = accounts_profile or (get_json(src_fp=accounts_profile_fp) if accounts_profile_fp else self.accounts_profile)
         oed_hierarchy = get_oed_hierarchy(exposure_profile, accounts_profile)
@@ -523,6 +525,7 @@ class OasisManager(object):
                 _, _ = olf.write_oasis_keys_file(keys, _keys_fp)
 
             else:
+                self.logger.info("Generating keys data from model lookup")
                 lookup_config = get_json(src_fp=lookup_config_fp) if lookup_config_fp else lookup_config
                 if lookup_config and lookup_config['keys_data_path'] in ['.', './']:
                     lookup_config['keys_data_path'] = os.path.join(os.path.dirname(lookup_config_fp))
@@ -545,6 +548,7 @@ class OasisManager(object):
                     errors_fp=_keys_errors_fp
                 )
         else:
+            self.logger.info("Keys data file provided, skipping lookup")
             _keys_fp = os.path.join(target_dir, os.path.basename(keys_fp))
 
         # Columns from loc file to assign group_id
@@ -703,7 +707,11 @@ class OasisManager(object):
             model_run_fp,
             'analysis_settings.json'
         ))
-        
+<<<<<<< HEAD
+
+=======
+
+>>>>>>> index on (no branch): 560749e Set version 1.7.1
         generate_summaryxref_files(model_run_fp,
                                    analysis_settings,
                                    gul_item_stream=gul_item_stream,
@@ -1015,7 +1023,7 @@ class OasisManager(object):
                         all_losses_df[all_losses_df.loss_factor_idx == str(i)],
                         frame_header=header,
                         cols=cols_to_print)
-                else:    
+                else:
                     print_dataframe(
                         all_losses_df,
                         frame_header=header,
@@ -1094,8 +1102,8 @@ class OasisManager(object):
             file_test_result = compare_files(generated, expected)
             if not file_test_result:
                 if update_expected:
-                    shutil.copyfile(generated, expected)  
-                else:    
+                    shutil.copyfile(generated, expected)
+                else:
                     raise OasisException(
                         f'\n FAIL: generated {generated} vs expected {expected}'
                     )

--- a/oasislmf/utils/data.py
+++ b/oasislmf/utils/data.py
@@ -781,8 +781,7 @@ def merge_dataframes(left, right, join_on=None, **kwargs):
         left = left.set_index(_join_on)
         right = right.drop(drop_cols, axis=1).set_index(_join_on)
 
-        join = left.join(right, how=(kwargs.get('how') or 'left'))
-        join.reset_index(inplace=True)
+        join = left.join(right, how=(kwargs.get('how') or 'left')).reset_index()
 
         return join
 

--- a/oasislmf/utils/data.py
+++ b/oasislmf/utils/data.py
@@ -757,8 +757,6 @@ def merge_dataframes(left, right, join_on=None, **kwargs):
     :return: A merged dataframe
     :rtype: pd.DataFrame
     """
-    merge = None
-
     if not join_on:
         left_keys = kwargs.get('left_on') or kwargs.get('on') or []
         left_keys = [left_keys] if isinstance(left_keys, str) else left_keys
@@ -780,11 +778,11 @@ def merge_dataframes(left, right, join_on=None, **kwargs):
     else:
         _join_on = [join_on] if isinstance(join_on, str) else join_on.copy()
         drop_cols = list(set(left.columns).intersection(right.columns).difference(_join_on))
-        _left = left.set_index(_join_on)
-        _right = right.drop(drop_cols, axis=1).set_index(_join_on)
+        left = left.set_index(_join_on)
+        right = right.drop(drop_cols, axis=1).set_index(_join_on)
 
-        join = _left.join(_right, how=(kwargs.get('how') or 'left')).reset_index()
-        del _left, _right
+        join = left.join(right, how=(kwargs.get('how') or 'left'))
+        join.reset_index(inplace=True)
 
         return join
 

--- a/setup.py
+++ b/setup.py
@@ -203,7 +203,7 @@ class PostInstallKtools(InstallKtoolsMixin, install):
                 self.install_ktools_bin(OS, ARCH)
             except:    
                 print('Fallback - building ktools from source')
-                self.install_ktools_source()
+                self.install_ktools_bin()
         else:
             self.install_ktools_source()
         install.run(self)
@@ -225,7 +225,7 @@ class PostDevelopKtools(InstallKtoolsMixin, develop):
         develop.__init__(self, *args, **kwargs)
 
     def run(self):
-        self.install_ktools_source()
+        self.install_ktools_bin(system(), machine())
         develop.run(self)
 
     def get_outputs(self):

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ def get_install_requirements():
     with io.open(os.path.join(SCRIPT_DIR, 'requirements-package.in'), encoding='utf-8') as reqs:
         return reqs.readlines()
 
+
 def get_version():
     """
     Return package version as listed in `__version__` in `init.py`.
@@ -75,10 +76,10 @@ class InstallKtoolsMixin(object):
         for i in range(attempts):
             try:
                 if proxy_config:
-                    # Proxied connection 
+                    # Proxied connection
                     req = urlrequest.urlopen(urlrequest.Request(url), timeout=timeout)
                     break
-                else:    
+                else:
                     # Non proxied connection
                     req = urlrequest.urlopen(url, timeout=timeout)
                     break
@@ -153,12 +154,25 @@ class InstallKtoolsMixin(object):
             shutil.copy(p, component_path)
             yield component_path
 
+    def try_get_bin_install_kwargs(self):
+        if '--plat-name' in sys.argv:
+            PLATFORM = sys.argv[sys.argv.index('--plat-name') + 1]
+            OS, ARCH = PLATFORM.split('_', 1)
+        else:
+            ARCH = machine()
+            OS = system()
+
+        if ARCH in ['x86_64'] and OS in ['Linux', 'Darwin']:
+            return {"system_os": OS, "system_architecture": ARCH}
+        else:
+            return None
+
     def install_ktools_source(self):
         with temp_dir() as d:
             local_tar_path = os.path.join(d, 'ktools.tar.gz')
             local_extract_path = os.path.join(d, 'extracted')
             source_url = 'https://github.com/OasisLMF/ktools/archive/v{}.tar.gz'.format(KTOOLS_VERSION)
-            
+
             self.fetch_ktools_tar(local_tar_path, source_url)
             self.unpack_tar(local_tar_path, local_extract_path)
             build_dir = self.build_ktools(local_extract_path)
@@ -174,6 +188,7 @@ class InstallKtoolsMixin(object):
             self.unpack_tar(local_tar_path, local_extract_path)
             self.ktools_components = list(self.add_ktools_bins_to_path(local_extract_path))
 
+
 class PostInstallKtools(InstallKtoolsMixin, install):
     command_name = 'install'
     user_options = install.user_options + [
@@ -186,26 +201,20 @@ class PostInstallKtools(InstallKtoolsMixin, install):
         install.__init__(self, *args, **kwargs)
 
     def run(self):
-        ''' 
-        If system arch matches Ktools static build try to install from pre-build 
-        with a fallback of compile ktools from source 
         '''
-        if '--plat-name' in sys.argv:
-            PLATFORM = sys.argv[sys.argv.index('--plat-name') + 1]
-            OS, ARCH = PLATFORM.split('_', 1)
-        else:
-            ARCH = machine()
-            OS = system()
-
-
-        if ARCH in ['x86_64'] and OS in ['Linux', 'Darwin']:
+        If system arch matches Ktools static build try to install from pre-build
+        with a fallback of compile ktools from source
+        '''
+        bin_install_kwargs = self.try_get_bin_install_kwargs()
+        if bin_install_kwargs:
             try:
-                self.install_ktools_bin(OS, ARCH)
-            except:    
+                self.install_ktools_bin(**bin_install_kwargs)
+            except:
                 print('Fallback - building ktools from source')
-                self.install_ktools_bin()
+                self.install_ktools_source()
         else:
             self.install_ktools_source()
+
         install.run(self)
 
     def get_outputs(self):
@@ -225,7 +234,16 @@ class PostDevelopKtools(InstallKtoolsMixin, develop):
         develop.__init__(self, *args, **kwargs)
 
     def run(self):
-        self.install_ktools_bin(system(), machine())
+        try:
+            self.install_ktools_source()
+        except:
+            bin_install_kwargs = self.try_get_bin_install_kwargs()
+            if bin_install_kwargs:
+                print('Fallback - installing precompiled ktools binary')
+                self.install_ktools_source()
+            else:
+                raise
+
         develop.run(self)
 
     def get_outputs(self):
@@ -237,7 +255,7 @@ class PostDevelopKtools(InstallKtoolsMixin, develop):
 
 try:
     from wheel.bdist_wheel import bdist_wheel
-    
+
     # https://github.com/pypa/wheel/blob/master/wheel/bdist_wheel.py#L43
     class BdistWheel(bdist_wheel):
         command_name = 'bdist_wheel'


### PR DESCRIPTION
The changes in this diff reduce the peak memory use during the GUL inputs creation by approximately half for a portfolio of 10 million rows. The results were passed through a mock lookup that returned a successful result for each one, producing keys for two perils. The changes also slightly speed up the process (reduced from ~12 minutes to ~10 for that 10 million row example).

The main change is to simplify the conversion of the per-coverage columns to generic columns. Originally, the method appended a dozen or so new columns to the entire dataframe, and duplicated data across to them on a per-coverage basis. The revised method pulls out a separate dataframe for each coverage, renames the coverage columns to their generic names, and concatenates the results at the end.

I slightly modified the code in the dataframe merging section to avoid holding references to duplicate copies of the dataframe simultaneously (`left` and `_left` were both held, despite `left` never being used again once `_left` was defined).

I have modified the FM test runner to use Pandas to compare the test results files. This allows some leeway for minor rounding differences in the outputs (and can also handle the order of columns being different, etc., if desired). The generated vs. expected outputs are also now printed to stdout in case of a mismatch - I found it was very difficult to diagnose failures, as the outputs were only contained in a temporary file that was deleted immediately after the comparison.

I have also slightly edited the install script so that it falls back on installing the ktools binaries for an editable (developer) install. For reasons I've diagnosed in great detail, the compilation always fails on my machine, but I've also no need for a from-source ktools version for changes like this (assuming the required binary is available, anyway).

I currently get two failing tests in `tests/utils/test_data` on the `develop` branch, which still fail with the code in this PR:
```
FAILED tests/utils/test_data.py::TestGetDataframe::test_get_dataframe__from_csv_file_with_mixed_case_cols__set_lowercase_cols_option_to_false__set_required_cols_and_col_defaults_options_and_use_defaults_for_all_other_options
FAILED tests/utils/test_data.py::TestGetDataframe::test_get_dataframe__from_csv_file_with_mixed_case_cols__set_sort_cols_option_on_single_col_and_use_defaults_for_all_other_options
```