### PR TITLE
Multi-peril exposure run

### DIFF
--- a/oasislmf/computation/generate/files.py
+++ b/oasislmf/computation/generate/files.py
@@ -83,8 +83,6 @@ class GenerateOasisFiles(ComputationStep):
         {'name': 'profile_loc',                   'default': get_default_exposure_profile()},
         {'name': 'profile_acc',                   'default': get_default_accounts_profile()},
         {'name': 'profile_fm_agg',                'default': get_default_fm_aggregation_profile()},
-        {'name': 'deterministic',                 'default': False},
-        #{'name': 'supported_oed_coverage_types',  'default': tuple(v['id'] for v in SUPPORTED_COVERAGE_TYPES.values())},
     ]
 
     def _get_output_dir(self):
@@ -97,16 +95,15 @@ class GenerateOasisFiles(ComputationStep):
     def run(self):
         self.logger.info('\nProcessing arguments - Creating Oasis Files')
 
-        if not self.deterministic:
-            if not (self.keys_data_csv or self.lookup_config_json or (self.lookup_data_dir and self.model_version_csv and self.lookup_module_path)):
-                raise OasisException(
-                    'No pre-generated keys file provided, and no lookup assets '
-                    'provided to generate a keys file - if you do not have a '
-                    'pre-generated keys file then lookup assets must be provided - '
-                    'for a built-in lookup the lookup config. JSON file path must '
-                    'be provided, or for custom lookups the keys data path + model '
-                    'version file path + lookup package path must be provided'
-                )
+        if not (self.keys_data_csv or self.lookup_config_json or (self.lookup_data_dir and self.model_version_csv and self.lookup_module_path)):
+            raise OasisException(
+                'No pre-generated keys file provided, and no lookup assets '
+                'provided to generate a keys file - if you do not have a '
+                'pre-generated keys file then lookup assets must be provided - '
+                'for a built-in lookup the lookup config. JSON file path must '
+                'be provided, or for custom lookups the keys data path + model '
+                'version file path + lookup package path must be provided'
+            )
 
         il = True if self.oed_accounts_csv else False
         ri = all([self.oed_info_csv, self.oed_scope_csv]) and il
@@ -149,17 +146,12 @@ class GenerateOasisFiles(ComputationStep):
         # If a pre-generated keys file path has not been provided,
         # then it is asssumed some model lookup assets have been provided, so
         # as to allow the lookup to be instantiated and called to generated
-        # the keys file. Otherwise if no model keys file path or lookup assets
-        # were provided then a "deterministic" keys file is generated.
+        # the keys file. 
         _keys_fp = _keys_errors_fp = None
         if not self.keys_data_csv:
             _keys_fp = self.kwargs['keys_data_csv'] = os.path.join(target_dir, 'keys.csv')
             _keys_errors_fp = self.kwargs['keys_errors_csv'] = os.path.join(target_dir, 'keys-errors.csv')
-
-            if self.deterministic:
-                GenerateKeysDeterministic(**self.kwargs).run()
-            else:
-                GenerateKeys(**self.kwargs).run()
+            GenerateKeys(**self.kwargs).run()
         else:
             _keys_fp = os.path.join(target_dir, os.path.basename(self.keys_data_csv))
             if self.keys_errors_csv:
@@ -190,7 +182,7 @@ class GenerateOasisFiles(ComputationStep):
         )
 
         # If not in det. loss gen. scenario, write exposure summary file
-        if summarise_exposure and not self.deterministic:
+        if summarise_exposure:
             write_exposure_summary(
                 target_dir,
                 gul_inputs_df,
@@ -219,6 +211,7 @@ class GenerateOasisFiles(ComputationStep):
         # input files, and therefore also RI input files, are not needed
         if not il:
             # Write `summary_map.csv` for GUL only
+            self.logger.info('\nOasis files generated: {}'.format(json.dumps(gul_input_files, indent=4)))
             return gul_input_files
 
         # Get the IL input items
@@ -247,6 +240,7 @@ class GenerateOasisFiles(ComputationStep):
         # If no RI input file paths (info. and scope) have been provided then
         # no RI input files are needed, just return the GUL and IL Oasis files
         if not ri:
+            self.logger.info('\nOasis files generated: {}'.format(json.dumps(oasis_files, indent=4)))
             return oasis_files
 
         # Write the RI input files, and write the returned RI layer info. as a

--- a/oasislmf/computation/generate/keys.py
+++ b/oasislmf/computation/generate/keys.py
@@ -124,6 +124,7 @@ class GenerateKeysDeterministic(ComputationStep):
         {'name': 'oed_location_csv',           'flag':'-x', 'is_path': True, 'pre_exist': True,  'help': 'Source location CSV file path', 'required': True},
         {'name': 'keys_data_csv',              'flag':'-k', 'is_path': True, 'pre_exist': False,  'help': 'Generated keys CSV output path'},
         {'name': 'supported_oed_coverage_types',  'default': tuple(v['id'] for v in SUPPORTED_COVERAGE_TYPES.values())},
+        {'name': 'num_subperils',               'flag':'-p', 'default': 1,  'type':int,          'help': 'Set the number of subperils returned by deterministic key generator'},
     ]
 
     def _get_output_dir(self):
@@ -139,7 +140,8 @@ class GenerateKeysDeterministic(ComputationStep):
 
         loc_ids = (loc_it['loc_id'] for _, loc_it in location_df.loc[:, ['loc_id']].sort_values('loc_id').iterrows())
         keys = [
-            {'loc_id': _loc_id, 'peril_id': 1, 'coverage_type': cov_type, 'area_peril_id': i + 1, 'vulnerability_id': i + 1}
-            for i, (_loc_id, cov_type) in enumerate(product(loc_ids, self.supported_oed_coverage_types))
+            {'loc_id': _loc_id, 'peril_id': peril, 'coverage_type': cov_type, 'area_peril_id': i + 1, 'vulnerability_id': i + 1}
+            for i, (_loc_id, peril, cov_type) in enumerate(product(loc_ids, range(1, 1 + self.num_subperils), self.supported_oed_coverage_types))
         ]
+
         return  olf.write_oasis_keys_file(keys, keys_fp)

--- a/oasislmf/computation/generate/losses.py
+++ b/oasislmf/computation/generate/losses.py
@@ -265,7 +265,7 @@ class GenerateLosses(ComputationStep):
 class GenerateLossesDeterministic(ComputationStep):
 
 
-    step_params = [ 
+    step_params = [
         {'name': 'oasis_files_dir',  'is_path': True, 'pre_exist': True},
         {'name': 'output_dir',           'default': None},
         {'name': 'include_loss_factor',  'default': True},
@@ -297,7 +297,7 @@ class GenerateLossesDeterministic(ComputationStep):
         items = merge_dataframes(
             pd.read_csv(os.path.join(self.oasis_files_dir, 'items.csv')),
             pd.read_csv(os.path.join(self.oasis_files_dir, 'coverages.csv')),
-            left_index=True, right_index=True
+            on=['coverage_id'], how='left'
         )
 
         dtypes = {t: ('uint32' if t != 'tiv' else 'float32') for t in items.columns}

--- a/oasislmf/computation/generate/losses.py
+++ b/oasislmf/computation/generate/losses.py
@@ -273,6 +273,7 @@ class GenerateLossesDeterministic(ComputationStep):
         {'name': 'net_ri',               'default': False},
         {'name': 'ktools_alloc_rule_il', 'default': KTOOLS_ALLOC_IL_DEFAULT},
         {'name': 'ktools_alloc_rule_ri', 'default': KTOOLS_ALLOC_RI_DEFAULT},
+        {'name': 'num_subperils',        'default': 1}
     ]
 
     def run(self):
@@ -322,8 +323,8 @@ class GenerateLossesDeterministic(ComputationStep):
                 'item_id': item_id,
                 'sidx': sidx,
                 'loss':
-                tiv * special_loss_factors[sidx] if sidx < 0
-                else (tiv * self.loss_factor[sidx - 1])
+                (tiv * special_loss_factors[sidx]) / self.num_subperils if sidx < 0
+                else (tiv * self.loss_factor[sidx - 1]) / self.num_subperils
             })
             for (item_id, tiv), sidx in product(
                 fast_zip_dataframe_columns(items, ['item_id', 'tiv']), gulcalc_sidxs

--- a/oasislmf/computation/run/exposure.py
+++ b/oasislmf/computation/run/exposure.py
@@ -130,6 +130,7 @@ class RunExposure(ComputationStep):
             output_dir=os.path.join(run_dir, 'output'),
             include_loss_factor=include_loss_factor,
             loss_factor=self.loss_factor,
+            num_subperils=self.num_subperils,
             net_ri=self.net_ri,
             ktools_alloc_rule_il=self.ktools_alloc_rule_il,
             ktools_alloc_rule_ri=self.ktools_alloc_rule_ri

--- a/oasislmf/computation/run/exposure.py
+++ b/oasislmf/computation/run/exposure.py
@@ -12,6 +12,7 @@ from itertools import chain
 import pandas as pd
 
 from ..base import ComputationStep
+from ..generate.keys import GenerateKeysDeterministic
 from ..generate.files import GenerateOasisFiles
 from ..generate.losses import GenerateLossesDeterministic
 
@@ -44,6 +45,7 @@ class RunExposure(ComputationStep):
         {'name': 'ktools_alloc_rule_il', 'flag':'-a', 'default': KTOOLS_ALLOC_IL_DEFAULT,  'type':int, 'help': 'Set the fmcalc allocation rule used in direct insured loss'},
         {'name': 'ktools_alloc_rule_ri', 'flag':'-A', 'default': KTOOLS_ALLOC_RI_DEFAULT,  'type':int, 'help': 'Set the fmcalc allocation rule used in reinsurance'},
         {'name': 'output_level',         'flag':'-o', 'help': 'Keys files output format', 'choices':['item', 'loc', 'pol', 'acc', 'port'], 'default': 'item'},
+        {'name': 'num_subperils',        'flag':'-p', 'default': 1,  'type':int,          'help': 'Set the number of subperils returned by deterministic key generator'},
 
         {'name': 'net_ri', 'default': True},
         {'name': 'include_loss_factor', 'default': True},
@@ -69,12 +71,12 @@ class RunExposure(ComputationStep):
             tmp_dir = tempfile.TemporaryDirectory()
             run_dir = tmp_dir.name
 
-        include_loss_factor = not (len(self.loss_factor) == 1) 
+        include_loss_factor = not (len(self.loss_factor) == 1)
         src_contents = [fn.lower() for fn in os.listdir(src_dir)]
 
         self._check_alloc_rules()
 
-        
+
         if 'location.csv' not in src_contents:
             raise OasisException(
                 'No location/exposure file found in source directory - '
@@ -104,16 +106,25 @@ class RunExposure(ComputationStep):
             except IndexError:
                 ri_info_fp = None
 
-        # Start Oasis files generation
+        # 1. Create Deterministic keys file
+        keys_fp = os.path.join(run_dir, 'keys.csv')
+        GenerateKeysDeterministic(
+            oed_location_csv=location_fp,
+            keys_data_csv=keys_fp,
+            num_subperils=self.num_subperils,
+        ).run()
+
+        # 2. Start Oasis files generation
         GenerateOasisFiles(
            oasis_files_dir=run_dir,
             oed_location_csv=location_fp,
             oed_accounts_csv=accounts_fp,
             oed_info_csv=ri_info_fp,
             oed_scope_csv=ri_scope_fp,
-            deterministic=True,
+            keys_data_csv=keys_fp,
         ).run()
 
+        # 3. Run Deterministic Losses
         losses = GenerateLossesDeterministic(
             oasis_files_dir=run_dir,
             output_dir=os.path.join(run_dir, 'output'),
@@ -276,7 +287,7 @@ class RunExposure(ComputationStep):
             tmp_dir.cleanup()
 
         return (il, ril)
-        
+
 
 
 
@@ -299,13 +310,13 @@ class RunFmTest(ComputationStep):
 
 
     def search_test_cases(self):
-        case_names = []                                                                                                                                   
+        case_names = []
         for test_case in os.listdir(path=self.test_case_dir):
-            if os.path.exists(              
+            if os.path.exists(
                 os.path.join(self.test_case_dir, test_case, "expected")
             ):
                 case_names.append(test_case)
-        case_names.sort()        
+        case_names.sort()
         return case_names, len(case_names)
 
 
@@ -316,7 +327,7 @@ class RunFmTest(ComputationStep):
             self.test_case_dir = os.getcwd()
         case_names, case_num = self.search_test_cases()
 
-        # If enabled, list found test cases and exit 
+        # If enabled, list found test cases and exit
         if self.list_tests:
             for name in case_names:
                 self.logger.info(name)
@@ -334,19 +345,19 @@ class RunFmTest(ComputationStep):
         failed_tests = []
         exit_status = 0
         for case in case_names:
-            test_result = self.execute_test_case(case)                                                                                                                                                               
+            test_result = self.execute_test_case(case)
 
             if not test_result:
                 failed_tests.append(case)
                 exit_status = 1
-            
+
         if len(failed_tests) == 0:
             self.logger.info("All tests passed")
         else:
             self.logger.info("{} test failed: ".format(len(failed_tests)))
             [self.logger.info(n) for n in failed_tests]
         exit(exit_status)
-            
+
 
 
 
@@ -382,10 +393,10 @@ class RunFmTest(ComputationStep):
 
         output_file = os.path.join(run_dir, 'loc_summary.csv')
         (il, ril) = RunExposure(
-            src_dir=test_dir, 
-            run_dir=run_dir, 
-            loss_factor=loss_factor, 
-            output_level=output_level, 
+            src_dir=test_dir,
+            run_dir=run_dir,
+            loss_factor=loss_factor,
+            output_level=output_level,
             output_file=output_file,
             include_loss_factor=include_loss_factor
         ).run()


### PR DESCRIPTION
PR for issue #575 

Added `-p <int>` or `--num-subperils <int>` to set the number of subperils returned by deterministic key generator

### Example  
 [example_keys_output.zip](https://github.com/OasisLMF/OasisLMF/files/5225604/example_keys_output.zip)
Running the command `oasislmf exposure run --num-subperils 2` with a three row location file generates the following:  

|LocID|PerilID|CoverageTypeID|AreaPerilID|VulnerabilityID|
|-----|-------|--------------|-----------|---------------|
|1    |1      |1             |1          |1              |
|1    |1      |2             |2          |2              |
|1    |1      |3             |3          |3              |
|1    |1      |4             |4          |4              |
|1    |2      |1             |5          |5              |
|1    |2      |2             |6          |6              |
|1    |2      |3             |7          |7              |
|1    |2      |4             |8          |8              |
|2    |1      |1             |9          |9              |
|2    |1      |2             |10         |10             |
|2    |1      |3             |11         |11             |
|2    |1      |4             |12         |12             |
|2    |2      |1             |13         |13             |
|2    |2      |2             |14         |14             |
|2    |2      |3             |15         |15             |
|2    |2      |4             |16         |16             |
|3    |1      |1             |17         |17             |
|3    |1      |2             |18         |18             |
|3    |1      |3             |19         |19             |
|3    |1      |4             |20         |20             |
|3    |2      |1             |21         |21             |
|3    |2      |2             |22         |22             |
|3    |2      |3             |23         |23             |
|3    |2      |4             |24         |24             |


