### PR TITLE
If param is path, load default value on empty string

### DIFF
--- a/oasislmf/computation/base.py
+++ b/oasislmf/computation/base.py
@@ -40,7 +40,7 @@ class ComputationStep:
 
         for param in self.get_params():
             param_value = kwargs.get(param['name'])
-            if param_value is None:
+            if param_value in [None, ""]:
                 if param.get('required'):
                     raise OasisException(f"parameter {param['name']} is required "
                                          f"for Computation Step {self.__class__.__name__}")

--- a/oasislmf/utils/inputs.py
+++ b/oasislmf/utils/inputs.py
@@ -132,7 +132,7 @@ class InputValues(object):
             value = default
             source = 'default'
 
-        if is_path and value is not None and not os.path.isabs(value):
+        if is_path and value not in [None, ""] and not os.path.isabs(value):
             if source == 'config':
                 value = os.path.join(self.config_dir, value)
             else:


### PR DESCRIPTION
### Fix 
If an empty path string is set in the config file and is **not** required, load the default value instead.

### Original Problem 
When loading a config file with empty path strings:
**oasislmf.json**
```
{                                                                                                                                                              
    "lookup_config_json": "keys_data/PiWind/lookup.json",
    "lookup_data_dir": "keys_data/PiWind",
    "model_data_dir": "model_data/PiWind",
    "model_settings_json": "meta-data/model_settings.json",
    "oed_location_csv": "tests/inputs/SourceLocOEDPiWind10.csv",
    "oed_accounts_csv": "tests/inputs/SourceAccOEDPiWind.csv",
    "oed_info_csv": "",
    "oed_scope_csv": "",
    "analysis_settings_json": "analysis_settings.json"
}
```

Then CLI will fail with an unhelpful error:
```
$ oasislmf model run
Processing arguments - RunModel
RUNNING: oasislmf.manager.interface
  0%|                                                                                                                                    | 0/2 [00:00<?, ?it/s]
Processing arguments - Creating Oasis Files

Generating Oasis files (GUL=True, IL=True, RIL=True)
  0%|                                                                                                                                    | 0/2 [00:00<?, ?it/s]
Exception raised in 'prepare_input_files_directory', IsADirectoryError: [Errno 21] Is a directory: '/home/sam/repos/models/piwind/'
```