### PR TITLE
add check if epa when copying file for file generation

### DIFF
--- a/oasislmf/cli/model.py
+++ b/oasislmf/cli/model.py
@@ -8,13 +8,8 @@ __all__ = [
     'RunCmd'
 ]
 
-import os
-
 from argparse import RawDescriptionHelpFormatter
 
-from ..utils.defaults import (
-    KEY_NAME_TO_FILE_NAME,
-)
 from .command import OasisBaseCommand, OasisComputationCommand
 
 
@@ -34,15 +29,6 @@ class GenerateExposurePreAnalysisCmd(OasisComputationCommand):
     """
     formatter_class = RawDescriptionHelpFormatter
     computation_name = 'ExposurePreAnalysis'
-
-    def action(self, args):  # TODO remove once integrated with archi 2020
-        super().action(args)
-
-        if args.model_run_dir:
-            input_dir = os.path.join(args.model_run_dir, 'input')
-            for input_name in ('oed_location_csv', 'oed_accounts_csv', 'oed_info_csv', 'oed_scope_csv'):
-                setattr(args, input_name, os.path.join(input_dir, KEY_NAME_TO_FILE_NAME[input_name]))
-
 
 class GenerateKeysCmd(OasisComputationCommand):
     """

--- a/oasislmf/computation/hooks/pre_analysis.py
+++ b/oasislmf/computation/hooks/pre_analysis.py
@@ -10,7 +10,7 @@ import shutil
 from ..base import ComputationStep
 from ...utils.path import get_custom_module
 from ...utils.exceptions import OasisException
-from ...utils.defaults import store_exposure_fp, KEY_NAME_TO_FILE_NAME
+from ...utils.defaults import store_exposure_fp
 
 
 class ExposurePreAnalysis(ComputationStep):
@@ -63,8 +63,8 @@ class ExposurePreAnalysis(ComputationStep):
         for input_name in ('oed_location_csv', 'oed_accounts_csv', 'oed_info_csv', 'oed_scope_csv'):
             file_path_in = getattr(self, input_name)
             if file_path_in is not None:
-                file_path_raw = os.path.join(input_dir, f'epa_{KEY_NAME_TO_FILE_NAME[input_name]}')
-                file_path_out = os.path.join(input_dir, KEY_NAME_TO_FILE_NAME[input_name])
+                file_path_raw = os.path.join(input_dir, f'epa_{store_exposure_fp(file_path_in, input_name)}')
+                file_path_out = os.path.join(input_dir, store_exposure_fp(file_path_in, input_name))
                 kwargs[f'raw_{input_name}'] = file_path_raw
                 kwargs[input_name] = file_path_out
 

--- a/oasislmf/preparation/dir_inputs.py
+++ b/oasislmf/preparation/dir_inputs.py
@@ -42,15 +42,12 @@ def prepare_input_files_directory(
                 complex_lookup_config_fp, keys_fp, keys_errors_fp
             ) if p
         ]
-        
-        if exposure_fp:
-            paths.append((exposure_fp, os.path.join(target_dir, store_exposure_fp(exposure_fp, 'loc'))))
-        if accounts_fp:
-            paths.append((accounts_fp, os.path.join(target_dir, store_exposure_fp(accounts_fp, 'acc'))))
-        if ri_info_fp:
-            paths.append((ri_info_fp, os.path.join(target_dir, store_exposure_fp(ri_info_fp, 'info'))))
-        if ri_scope_fp:
-            paths.append((ri_scope_fp, os.path.join(target_dir, store_exposure_fp(ri_scope_fp, 'scope'))))
+
+        for fp, key in ((exposure_fp, "loc"), (accounts_fp, "acc"), (ri_info_fp, "info"), (ri_scope_fp, "scope")):
+            if fp:
+                # check if exposure pre-analysis has run:
+                if not os.path.exists(os.path.join(target_dir, f'epa_{store_exposure_fp(fp, key)}')):
+                    paths.append((fp, os.path.join(target_dir, store_exposure_fp(fp, key))))
 
         for src, dst in paths:
             if src and os.path.exists(src):

--- a/oasislmf/utils/defaults.py
+++ b/oasislmf/utils/defaults.py
@@ -55,14 +55,6 @@ SOURCE_FILENAMES = OrderedDict({
     'acc': 'account.csv',
     'info': 'reinsinfo.csv',
     'scope': 'reinsscope.csv',
-})
-
-API_EXAMPLE_AUTH = OrderedDict({
-    'user': 'admin',
-    'pass': 'password',
-})
-
-KEY_NAME_TO_FILE_NAME = {
     'oed_location_csv': 'location.csv',
     'oed_accounts_csv': 'account.csv',
     'oed_info_csv': 'reinsinfo.csv',
@@ -74,7 +66,12 @@ KEY_NAME_TO_FILE_NAME = {
     'lookup_complex_config_json': 'lookup_complex.json',
     'profile_acc_json': 'profile_account.json',
     'profile_fm_agg_json': 'profile_fm_agg.json',
-}
+})
+
+API_EXAMPLE_AUTH = OrderedDict({
+    'user': 'admin',
+    'pass': 'password',
+})
 
 DEFAULT_RTREE_INDEX_PROPS = {
     'buffering_capacity': 10,

--- a/tests/model_preparation/test_exposure_pre_analysis.py
+++ b/tests/model_preparation/test_exposure_pre_analysis.py
@@ -4,7 +4,7 @@ import pytest
 from backports.tempfile import TemporaryDirectory
 
 from oasislmf.manager import OasisManager
-from oasislmf.utils.defaults import KEY_NAME_TO_FILE_NAME
+from oasislmf.utils.defaults import SOURCE_FILENAMES
 from oasislmf.utils.exceptions import OasisException
 
 input_oed_location = """BuildingTIV
@@ -60,7 +60,7 @@ def test_exposure_pre_analysis_simple_example():
     with TemporaryDirectory() as d:
         kwargs = {'model_run_dir': d,
                   'exposure_pre_analysis_module': os.path.join(d, 'exposure_pre_analysis_simple.py'),
-                  'oed_location_csv': os.path.join(d, KEY_NAME_TO_FILE_NAME['oed_location_csv']),
+                  'oed_location_csv': os.path.join(d, SOURCE_FILENAMES['oed_location_csv']),
                   'exposure_pre_analysis_setting_json': os.path.join(d, 'exposure_pre_analysis_setting.json'),}
 
         write_simple_epa_module(kwargs['exposure_pre_analysis_module'])
@@ -69,7 +69,7 @@ def test_exposure_pre_analysis_simple_example():
 
         OasisManager().exposure_pre_analysis(**kwargs)
 
-        with open(os.path.join(d, 'input', KEY_NAME_TO_FILE_NAME['oed_location_csv'])) as new_oed_location_csv:
+        with open(os.path.join(d, 'input', SOURCE_FILENAMES['oed_location_csv'])) as new_oed_location_csv:
             new_oed_location_csv_data = new_oed_location_csv.read()
             assert new_oed_location_csv_data == output_oed_location
 
@@ -79,7 +79,7 @@ def test_exposure_pre_analysis_class_name():
         kwargs = {'model_run_dir': d,
                   'exposure_pre_analysis_class_name': 'foobar',
                   'exposure_pre_analysis_module': os.path.join(d, 'exposure_pre_analysis_simple_foobar.py'),
-                  'oed_location_csv': os.path.join(d, KEY_NAME_TO_FILE_NAME['oed_location_csv']),
+                  'oed_location_csv': os.path.join(d, SOURCE_FILENAMES['oed_location_csv']),
                   'exposure_pre_analysis_setting_json': os.path.join(d, 'exposure_pre_analysis_setting.json'), }
 
         write_simple_epa_module(kwargs['exposure_pre_analysis_module'], kwargs['exposure_pre_analysis_class_name'])
@@ -88,7 +88,7 @@ def test_exposure_pre_analysis_class_name():
 
         OasisManager().exposure_pre_analysis(**kwargs)
 
-        with open(os.path.join(d, 'input', KEY_NAME_TO_FILE_NAME['oed_location_csv'])) as new_oed_location_csv:
+        with open(os.path.join(d, 'input', SOURCE_FILENAMES['oed_location_csv'])) as new_oed_location_csv:
             new_oed_location_csv_data = new_oed_location_csv.read()
             assert new_oed_location_csv_data == output_oed_location
 
@@ -103,7 +103,7 @@ def test_wrong_class():
         kwargs = {'model_run_dir': d,
                   'exposure_pre_analysis_class_name': 'foobar',
                   'exposure_pre_analysis_module': os.path.join(d, 'exposure_pre_analysis_simple.py'),
-                  'oed_location_csv': os.path.join(d, KEY_NAME_TO_FILE_NAME['oed_location_csv']),
+                  'oed_location_csv': os.path.join(d, SOURCE_FILENAMES['oed_location_csv']),
                   'exposure_pre_analysis_setting_json': os.path.join(d, 'exposure_pre_analysis_setting.json'), }
 
         write_simple_epa_module(kwargs['exposure_pre_analysis_module'])


### PR DESCRIPTION
After the big refactoring, the exposure files created by exposure-pre-analysis hook were overwritten.
Add a check for epa before overwriting exposure files during GenerateOasisFiles