### PR TITLE
Fix/flag ktools fifo relative

### DIFF
--- a/oasislmf/computation/generate/files.py
+++ b/oasislmf/computation/generate/files.py
@@ -14,6 +14,7 @@ from ...preparation.oed import load_oed_dfs
 from ...preparation.dir_inputs import prepare_input_files_directory
 from ...preparation.reinsurance_layer import write_files_for_reinsurance
 from ...utils.exceptions import OasisException
+from ...utils.inputs import str2bool
 
 from ...utils.data import (
     get_model_settings,
@@ -73,7 +74,7 @@ class GenerateFiles(ComputationStep):
         {'name': 'oed_accounts_csv',           'flag':'-y', 'is_path': True, 'pre_exist': True,  'help': 'Source accounts CSV file path'},
         {'name': 'oed_info_csv',               'flag':'-i', 'is_path': True, 'pre_exist': True,  'help': 'Reinsurance info. CSV file path'},
         {'name': 'oed_scope_csv',              'flag':'-s', 'is_path': True, 'pre_exist': True,  'help': 'Reinsurance scope CSV file path'},
-        {'name': 'disable_summarise_exposure', 'flag':'-S', 'action':'store_true',               'help': 'Disables creation of an exposure summary report'},
+        {'name': 'disable_summarise_exposure', 'flag':'-S', 'default': False, 'type': str2bool, 'const':True, 'nargs':'?', 'help': 'Disables creation of an exposure summary report'},
         {'name': 'group_id_cols',              'flag':'-G', 'nargs':'+',                         'help': 'Columns from loc file to set group_id', 'default': GROUP_ID_COLS},
 
         # Manager only options (pass data directy instead of filepaths)

--- a/oasislmf/computation/generate/losses.py
+++ b/oasislmf/computation/generate/losses.py
@@ -213,9 +213,9 @@ class GenerateLosses(ComputationStep):
                         num_gul_per_lb=self.ktools_num_gul_per_lb,
                         num_fm_per_lb=self.ktools_num_fm_per_lb,
                         run_debug=self.verbose,
-                        stderr_guard= not self.ktools_disable_guard,
+                        stderr_guard=not self.ktools_disable_guard,
                         gul_legacy_stream=self.ktools_legacy_stream,
-                        fifo_tmp_dir=self.ktools_fifo_relative,
+                        fifo_tmp_dir=not self.ktools_fifo_relative,
                         custom_gulcalc_cmd=self.model_custom_gulcalc,
                     )
                 except TypeError:
@@ -230,9 +230,9 @@ class GenerateLosses(ComputationStep):
                         set_alloc_rule_il=self.ktools_alloc_rule_il,
                         set_alloc_rule_ri=self.ktools_alloc_rule_ri,
                         run_debug=self.verbose,
-                        stderr_guard= not self.ktools_disable_guard,
+                        stderr_guard=not self.ktools_disable_guard,
                         gul_legacy_stream=self.ktools_legacy_stream,
-                        fifo_tmp_dir=self.ktools_fifo_relative,
+                        fifo_tmp_dir=not self.ktools_fifo_relative,
                         custom_gulcalc_cmd=self.model_custom_gulcalc,
                     )
             except CalledProcessError as e:

--- a/oasislmf/computation/generate/losses.py
+++ b/oasislmf/computation/generate/losses.py
@@ -28,6 +28,7 @@ from ...execution.bin import (
 from ...preparation.summaries import generate_summaryxref_files
 from ...utils.exceptions import OasisException
 from ...utils.path import setcwd
+from ...utils.inputs import str2bool
 
 from ...utils.data import (
     fast_zip_dataframe_columns,
@@ -44,7 +45,7 @@ from ...utils.defaults import (
     KTOOLS_ALLOC_IL_DEFAULT,
     KTOOLS_ALLOC_RI_DEFAULT,
     KTOOLS_DEBUG,
-    KTOOLS_ERR_GUARD,
+    KTOOLS_DISABLE_ERR_GUARD,
     KTOOLS_FIFO_RELATIVE,
     KTOOLS_GUL_LEGACY_STREAM,
     KTOOLS_MEAN_SAMPLE_IDX,
@@ -102,8 +103,8 @@ class GenerateLosses(ComputationStep):
         {'name': 'ktools_alloc_rule_ri',   'default': KTOOLS_ALLOC_RI_DEFAULT,  'type':int, 'help': 'Set the fmcalc allocation rule used in reinsurance'},
         {'name': 'ktools_num_gul_per_lb',  'default': KTOOL_N_GUL_PER_LB,       'type':int, 'help': 'Number of gul per load balancer (0 means no load balancer)'},
         {'name': 'ktools_num_fm_per_lb',   'default': KTOOL_N_FM_PER_LB,        'type':int, 'help': 'Number of fm per load balancer (0 means no load balancer)'},
-        {'name': 'ktools_disable_guard',   'default': not KTOOLS_ERR_GUARD, 'action': 'store_true', 'help': 'Disables error handling in the ktools run script (abort on non-zero exitcode or output on stderr)'},
-        {'name': 'ktools_fifo_relative',   'default': KTOOLS_FIFO_RELATIVE, 'action': 'store_true', 'help': 'Create ktools fifo queues under the ./fifo dir'},
+        {'name': 'ktools_disable_guard',   'default': False, 'type': str2bool, 'const':True, 'nargs':'?', 'help': 'Disables error handling in the ktools run script (abort on non-zero exitcode or output on stderr)'},
+        {'name': 'ktools_fifo_relative',   'default': False, 'type': str2bool, 'const':True, 'nargs':'?', 'help': 'Create ktools fifo queues under the ./fifo dir'},
 
         # Manager only options (pass data directy instead of filepaths)
         {'name': 'verbose',              'default': KTOOLS_DEBUG},
@@ -238,7 +239,7 @@ class GenerateLosses(ComputationStep):
             except CalledProcessError as e:
                 bash_trace_fp = os.path.join(model_run_fp, 'log', 'bash.log')
                 if os.path.isfile(bash_trace_fp):
-                    with io.open(bash_trace_fp, 'r', encoding='utf-8') as f:
+                   with io.open(bash_trace_fp, 'r', encoding='utf-8') as f:
                         self.logger.info('\nBASH_TRACE:\n' + "".join(f.readlines()))
 
                 stderror_fp = os.path.join(model_run_fp, 'log', 'stderror.err')

--- a/oasislmf/utils/defaults.py
+++ b/oasislmf/utils/defaults.py
@@ -24,7 +24,7 @@ __all__ = [
     'KTOOLS_ALLOC_FM_MAX',
     'KTOOLS_FIFO_RELATIVE',
     'KTOOLS_DEBUG',
-    'KTOOLS_ERR_GUARD',
+    'KTOOLS_DISABLE_ERR_GUARD',
     'KTOOLS_NUM_PROCESSES',
     'KTOOLS_GUL_LEGACY_STREAM',
     'OASIS_FILES_PREFIXES',
@@ -313,7 +313,7 @@ def get_default_deterministic_analysis_settings(path=False):
 # Defaults for Ktools runtime parameters
 KTOOLS_NUM_PROCESSES = -1
 KTOOLS_FIFO_RELATIVE = False
-KTOOLS_ERR_GUARD = True
+KTOOLS_DISABLE_ERR_GUARD = False
 KTOOLS_GUL_LEGACY_STREAM = False
 # ktools gul alloc rules:
 # 2 = total loss is maximum subperil loss

--- a/oasislmf/utils/inputs.py
+++ b/oasislmf/utils/inputs.py
@@ -9,7 +9,7 @@ import logging
 
 from ..utils.defaults import get_config_profile
 from ..utils.exceptions import OasisException
-
+from argparse import ArgumentTypeError
 
 class InputValues(object):
     """
@@ -32,10 +32,7 @@ class InputValues(object):
             self.config_dir = os.path.dirname(self.config_fp)
 
         self.obsolete_keys = set(self.config) & set(self.config_mapping)
-    
-        ##! Not sure why this is needed?
-        #self.logger.warning(str(self.config))
-    
+
         self.list_obsolete_keys()
         if update_keys:
             self.update_config_keys()
@@ -118,9 +115,9 @@ class InputValues(object):
 
         :return: The found value or the default
         """
-
         value = getattr(self.args, name, None)
         source = 'arg'
+
         if value is None:
             value = self.config.get(name)
             source = 'config'
@@ -139,3 +136,29 @@ class InputValues(object):
                 value = os.path.abspath(value)
 
         return value
+
+
+def str2bool(v):
+    """ Func type for loading strings to boolean values using argparse
+        https://stackoverflow.com/a/43357954
+
+        step_params:
+            use: `'default': False, 'type': str2bool, 'const':True, 'nargs':'?', ...`
+
+        CLI:
+            oasislmf --some-flag
+            oasislmf --some-flag <bool>
+
+        oasislmf.json
+        {"some_flag": true, ...}
+    """
+    if v is None:
+        return v
+    elif isinstance(v, bool):
+        return v
+    elif v.lower() in ('yes', 'true', 't', 'y', '1'):
+        return True
+    elif v.lower() in ('no', 'false', 'f', 'n', '0'):
+        return False
+    else:
+        raise ArgumentTypeError('Boolean value expected.')


### PR DESCRIPTION
* Fixes loading boolean variables in oasislmf.json 
* Fixes the flag --ktools-fifo-relative which bug caused value to be flipped 

## Example

* run with default: `oasislmf model run`
```
ktools_disable_guard:False
ktools_fifo_relative:False 
```
* run with flags: `oasislmf model run --ktools-disable-guard --ktools-fifo-relative`
```
ktools_disable_guard:True
ktools_fifo_relative:True 
```

* run with config `oasislmf model run --config oasislmf.json`:
```
{ 
   ... piwind defaults ...
    "ktools_disable_guard": true,
    "ktools_fifo_relative": true
}
```
```
ktools_disable_guard:True
ktools_fifo_relative:True
```