### PR TITLE
Fix ENV var loading and add override option for worker

### DIFF
--- a/oasislmf/cli/command.py
+++ b/oasislmf/cli/command.py
@@ -120,7 +120,7 @@ class OasisComputationCommand(OasisBaseCommand):
         inputs = InputValues(args)
 
         _kwargs = {
-            param['name']: inputs.get(param['name'], required=param.get('required'), is_path=param.get('is_path')) for
+            param['name']: inputs.get(param['name'], required=param.get('required'), is_path=param.get('is_path'), dtype=param.get('type')) for
             param in om.computations_params[self.computation_name]}
 
         manager_method = getattr(om(), om.computation_name_to_method(self.computation_name))

--- a/oasislmf/cli/command.py
+++ b/oasislmf/cli/command.py
@@ -10,7 +10,7 @@ import sys
 from argparsetree import BaseCommand
 
 from ..utils.path import PathCleaner
-from ..utils.inputs import InputValues
+from ..utils.inputs import InputValues, str2bool
 
 from ..manager import OasisManager as om
 
@@ -116,12 +116,16 @@ class OasisComputationCommand(OasisBaseCommand):
         :param args: The arguments from the command line
         :type args: Namespace
         """
-        self.logger.info(f'\nProcessing arguments - {self.computation_name}')
         inputs = InputValues(args)
 
         _kwargs = {
             param['name']: inputs.get(param['name'], required=param.get('required'), is_path=param.get('is_path'), dtype=param.get('type')) for
             param in om.computations_params[self.computation_name]}
 
+        # Override logger setup from kwargs
+        if 'verbose' in _kwargs:
+            self.logger.level = logging.DEBUG if str2bool(_kwargs.get('verbose')) else logging.INFO
+
+        self.logger.info(f'\nStating oasislmf command - {self.computation_name}')
         manager_method = getattr(om(), om.computation_name_to_method(self.computation_name))
         manager_method(**_kwargs)

--- a/oasislmf/computation/generate/files.py
+++ b/oasislmf/computation/generate/files.py
@@ -80,6 +80,7 @@ class GenerateFiles(ComputationStep):
         # Manager only options (pass data directy instead of filepaths)
         {'name': 'lookup_config'},
         {'name': 'lookup_complex_config'},
+        {'name': 'verbose',                       'default': False},
         {'name': 'write_chunksize', 'type':int,   'default': WRITE_CHUNKSIZE},
         {'name': 'oasis_files_prefixes',          'default': OASIS_FILES_PREFIXES},
         {'name': 'profile_loc',                   'default': get_default_exposure_profile()},

--- a/oasislmf/utils/inputs.py
+++ b/oasislmf/utils/inputs.py
@@ -87,12 +87,14 @@ class InputValues(object):
             self.logger.error('\nexiting.')
 
     def get_env(self, name, dtype=None, default=None):
-        prefix = 'OASIS'
-        env_var = os.getenv(f'{prefix}_{name.upper()}', default=default)
+        env_var = os.getenv(f'OASIS_{name.upper()}', default=default)
         if dtype and env_var:
             return dtype(env_var)
         else:
             return env_var
+
+    def has_env(self, name):
+        return f'OASIS_{name.upper()}' in os.environ
 
     def get(self, name, default=None, required=False, is_path=False, dtype=None):
         """
@@ -132,7 +134,7 @@ class InputValues(object):
         value = getattr(self.args, name, None)
 
         # Load order 1: ENV override (intended for worker images)
-        if str2bool(os.getenv('OASIS_ENV_OVERRIDE', default=False)) and name != 'config':
+        if str2bool(os.getenv('OASIS_ENV_OVERRIDE', default=False)) and self.has_env(name):
             source = 'env_override'
             value = self.get_env(name, dtype)
 

--- a/oasislmf/utils/inputs.py
+++ b/oasislmf/utils/inputs.py
@@ -162,9 +162,9 @@ class InputValues(object):
             else:
                 value = os.path.abspath(value)
 
-        # Warn user of Enviroment variable load
+        # Warn user of environment variable load
         if source == 'env_override':
-            self.logger.warn(f'Warning - enviroment variable override: OASIS_{name.upper()}={value}')
+            self.logger.warn(f'Warning - environment variable override: OASIS_{name.upper()}={value}')
 
         return value
 

--- a/oasislmf/utils/inputs.py
+++ b/oasislmf/utils/inputs.py
@@ -11,6 +11,7 @@ from ..utils.defaults import get_config_profile
 from ..utils.exceptions import OasisException
 from argparse import ArgumentTypeError
 
+
 class InputValues(object):
     """
     Helper class for accessing the input values from either
@@ -85,7 +86,15 @@ class InputValues(object):
         except KeyboardInterrupt:
             self.logger.error('\nexiting.')
 
-    def get(self, name, default=None, required=False, is_path=False):
+    def get_env(self, name, dtype=None, default=None):
+        prefix = 'OASIS'
+        env_var = os.getenv(f'{prefix}_{name.upper()}', default=default)
+        if dtype and env_var:
+            return dtype(env_var)
+        else:
+            return env_var
+
+    def get(self, name, default=None, required=False, is_path=False, dtype=None):
         """
         Gets the name parameter until found from:
           - the command line arguments.
@@ -110,30 +119,52 @@ class InputValues(object):
             use config_dir as base dir if value comes from the config
         :type is_path: bool
 
+        :param dtype: the class <type> of the value, if 'None' load as string by default
+        :type: class
+
         :raise OasisException: If the value is not found and ``required``
             is True
 
         :return: The found value or the default
         """
-        value = getattr(self.args, name, None)
+        # Load order 0:  Get from CLI flag
         source = 'arg'
+        value = getattr(self.args, name, None)
 
+        # Load order 1: ENV override (intended for worker images)
+        if str2bool(os.getenv('OASIS_ENV_OVERRIDE', default=False)) and name != 'config':
+            source = 'env_override'
+            value = self.get_env(name, dtype)
+
+        # Load order 2: Get from config JSON
         if value is None:
-            value = self.config.get(name)
             source = 'config'
+            value = self.config.get(name)
+
+        # Load order 3: Get from environment variable
+        if value is None:
+            source = 'env'
+            value = self.get_env(name, dtype)
+
         if value is None and required:
             raise OasisException(
                 'Required argument {} could not be found in the command args or the MDK config. file'.format(name)
             )
+
+        # Load order 4: Get default value
         if value is None:
-            value = default
             source = 'default'
+            value = default
 
         if is_path and value not in [None, ""] and not os.path.isabs(value):
             if source == 'config':
                 value = os.path.join(self.config_dir, value)
             else:
                 value = os.path.abspath(value)
+
+        # Warn user of Enviroment variable load
+        if source == 'env_override':
+            self.logger.warn(f'Warning - enviroment variable override: OASIS_{name.upper()}={value}')
 
         return value
 


### PR DESCRIPTION
Fix for issue #678 
* Fixed problem with environment variables not loading
* Added option for worker `OASIS_ENV_OVERRIDE` which changes the load order so environment variables take priority 

**Example**
```
$ export OASIS_ENV_OVERRIDE=true
$ export OASIS_ANALYSIS_SETTINGS_JSON=analysis_settings.json
$ export OASIS_KTOOLS_NUM_PROCESSES=5
$ oasislmf model run --ktools-num-processes 66

Processing arguments - RunModel
Warning - environment variable override: OASIS_ANALYSIS_SETTINGS_JSON=/home/sam/repos/models/piwind/analysis_settings.json
Warning - environment variable override: OASIS_KTOOLS_NUM_PROCESSES=5
RUNNING: oasislmf.manager.interface
Processing arguments - Creating Oasis Files
  .... 

2020-11-17 16:52:04,929 - root - DEBUG -     number_of_processes == 5
2020-11-17 16:52:04,929 - root - DEBUG -     filename == /home/sam/repos/models/piwind/runs/losses-20201117165159/run_ktools.sh
2020-11-17 16:52:04,929 - root - DEBUG -     num_reinsurance_iterations == 1
2020-11-17 16:52:04,929 - root - DEBUG -     set_alloc_rule_gul == 0
2020-11-17 16:52:04,929 - root - DEBUG -     set_alloc_rule_il == 2
2020-11-17 16:52:04,929 - root - DEBUG -     set_alloc_rule_ri == 3
2020-11-17 16:52:04,929 - root - DEBUG -     num_gul_per_lb == 0
2020-11-17 16:52:04,929 - root - DEBUG -     num_fm_per_lb == 0
2020-11-17 16:52:04,929 - root - DEBUG -     run_debug == False
2020-11-17 16:52:04,929 - root - DEBUG -     stderr_guard == True
2020-11-17 16:52:04,929 - root - DEBUG -     gul_legacy_stream == False
2020-11-17 16:52:04,929 - root - DEBUG -     fifo_tmp_dir == True
2020-11-17 16:52:04,929 - root - DEBUG -     custom_gulcalc_cmd == None
2020-11-17 16:52:04,929 - root - DEBUG -     fmpy == False
2020-11-17 16:52:04,929 - root - DEBUG -     fmpy_low_memory == False
```


