### PR TITLE
Add flags for lookup multiproc options

### DIFF
--- a/oasislmf/computation/generate/files.py
+++ b/oasislmf/computation/generate/files.py
@@ -64,6 +64,8 @@ class GenerateFiles(ComputationStep):
         {'name': 'lookup_data_dir',            'flag':'-k', 'is_path': True, 'pre_exist': True,  'help': 'Model lookup/keys data directory path'},
         {'name': 'lookup_module_path',         'flag':'-l', 'is_path': True, 'pre_exist': False, 'help': 'Model lookup module path'},
         {'name': 'lookup_complex_config_json', 'flag':'-L', 'is_path': True, 'pre_exist': False, 'help': 'Complex lookup config JSON file path'},
+        {'name': 'lookup_num_processes',       'type':int,  'default': -1,                       'help': 'Number of workers in multiprocess pools'},
+        {'name': 'lookup_num_chunks',          'type':int,  'default': -1,                       'help': 'Number of chunks to split the location file into for multiprocessing'},
         {'name': 'model_version_csv',          'flag':'-v', 'is_path': True, 'pre_exist': False, 'help': 'Model version CSV file path'},
         {'name': 'model_settings_json',        'flag':'-M', 'is_path': True, 'pre_exist': True,  'help': 'Model settings JSON file path'},
         {'name': 'user_data_dir',              'flag':'-D', 'is_path': True, 'pre_exist': False, 'help': 'Directory containing additional model data files which varies between analysis runs'},
@@ -80,6 +82,7 @@ class GenerateFiles(ComputationStep):
         # Manager only options (pass data directy instead of filepaths)
         {'name': 'lookup_config'},
         {'name': 'lookup_complex_config'},
+        {'name': 'lookup_multiprocessing',        'default': True},
         {'name': 'verbose',                       'default': False},
         {'name': 'write_chunksize', 'type':int,   'default': WRITE_CHUNKSIZE},
         {'name': 'oasis_files_prefixes',          'default': OASIS_FILES_PREFIXES},

--- a/oasislmf/computation/generate/keys.py
+++ b/oasislmf/computation/generate/keys.py
@@ -69,6 +69,7 @@ class GenerateKeys(ComputationStep):
         {'name': 'user_data_dir',              'flag':'-D', 'is_path': True, 'pre_exist': False, 'help': 'Directory containing additional model data files which varies between analysis runs'},
 
         # Manager only options
+        {'name': 'verbose',                'default': False},
         {'name': 'lookup_multiprocessing', 'default': True},            # Enable/disable multiprocessing
     ]
 

--- a/oasislmf/computation/generate/keys.py
+++ b/oasislmf/computation/generate/keys.py
@@ -56,15 +56,20 @@ class GenerateKeys(ComputationStep):
 
     step_params = [
         {'name': 'oed_location_csv',           'flag':'-x', 'is_path': True, 'pre_exist': True,  'help': 'Source location CSV file path', 'required': True},
-        {'name': 'keys_data_csv',              'flag':'-k', 'is_path': True, 'pre_exist': False,  'help': 'Generated keys CSV output path'},
-        {'name': 'keys_errors_csv',            'flag':'-e', 'is_path': True, 'pre_exist': False,  'help': 'Generated keys errors CSV output path'},
+        {'name': 'keys_data_csv',              'flag':'-k', 'is_path': True, 'pre_exist': False, 'help': 'Generated keys CSV output path'},
+        {'name': 'keys_errors_csv',            'flag':'-e', 'is_path': True, 'pre_exist': False, 'help': 'Generated keys errors CSV output path'},
         {'name': 'keys_format',                'flag':'-f',  'help': 'Keys files output format', 'choices':['oasis', 'json'], 'default':'oasis'},
         {'name': 'lookup_config_json',         'flag':'-g', 'is_path': True, 'pre_exist': False, 'help': 'Lookup config JSON file path'},
         {'name': 'lookup_data_dir',            'flag':'-d', 'is_path': True, 'pre_exist': True,  'help': 'Model lookup/keys data directory path'},
         {'name': 'lookup_module_path',         'flag':'-l', 'is_path': True, 'pre_exist': False, 'help': 'Model lookup module path'},
         {'name': 'lookup_complex_config_json', 'flag':'-L', 'is_path': True, 'pre_exist': False, 'help': 'Complex lookup config JSON file path'},
+        {'name': 'lookup_num_processes',       'type':int,  'default': -1,                       'help': 'Number of workers in multiprocess pools'},
+        {'name': 'lookup_num_chunks',          'type':int,  'default': -1,                       'help': 'Number of chunks to split the location file into for multiprocessing'},
         {'name': 'model_version_csv',          'flag':'-v', 'is_path': True, 'pre_exist': False, 'help': 'Model version CSV file path'},
         {'name': 'user_data_dir',              'flag':'-D', 'is_path': True, 'pre_exist': False, 'help': 'Directory containing additional model data files which varies between analysis runs'},
+
+        # Manager only options
+        {'name': 'lookup_multiprocessing', 'default': True},            # Enable/disable multiprocessing
     ]
 
 
@@ -111,7 +116,10 @@ class GenerateKeys(ComputationStep):
             successes_fp=keys_fp,
             errors_fp=keys_errors_fp,
             format=self.keys_format,
-            keys_success_msg=keys_success_msg
+            keys_success_msg=keys_success_msg,
+            multiproc_enabled=self.lookup_multiprocessing,
+            multiproc_num_cores=self.lookup_num_processes,
+            multiproc_num_partitions=self.lookup_num_chunks,
         )
         self.logger.info('\nKeys successful: {} generated with {} items'.format(f1, n1))
         self.logger.info('Keys errors: {} generated with {} items'.format(f2, n2))


### PR DESCRIPTION
Added the following flags to the CLI commands: 
* run
* generate-oasis-files
* generate-keys 

`--lookup-num-processes`: Set the number of workers in the multiprocess pool, default is the number of logical cores available 
`--lookup-num-chunks` Set the number of chunks to break the location file into for assignment in the pool, default is 2 chunks per 'num-processes' 
