### PR TITLE
Feature/438 restrict output by eventset

### DIFF
--- a/oasislmf/schema/example_model_settings.json
+++ b/oasislmf/schema/example_model_settings.json
@@ -15,7 +15,9 @@
             {
                "id":"P",
                "desc":"Probabilistic",
-               "valid_occurrence_ids":["1"]
+               "valid_occurrence_ids":["1"],
+               "valid_perspectives": ["gul", "il"],
+               "valid_metrics": ["plt", "elt"]
             },
             {
                "id":"H",

--- a/oasislmf/schema/model_settings.json
+++ b/oasislmf/schema/model_settings.json
@@ -140,6 +140,7 @@
                                     "lec",
                                     "aep",
                                     "oep",
+                                    "summarycalc",
                                     "full_uncertainty_aep",
                                     "full_uncertainty_oep",
                                     "sample_mean_aep",

--- a/oasislmf/schema/model_settings.json
+++ b/oasislmf/schema/model_settings.json
@@ -120,7 +120,6 @@
                               "description":"If set, this event set only supports the given output perspectives. 'gul': ground up losses, 'il': insured losses, 'ri': reinsurance losses.",
                               "items":{
                                  "type":"string",
-                                 "minLength":1,
                                  "enum":[
                                     "gul",
                                     "il",
@@ -134,7 +133,6 @@
                               "description":"If set, this event set only supports the given output metrics, matches the output types set in the summaries section on an `analysis_settings.json` file. Example: 'valid_metrics':['ptl','elt'] means that only valid summary outputs are 'eltcalc' and 'pltcalc'.",
                               "items":{
                                  "type":"string",
-                                 "minLength":1,
                                  "enum":[
                                     "aal", 
                                     "elt", 

--- a/oasislmf/schema/model_settings.json
+++ b/oasislmf/schema/model_settings.json
@@ -114,6 +114,45 @@
                                  "minLength":1
                               }
                            },
+                           "valid_perspectives":{
+                              "type":"array",
+                              "title":"Supported loss perspectives ",
+                              "description":"If set, this event set only supports the given output perspectives. 'gul': ground up losses, 'il': insured losses, 'ri': reinsurance losses.",
+                              "items":{
+                                 "type":"string",
+                                 "minLength":1,
+                                 "enum":[
+                                    "gul",
+                                    "il",
+                                    "ri"
+                                 ]
+                              }
+                           },
+                           "valid_metrics":{
+                              "type":"array",
+                              "title":"Supported output metrics",
+                              "description":"If set, this event set only supports the given output metrics, matches the output types set in the summaries section on an `analysis_settings.json` file. Example: 'valid_metrics':['ptl','elt'] means that only valid summary outputs are 'eltcalc' and 'pltcalc'.",
+                              "items":{
+                                 "type":"string",
+                                 "minLength":1,
+                                 "enum":[
+                                    "aal", 
+                                    "elt", 
+                                    "plt",
+                                    "lec",
+                                    "aep",
+                                    "oep",
+                                    "full_uncertainty_aep",
+                                    "full_uncertainty_oep",
+                                    "sample_mean_aep",
+                                    "sample_mean_oep",
+                                    "wheatsheaf_aep",
+                                    "wheatsheaf_mean_aep",
+                                    "wheatsheaf_mean_oep",
+                                    "wheatsheaf_oep"
+                                 ]
+                              }
+                           },
                            "tooltip":{
                               "type":"string",
                               "title":"UI tooltip",
@@ -867,7 +906,7 @@
                      "name"
                   ]
                }
-            },   
+            },
             "group_fields":{
                "title":"Group OED fields",
                "description":"List of OED fields from location file to form groups",


### PR DESCRIPTION
Update schema for issue: https://github.com/OasisLMF/OasisPlatform/issues/438

Added two new array field options to the `models_settings.json` event set options to indicate which output perspectives and metrics are valid for an event set. If these options are not set, then the default assumption is that everything is valid. 

#### valid_perspectives (Accepted values)
"gul" - ground up losses 
"il" - insurance losses 
"ri" - reinsurance losses 

#### valid_metrics (Accepted values)
"aal" - average annual loss  
"elt" - event loss table
"plt" - period loss table
"lec" - all exceedance curves
"aep" - all aggregate loss curves                                  
"oep" - all occurrence loss curves
"summarycalc" - full sample                                       
"full_uncertainty_aep", 
"full_uncertainty_oep", 
"sample_mean_aep", 
"sample_mean_oep", 
"wheatsheaf_aep", 
"wheatsheaf_mean_aep", 
"wheatsheaf_mean_oep", 
"wheatsheaf_oep" 


#### Example
```
 "model_settings":{
      "event_set":{
         "name":"Event Set",
         "default":"P",
         "desc": "Lists of event sets",
         "options":[
            {   
               "id":"P",
               "desc":"Probabilistic",
               "valid_occurrence_ids":["1"],
               "valid_perspectives": ["gul", "il"],
               "valid_metrics": ["plt", "elt"]
            }
        ]
          ...
```