### PR TITLE
CI fix - cleanup unittests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,9 @@
 .*
 *.egg-info
 *.pyc
+*.hypothesis
+*.__pycache__
+.tox
+.git
 Dockerfile
 tests/model_execution/kparse_output/

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,7 +2,7 @@
 *.egg-info
 *.pyc
 *.hypothesis
-*.__pycache__
+__pycache__
 .tox
 .git
 Dockerfile

--- a/docker/Dockerfile.oasislmf_tester
+++ b/docker/Dockerfile.oasislmf_tester
@@ -6,6 +6,6 @@ RUN  mkdir /tmp/output && \
 RUN apt-get update && apt-get install -y --no-install-recommends \ 
             vim libspatialindex-dev && rm -rf /var/lib/apt/lists/* 
 
-#COPY ./ /home/
 WORKDIR /home
+COPY . .
 CMD ./docker/entrypoint_tester.sh

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -6,7 +6,6 @@ LOG_OUTPUT="$ROOT_DIR"reports
 TAR_OUTPUT="$ROOT_DIR"dist
 
 cd $ROOT_DIR
-find . | grep -E "(__pycache__|\.pyc|\.pyo$)" | xargs rm -rf
 
 if [ ! -d "$LOG_OUTPUT" ]; then
   mkdir "$LOG_OUTPUT"
@@ -27,4 +26,4 @@ else
 fi
 
 docker build --no-cache -f docker/Dockerfile.oasislmf_tester -t oasislmf-tester .
-docker run  --ulimit nofile=8192:8192 -v "$LOG_OUTPUT":/var/log/oasis -v "$ROOT_DIR":/home  oasislmf-tester:"$DOCKER_TAG"
+docker run  --ulimit nofile=8192:8192 -v "$LOG_OUTPUT":/var/log/oasis -v "$TAR_OUTPUT":/home/dist  oasislmf-tester:"$DOCKER_TAG"


### PR DESCRIPTION
* unittests create wasted space in CI, move the generated `.tox` folder into the container's volume which gets cleared via a CRON job 