### PR TITLE
Fix pandas compatibility & non summary map columns issue

### DIFF
--- a/oasislmf/preparation/summaries.py
+++ b/oasislmf/preparation/summaries.py
@@ -186,9 +186,10 @@ def group_by_oed(oed_col_group, summary_map_df, exposure_df, sort_by, accounts_d
     oed_cols = [c.lower() for c in oed_col_group]                                               # All requred columns
     unmapped_cols = [c for c in oed_cols if c not in summary_map_df.columns]                    # columns which in locations / Accounts file
     mapped_cols = [c for c in oed_cols + [SOURCE_IDX['loc'], SOURCE_IDX['acc'], sort_by] if c in summary_map_df.columns]    # Columns already in summary_map_df
+    tiv_cols = ['tiv', 'loc_id', 'coverage_type_id']
 
     # Extract mapped_cols from summary_map_df
-    summary_group_df = summary_map_df.loc[:, mapped_cols]
+    summary_group_df = summary_map_df.loc[:, mapped_cols + tiv_cols]
 
     # Search Loc / Acc files and merge in remaing
     if unmapped_cols is not []:
@@ -207,7 +208,7 @@ def group_by_oed(oed_col_group, summary_map_df, exposure_df, sort_by, accounts_d
     fill_na_with_categoricals(summary_group_df, 0)
     summary_group_df.sort_values(by=[sort_by], inplace=True)
     summary_ids = factorize_dataframe(summary_group_df, by_col_labels=oed_cols)
-    summary_tiv = summary_map_df.drop_duplicates(['loc_id', 'coverage_type_id'] + oed_col_group, keep='first').groupby(oed_col_group).sum('tiv').tiv
+    summary_tiv = summary_group_df.drop_duplicates(['loc_id', 'coverage_type_id'] + oed_col_group, keep='first').groupby(oed_col_group).agg({'tiv': np.sum})
 
     return summary_ids[0], summary_ids[1], summary_tiv
 


### PR DESCRIPTION
### Fix compatibility for pandas
When running with `pandas==1.0.5`

**Error**
```
   summary_tiv = summary_map_df.drop_duplicates(['loc_id', 'coverage_type_id'] + oed_col_group, keep='first').groupby(oed_col_group).sum('tiv').tiv
TypeError: f() takes 1 positional argument but 2 were given

```

### Fix error when selecting columns outside of the summary_map file 

**Example**
```
   "gul_summaries": [                                                                                                                       
        { 
            "oed_fields": ["OccupancyCode", "peril_id"],
            "aalcalc": true,
            "eltcalc": true,
            "id": 1,
        }
```

**Error**
```
  File "/home/sam/repos/venv/py3/lib/python3.8/site-packages/pandas/core/frame.py", line 5248, in duplicated
    raise KeyError(diff)
KeyError: Index(['occupancycode'], dtype='object')

```