### PR TITLE
Feature/key server revamp

### DIFF
--- a/oasislmf/lookup/factory.py
+++ b/oasislmf/lookup/factory.py
@@ -1,34 +1,70 @@
 __all__ = [
-    'OasisLookupFactory'
+    'KeyServerFactory',
+    'BasicKeyServer'
 ]
 
+import copy
 import csv
-import io
 import json
-import itertools
+import os
+import sys
+import types
+import warnings
 
 from collections import OrderedDict
+from contextlib import ExitStack
 
-from multiprocessing import cpu_count
-from billiard import Pool
-
+import math
 import numpy as np
 import pandas as pd
 
-from .base import OasisBaseLookup
-from .rtree import RTreeLookup
-from .interface import OasisLookupInterface
-
+from ..utils.data import get_json, get_location_df
 from ..utils.exceptions import OasisException
-from ..utils.status import OASIS_KEYS_STATUS
+from ..utils.log import oasis_log
 from ..utils.path import get_custom_module, as_path
+from ..utils.status import OASIS_KEYS_STATUS
+
+from .rtree import RTreeLookup, DeterministicLookup
+
+from multiprocessing import cpu_count,  Queue, Process
+from queue import Empty, Full
+
+# add pickling support for traceback object
+import tblib.pickling_support
+tblib.pickling_support.install()
 
 
-class OasisLookupFactory(object):
+def with_error_queue(fct):
+    def wrapped_fct(error_queue, *args, **kwargs):
+        try:
+            return fct(error_queue, *args, **kwargs)
+        except Exception:
+            error_queue.put(sys.exc_info())
+    return wrapped_fct
+
+
+class KeyServerFactory(object):
     """
-    A factory class to load and run keys lookup services for different
-    models/suppliers.
+    A factory class to create the Keys Server that will be use to generate the keys files
+    All Key Server must implement the interface defined in lookup.interface.KeyServerInterface
+
+    Oasis provides a built-in Key Server that manage the generation of the key files from the key provided by
+    a built-in or a custom Key Lookup.
+
+    The factory now return a KeyServer object and not a KeyLookup.
+    The parameter to pass has also been simplified
+    usage of all the below parameter are now deprecated
+      - complex_lookup_config_fp => pass the path to your complex lookup config directly in lookup_config_fg
+      - lookup_module_path => set as key 'lookup_module_path' in the lookup config
+      - model_keys_data_path => set as key 'keys_data_path' in the lookup config
+      - model_version_file_path => set the model information ('supplier_id', 'model_id', 'model_version') directly
+        into the config
     """
+
+    @classmethod
+    def get_config(cls, config_fp):
+        return as_path(os.path.dirname(config_fp), 'config_fp'), get_json(config_fp)
+
     @classmethod
     def get_model_info(cls, model_version_file_path):
         """
@@ -36,123 +72,36 @@ class OasisLookupFactory(object):
         """
         model_version_file_path = as_path(model_version_file_path, 'model_version_file_path', preexists=True, null_is_valid=False)
 
-        with io.open(model_version_file_path, 'r', encoding='utf-8') as f:
+        with open(model_version_file_path, 'r', encoding='utf-8') as f:
             return next(csv.DictReader(
                 f, fieldnames=['supplier_id', 'model_id', 'model_version']
             ))
 
     @classmethod
-    def get_custom_lookup(
-        cls,
-        lookup_module,
-        keys_data_path,
-        model_info,
-        complex_lookup_config_fp=None,
-        user_data_dir=None,
-        output_directory=None
-    ):
-        """
-        Get the keys lookup class instance.
-        """
-        klc = getattr(lookup_module, '{}KeysLookup'.format(model_info['model_id']))
+    def update_deprecated_args(cls, config_dir, config,
+                               complex_lookup_config_fp, model_keys_data_path, model_version_file_path, lookup_module_path):
 
-        if not (complex_lookup_config_fp and output_directory):
-            return klc(
-                keys_data_directory=keys_data_path,
-                supplier=model_info['supplier_id'],
-                model_name=model_info['model_id'],
-                model_version=model_info['model_version']
-            )
-        elif not user_data_dir:
-            return klc(
-                keys_data_directory=keys_data_path,
-                supplier=model_info['supplier_id'],
-                model_name=model_info['model_id'],
-                model_version=model_info['model_version'],
-                complex_lookup_config_fp=complex_lookup_config_fp,
-                output_directory=output_directory
-            )
-        else:
-            return klc(
-                keys_data_directory=keys_data_path,
-                supplier=model_info['supplier_id'],
-                model_name=model_info['model_id'],
-                model_version=model_info['model_version'],
-                complex_lookup_config_fp=complex_lookup_config_fp,
-                user_data_dir=user_data_dir,
-                output_directory=output_directory
-            )
+        if (complex_lookup_config_fp
+                or model_keys_data_path
+                or model_version_file_path
+                or lookup_module_path):
+            warnings.warn('usage of complex_lookup_config_fp, model_keys_data_path, '
+                          'model_version_file_path and lookup_module_path is now deprecated'
+                          'those variables now need to be set in lookup config see (key server documentation)')
 
-    @classmethod
-    def write_oasis_keys_file(cls, records, output_file_path, output_success_msg=False):
-        """
-        Writes an Oasis keys file from an iterable of keys records.
-        """
+        if complex_lookup_config_fp:
+            config_dir, config = cls.get_config(complex_lookup_config_fp)
 
-        if len(records) > 0 and 'model_data' in records[0]:
-            heading_row = OrderedDict([
-                ('loc_id', 'LocID'),
-                ('peril_id', 'PerilID'),
-                ('coverage_type', 'CoverageTypeID'),
-                ('model_data', 'ModelData'),
-            ])
-        else:
-            heading_row = OrderedDict([
-                ('loc_id', 'LocID'),
-                ('peril_id', 'PerilID'),
-                ('coverage_type', 'CoverageTypeID'),
-                ('area_peril_id', 'AreaPerilID'),
-                ('vulnerability_id', 'VulnerabilityID'),
-            ])
-            if output_success_msg:
-                heading_row.update({'message': 'Message'})
+        if model_keys_data_path:
+            config['keys_data_path'] = as_path(model_keys_data_path, 'model_keys_data_path', preexists=True)
 
-        pd.DataFrame(
-            columns=heading_row.keys(),
-            data=[heading_row] + records,
-        ).to_csv(
-            output_file_path,
-            index=False,
-            encoding='utf-8',
-            header=False,
-        )
+        if model_version_file_path:
+            config['model'] = cls.get_model_info(model_version_file_path)
 
-        return output_file_path, len(records)
+        if lookup_module_path:
+            config['lookup_module_path'] = lookup_module_path
 
-    @classmethod
-    def write_oasis_keys_errors_file(cls, records, output_file_path):
-        """
-        Writes an Oasis keys errors file from an iterable of keys records.
-        """
-        heading_row = OrderedDict([
-            ('loc_id', 'LocID'),
-            ('peril_id', 'PerilID'),
-            ('coverage_type', 'CoverageTypeID'),
-            ('status', 'Status'),
-            ('message', 'Message'),
-        ])
-
-        pd.DataFrame(
-            columns=heading_row.keys(),
-            data=[heading_row] + records,
-        ).to_csv(
-            output_file_path,
-            index=False,
-            encoding='utf-8',
-            header=False,
-        )
-
-        return output_file_path, len(records)
-
-    @classmethod
-    def write_json_keys_file(cls, records, output_file_path):
-        """
-        Writes the keys records as a simple list to file.
-        """
-        with io.open(output_file_path, 'w', encoding='utf-8') as f:
-            f.write(u'{}'.format(json.dumps(records, sort_keys=True, indent=4, ensure_ascii=False)))
-
-            return output_file_path, len(records)
+        return config_dir, config
 
     @classmethod
     def create(
@@ -166,7 +115,6 @@ class OasisLookupFactory(object):
         complex_lookup_config_fp=None,
         user_data_dir=None,
         output_directory=None,
-        builtin_lookup_type='combined'
     ):
         """
         Creates a keys lookup class instance for the given model and supplier -
@@ -176,303 +124,408 @@ class OasisLookupFactory(object):
         model information from the model version file and `klc` is the lookup
         service class instance for the model.
         """
-        is_builtin = lookup_config or lookup_config_json or lookup_config_fp
-        is_complex = complex_lookup_config_fp and output_directory
+        if lookup_config:
+            config_dir = '.'
+            config = lookup_config
+        elif lookup_config_json:
+            config_dir = '.'
+            config = json.loads(lookup_config_json)
+        elif lookup_config_fp:
+            config_dir, config = cls.get_config(lookup_config_fp)
+        else: # no config
+            config_dir, config = '.', {}
 
-        if is_builtin:
-            lookup = RTreeLookup(
-                config=lookup_config,
-                config_json=lookup_config_json,
-                config_fp=lookup_config_fp
-            )
-            model_info = lookup.config.get('model')
-            if builtin_lookup_type == 'base':
-                lookup = OasisBuiltinBaseLookup(
-                    config=lookup_config,
-                    config_json=lookup_config_json,
-                    config_fp=lookup_config_fp
-                )
-                return lookup.config.get('model'), lookup
-            elif builtin_lookup_type == 'combined':
-                return model_info, lookup
-            elif builtin_lookup_type == 'peril':
-                return model_info, lookup.peril_lookup
-            elif builtin_lookup_type == 'vulnerability':
-                return model_info, lookup.vulnerability_lookup
+        config_dir, config = cls.update_deprecated_args(config_dir, config,
+                                                        complex_lookup_config_fp, model_keys_data_path,
+                                                        model_version_file_path, lookup_module_path)
+
+        if config.get('key_server_module_path'):
+            _KeyServer = get_custom_module(config.get('key_server_module_path'), 'key_server_module_path')
         else:
-            _model_keys_data_path = as_path(model_keys_data_path, 'model_keys_data_path', preexists=True)
+            _KeyServer = BasicKeyServer
 
-            model_info = cls.get_model_info(model_version_file_path)
-            lookup_module = get_custom_module(lookup_module_path, 'lookup_module_path')
+        if _KeyServer.interface_version == '1':
+            key_server = _KeyServer(config,
+                                    config_dir=config_dir,
+                                    user_data_dir=user_data_dir,
+                                    output_dir=output_directory)
+        else:
+            raise OasisException(f"KeyServer interface version {_KeyServer.interface_version} not implemented")
 
-            if not is_complex:
-                lookup = cls.get_custom_lookup(
-                    lookup_module=lookup_module,
-                    keys_data_path=_model_keys_data_path,
-                    model_info=model_info
+        if complex_lookup_config_fp:
+            key_server.complex_lookup_config_fp = complex_lookup_config_fp
+
+        return config['model'], key_server
+
+
+class BasicKeyServer:
+    """
+    A basic implementation of the KeyServerInterface
+    will load the KeyLookup class from config['lookup_module_path'] if present or used the built-in KeyLookup
+    KeyLookup must implement the KeyLookupInterface
+
+    will provide a multiprocess solution if KeyLoopup implement the process_locations_multiproc method
+
+    both single and multiprocess solutions will use low amount of memory
+    as they process the key by chunk of limited size.
+
+    This class implement all the file writing method that were previously handled by the lookup factory
+    """
+    interface_version = "1"
+
+    valid_format = ['oasis', 'json']
+
+    error_heading_row = OrderedDict([
+        ('loc_id', 'LocID'),
+        ('peril_id', 'PerilID'),
+        ('coverage_type', 'CoverageTypeID'),
+        ('status', 'Status'),
+        ('message', 'Message'),
+    ])
+
+    model_data_heading_row = OrderedDict([
+        ('loc_id', 'LocID'),
+        ('peril_id', 'PerilID'),
+        ('coverage_type', 'CoverageTypeID'),
+        ('model_data', 'ModelData'),
+    ])
+
+    key_success_heading_row = OrderedDict([
+        ('loc_id', 'LocID'),
+        ('peril_id', 'PerilID'),
+        ('coverage_type', 'CoverageTypeID'),
+        ('area_peril_id', 'AreaPerilID'),
+        ('vulnerability_id', 'VulnerabilityID'),
+    ])
+
+    key_success_with_message_heading_row = OrderedDict([
+        ('loc_id', 'LocID'),
+        ('peril_id', 'PerilID'),
+        ('coverage_type', 'CoverageTypeID'),
+        ('area_peril_id', 'AreaPerilID'),
+        ('vulnerability_id', 'VulnerabilityID'),
+        ('message', 'Message')
+    ])
+
+    min_bloc_size = 1000
+    max_bloc_size = 10000
+
+    def __init__(self, config, config_dir=None, user_data_dir=None, output_dir=None):
+        self.config = config
+        self.config_dir = config_dir or '.'
+        self.user_data_dir = user_data_dir
+        self.output_dir = output_dir
+        self.lookup_cls = self.get_lookup_cls()
+
+    def get_lookup_cls(self):
+        if self.config.get('lookup_module_path'): # custom lookup
+            lookup_module = get_custom_module(self.config.get('lookup_module_path'), 'lookup_module_path')
+            lookup_cls = getattr(lookup_module, '{}KeysLookup'.format(self.config['model']['model_id']))
+        else: # built-in lookup
+            if self.config.get('builtin_lookup_type') == 'deterministic':
+                lookup_cls = DeterministicLookup
+            else:
+                lookup_cls = RTreeLookup
+
+        return lookup_cls
+
+    @staticmethod
+    def create_lookup(lookup_cls, config, config_dir, user_data_dir, output_dir, lookup_id):
+        lookup_config = copy.deepcopy(config)
+        lookup_config['lookup_id'] = lookup_id
+        lookup_interface_version = getattr(lookup_cls, 'interface_version', '0')
+        if lookup_interface_version == '1':
+            return lookup_cls(config,
+                              config_dir=config_dir,
+                              user_data_dir=user_data_dir,
+                              output_dir=output_dir)
+        elif lookup_interface_version == '0':
+            warnings.warn('OasisLookupInterface (or OasisBaseKeysLookup) is now deprecated'
+                          ' Interface for lookup is now lookup.interface.LookupInterface'
+                          ' for similar functionality use lookup.base.AbstractBasicKeyLookup'
+                          ' for multiprocess implementation add lookup.base.MultiprocLookupMixin')
+            if not (config and output_dir):
+                return lookup_cls(
+                    keys_data_directory=config.get('keys_data_path'),
+                    supplier=config['model']['supplier_id'],
+                    model_name=config['model']['model_id'],
+                    model_version=config['model']['model_version'],
                 )
-                return model_info, lookup
-
-            _complex_lookup_config_fp = as_path(complex_lookup_config_fp, 'complex_lookup_config_fp', preexists=True)
-            _output_directory = as_path(output_directory, 'output_directory', preexists=True)
-
-            lookup = cls.get_custom_lookup(
-                lookup_module=lookup_module,
-                keys_data_path=_model_keys_data_path,
-                model_info=model_info,
-                complex_lookup_config_fp=_complex_lookup_config_fp,
-                user_data_dir=user_data_dir,
-                output_directory=_output_directory
-            )
-
-            return model_info, lookup
-
-    @classmethod
-    def get_keys_base(
-        cls,
-        lookup,
-        loc_df,
-        success_only=False
-    ):
-        """
-        Used when lookup is an instances of `OasisBaseKeysLookup(object)`
-
-        Generates keys records (JSON) for the given model and supplier -
-        requires an instance of the lookup service (which can be created using
-        the `create` method in this factory class), and either the model
-        location file path or the string contents of such a file.
-
-        The optional keyword argument ``success_only`` indicates whether only
-        records with successful lookups should be returned (default), or all
-        records.
-        """
-        for record in lookup.process_locations(loc_df):
-            if success_only:
-                if record['status'].lower() == OASIS_KEYS_STATUS['success']['id']:
-                    yield record
+            elif not user_data_dir:
+                return lookup_cls(
+                    keys_data_directory=config.get('keys_data_path'),
+                    supplier=config['model']['supplier_id'],
+                    model_name=config['model']['model_id'],
+                    model_version=config['model']['model_version'],
+                    complex_lookup_config_fp=config_dir,
+                    output_directory=output_dir
+                )
             else:
-                yield record
+                return lookup_cls(
+                    keys_data_directory=config.get('keys_data_path'),
+                    supplier=config['model']['supplier_id'],
+                    model_name=config['model']['model_id'],
+                    model_version=config['model']['model_version'],
+                    complex_lookup_config_fp=config_dir,
+                    user_data_dir=user_data_dir,
+                    output_directory=output_dir
+                )
+        else:
+            raise OasisException(f"lookup interface version {lookup_interface_version} not implemented")
 
-    @classmethod
-    def get_keys_builtin(
-        cls,
-        lookup,
-        loc_df,
-        success_only=False
-    ):
-        """
-        Used when lookup is an instances of `OasisBuiltinBaseLookup(object)`
+    def get_locations(self, location_fp):
+        """load exposure data from location_fp and return the exposure dataframe"""
+        return get_location_df(location_fp)
 
-        Generates lookup results (dicts) for the given model and supplier -
-        requires a lookup instance (which can be created using the `create2`
-        method in this factory class), and the source exposures/locations
-        dataframe.
-
-        The optional keyword argument ``success_only`` indicates whether only
-        results with successful lookup status should be returned (default),
-        or all results.
-        """
-        locations = (loc for _, loc in loc_df.iterrows())
-        for result in lookup.bulk_lookup(locations):
-            if success_only:
-                if result['status'].lower() == OASIS_KEYS_STATUS['success']['id']:
-                    yield result
+    @staticmethod
+    @with_error_queue
+    def location_producer(error_queue, loc_df, part_count, loc_queue):
+        loc_ids_parts = np.array_split(np.unique(loc_df['loc_id']), part_count)
+        loc_df_parts = (loc_df[loc_df['loc_id'].isin(loc_ids_parts[i])] for i in range(part_count))
+        loc_df_part = True
+        while loc_df_part is not None:
+            loc_df_part = next(loc_df_parts, None)
+            while error_queue.empty():
+                try:
+                    loc_queue.put(loc_df_part, timeout=5)
+                    break
+                except Full:
+                    pass
             else:
-                yield result
+                return
 
-    @classmethod
-    def get_keys_multiproc(
-        cls,
-        lookup,
-        loc_df,
-        success_only=False,
-        num_cores=-1,
-        num_partitions=-1
-    ):
+    @staticmethod
+    @with_error_queue
+    def lookup_multiproc_worker(error_queue, lookup_cls, config, config_dir, user_data_dir, output_dir, lookup_id, loc_queue, key_queue):
+        lookup = BasicKeyServer.create_lookup(lookup_cls, config, config_dir, user_data_dir, output_dir, lookup_id)
+        while True:
+            while error_queue.empty():
+                try:
+                    loc_df_part = loc_queue.get(timeout=5)
+
+                    break
+                except Empty:
+                    pass
+            else:
+                return
+
+            if loc_df_part is None:
+                loc_queue.put(None)
+                key_queue.put(None)
+                break
+
+            while error_queue.empty():
+                try:
+                    key_queue.put(lookup.process_locations_multiproc(loc_df_part), timeout=5)
+                    break
+                except Full:
+                    pass
+            else:
+                return
+
+    @staticmethod
+    def key_producer(key_queue, error_queue, worker_count):
+        finished_workers = 0
+        while finished_workers < worker_count and error_queue.empty():
+            while error_queue.empty():
+                try:
+                    res = key_queue.get(timeout=5)
+                    break
+                except Empty:
+                    pass
+            else:
+                break
+
+            if res is None:
+                finished_workers+=1
+            else:
+                yield res
+
+    def get_success_heading_row(self, keys, keys_success_msg):
+        if 'model_data' in keys:
+            return self.model_data_heading_row
+        elif keys_success_msg:
+            return self.key_success_with_message_heading_row
+        else:
+            return self.key_success_heading_row
+
+    def write_json_keys_file(self, results, keys_success_msg, successes_fp, errors_fp):
+        # no streaming implementation for json format
+        results = pd.concat((r for r in results if not r.empty))
+
+        success = results['status'] == OASIS_KEYS_STATUS['success']['id']
+        success_df = results[success]
+        success_df.to_json(successes_fp, orient='records', indent=4, force_ascii=False)
+        successes_count = success_df.shape[0]
+        if errors_fp:
+            errors_df = results[~success]
+            errors_df.to_json(errors_fp, orient='records', indent=4, force_ascii=False)
+            error_count = errors_df.shape[0]
+        else:
+            error_count = 0
+        return successes_count, error_count
+
+    def write_oasis_keys_file(self, results, keys_success_msg, successes_fp, errors_fp):
+        with ExitStack() as stack:
+            successes_file = stack.enter_context(open(successes_fp, 'w', encoding='utf-8'))
+            if errors_fp:
+                errors_file = stack.enter_context(open(errors_fp, 'w', encoding='utf-8'))
+                errors_file.write(','.join(self.error_heading_row.values()) + '\n')
+            else:
+                errors_file = None
+            success_heading_row = None
+            successes_count = 0
+            error_count = 0
+            for i, result in enumerate(results):
+                success = result['status'] == OASIS_KEYS_STATUS['success']['id']
+                success_df = result[success]
+                if success_heading_row is None:
+                    success_heading_row = self.get_success_heading_row(result.columns, keys_success_msg)
+                success_df[success_heading_row.keys()].rename(columns=success_heading_row
+                                                                ).to_csv(successes_file, index=False, header=not i)
+                successes_count += success_df.shape[0]
+                if errors_file:
+                    errors_df = result[~success]
+                    errors_df[self.error_heading_row.keys()].rename(columns=self.error_heading_row
+                                                                    ).to_csv(errors_file, index=False, header=False)
+                    error_count += errors_df.shape[0]
+            return successes_count, error_count
+
+    def write_keys_file(self, results, successes_fp, errors_fp, output_format, keys_success_msg):
+        if output_format not in self.valid_format:
+            raise OasisException(f"Unrecognised lookup file output format {output_format} - valid formats are {self.valid_format}")
+
+        write = getattr(self, f'write_{output_format}_keys_file')
+        successes_count, error_count = write(results, keys_success_msg, successes_fp, errors_fp)
+
+        if errors_fp:
+            return successes_fp, successes_count, errors_fp, error_count
+        else:
+            return successes_fp, successes_count
+
+    def generate_key_files_singleproc(self, loc_df, successes_fp, errors_fp, output_format, keys_success_msg, **kwargs):
+        if getattr(self, 'complex_lookup_config_fp', None):  # backward compatibility 1.15 hack
+            config_dir = getattr(self, 'complex_lookup_config_fp', None)
+        else:
+            config_dir = self.config_dir
+        lookup = self.create_lookup(self.lookup_cls, self.config, config_dir, self.user_data_dir, self.output_dir,
+                                    lookup_id=None)
+
+        key_results = lookup.process_locations(loc_df)
+
+        def gen_results(results):
+            if isinstance(results, pd.DataFrame):
+                yield results
+            elif isinstance(results, (list, tuple)):
+                yield pd.DataFrame(results)
+            elif isinstance(results, types.GeneratorType):
+                results_part = pd.DataFrame.from_records(results, nrows=self.max_bloc_size)
+                while not results_part.empty:
+                    yield results_part
+                    results_part = pd.DataFrame.from_records(results, nrows=self.max_bloc_size)
+            else:
+                raise OasisException("Unrecognised type for results: {type(results)}. expected ")
+
+        return self.write_keys_file(gen_results(key_results),
+                                    successes_fp=successes_fp,
+                                    errors_fp=errors_fp,
+                                    output_format=output_format,
+                                    keys_success_msg=keys_success_msg,)
+
+    def generate_key_files_multiproc(self, loc_df, successes_fp, errors_fp, output_format, keys_success_msg,
+                                     num_cores, num_partitions, **kwargs):
         """
-        Used for CPU bound lookup operations, Depends on a method
+        Process and return the lookup results a location row
+        Used in multiprocessing based query
 
-        `process_locations_multiproc(dataframe)`
+        location_row is of type <class 'pandas.core.series.Series'>
 
-        where single_row is a pandas series from a location Pandas DataFrame
-        and returns a list of dicts holding the lookup results for that single row
         """
+        if getattr(self, 'complex_lookup_config_fp', None):  # backward compatibility 1.15 hack
+            config_dir = getattr(self, 'complex_lookup_config_fp', None)
+        else:
+            config_dir = self.config_dir
+
         pool_count = num_cores if num_cores > 0 else cpu_count()
-        part_count = num_partitions if num_partitions > 0 else min(pool_count * 2, len(loc_df))
-        locations = np.array_split(loc_df, part_count)
-
-        pool = Pool(pool_count)
-        results = pool.map(lookup.process_locations_multiproc, locations)
-        lookup_results = sum([r for r in results if r], [])
-        pool.terminate()
-        return lookup_results
-
-    @classmethod
-    def save_keys(
-        cls,
-        keys_data,
-        keys_file_path=None,
-        keys_errors_file_path=None,
-        keys_format='oasis',
-        keys_success_msg=False
-    ):
-        """
-        Writes a keys file, and optionally a keys error file, for the keys
-        generated by the lookup service for the given model, supplier and
-        exposure sfile - requires a lookup service instance (which can be
-        created using the `create` method in this factory class), the path of
-        the model location file, the path of the keys file, and the format of
-        the output file which can be an Oasis keys file (``oasis``) or a
-        simple listing of the records to file (``json``).
-
-        The optional keyword argument ``keys_error_file_path`` if present
-        indicates that all keys records, whether for locations with successful
-        or unsuccessful lookups, will be generated and written to separate
-        files. A keys record with a successful lookup will have a `status`
-        field whose value will be `success`, otherwise the record will have
-        a `status` field value of `failure` or `nomatch`.
-
-        If ``keys_errors_file_path`` is not present then the method returns a
-        pair ``(p, n)`` where ``p`` is the keys file path and ``n`` is the
-        number of "successful" keys records written to the keys file, otherwise
-        it returns a quadruple ``(p1, n1, p2, n2)`` where ``p1`` is the keys
-        file path, ``n1`` is the number of "successful" keys records written to
-        the keys file, ``p2`` is the keys errors file path and ``n2`` is the
-        number of "unsuccessful" keys records written to keys errors file.
-        """
-
-        _keys_file_path = as_path(keys_file_path, 'keys_file_path', preexists=False)
-        _keys_errors_file_path = as_path(keys_errors_file_path, 'keys_errors_file_path', preexists=False)
-
-        successes = []
-        nonsuccesses = []
-        for k in keys_data:
-            successes.append(k) if k['status'] == OASIS_KEYS_STATUS['success']['id'] else nonsuccesses.append(k)
-
-        if keys_format == 'json':
-            if _keys_errors_file_path:
-                fp1, n1 = cls.write_json_keys_file(successes, _keys_file_path)
-                fp2, n2 = cls.write_json_keys_file(nonsuccesses, _keys_errors_file_path)
-
-                return fp1, n1, fp2, n2
-            return cls.write_json_keys_file(successes, _keys_file_path)
-        elif keys_format == 'oasis':
-            if _keys_errors_file_path:
-                fp1, n1 = cls.write_oasis_keys_file(successes, _keys_file_path, keys_success_msg)
-                fp2, n2 = cls.write_oasis_keys_errors_file(nonsuccesses, _keys_errors_file_path)
-
-                return fp1, n1, fp2, n2
-            return cls.write_oasis_keys_file(successes, _keys_file_path, keys_success_msg)
+        if num_partitions > 0:
+            part_count = num_partitions
         else:
-            raise OasisException("Unrecognised keys file output format - valid formats are 'oasis' or 'json'")
+            bloc_size = min(max(math.ceil(loc_df.shape[0] / pool_count), self.min_bloc_size), self.max_bloc_size)
+            part_count = math.ceil(loc_df.shape[0] / bloc_size)
+            pool_count = min(pool_count, part_count)
+        if pool_count <= 1:
+            return self.generate_key_files_singleproc(loc_df, successes_fp, errors_fp, output_format, keys_success_msg)
 
-    @classmethod
-    def check_results(
-        cls,
-        key_results
-    ):
-        """
-        checks that the keys return data is populated
-        """
-        if isinstance(key_results, list):
-            if len(key_results) == 0:
-                return True, None
-            else:
-                return False, key_results
-        else:
-            try:
-                first = next(key_results)
-            except StopIteration:
-                return True, None
-            return False, itertools.chain([first], key_results)
+        loc_queue = Queue(maxsize=pool_count)
+        key_queue = Queue(maxsize=pool_count)
+        error_queue = Queue()
 
-    @classmethod
-    def save_results(
-        cls,
-        lookup,
-        location_df,
-        successes_fp=None,
+        location_producer = Process(target=self.location_producer, args=(error_queue, loc_df, part_count, loc_queue))
+
+        workers = [Process(target=self.lookup_multiproc_worker,
+                           args=(error_queue, self.lookup_cls, self.config, config_dir,
+                                 self.user_data_dir, self.output_dir,
+                                 lookup_id, loc_queue, key_queue))
+                   for lookup_id in range(pool_count)]
+
+        location_producer.start()
+        [worker.start() for worker in workers]
+
+        try:
+            return self.write_keys_file(self.key_producer(key_queue, error_queue, worker_count= pool_count),
+                                        successes_fp=successes_fp,
+                                        errors_fp=errors_fp,
+                                        output_format=output_format,
+                                        keys_success_msg=keys_success_msg,)
+        except Exception:
+            error_queue.put(sys.exc_info())
+        finally:
+            for process in [location_producer] + workers:
+                if process.is_alive():
+                    process.terminate()
+                    process.join()
+            loc_queue.close()
+            key_queue.close()
+            if not error_queue.empty():
+                exc_info = error_queue.get()
+                raise exc_info[0].with_traceback(exc_info[1], exc_info[2])
+
+    @oasis_log()
+    def generate_key_files(
+        self,
+        location_fp,
+        successes_fp,
         errors_fp=None,
-        format='oasis',
+        output_format='oasis',
         keys_success_msg=False,
         multiproc_enabled=True,
         multiproc_num_cores=-1,
         multiproc_num_partitions=-1,
-
+        **kwargs
     ):
         """
-        Writes a keys file, and optionally a keys error file, for the keys
-        generated by the lookup service for the given model, supplier and
-        exposure sfile - requires a lookup service instance (which can be
-        created using the `create` method in this factory class), the path of
-        the model location file, the path of the keys file, and the format of
-        the output file which can be an Oasis keys file (``oasis``) or a
-        simple listing of the records to file (``json``).
-
-        The optional keyword argument ``keys_error_file_path`` if present
-        indicates that all keys records, whether for locations with successful
-        or unsuccessful lookups, will be generated and written to separate
-        files. A keys record with a successful lookup will have a `status`
-        field whose value will be `success`, otherwise the record will have
-        a `status` field value of `failure` or `nomatch`.
-
-        If ``keys_errors_file_path`` is not present then the method returns a
-        pair ``(p, n)`` where ``p`` is the keys file path and ``n`` is the
-        number of "successful" keys records written to the keys file, otherwise
-        it returns a quadruple ``(p1, n1, p2, n2)`` where ``p1`` is the keys
-        file path, ``n1`` is the number of "successful" keys records written to
-        the keys file, ``p2`` is the keys errors file path and ``n2`` is the
-        number of "unsuccessful" keys records written to keys errors file.
+        generate key files by calling:
+        1. get_locations to get a location object from the location_fp
+        2. process_locations or process_locations_multiproc to get results object from the locations object
+        3. write_keys_file to writes the relevant files from the results object
         """
-        sfp = as_path(successes_fp, 'successes_fp', preexists=False)
-        efp = as_path(errors_fp, 'errors_fp', preexists=False)
-        kwargs = {
-            "lookup": lookup,
-            "loc_df": location_df,
-            "success_only": (False if efp else True)
-        }
+        successes_fp = as_path(successes_fp, 'successes_fp', preexists=False)
+        errors_fp = as_path(errors_fp, 'errors_fp', preexists=False)
 
-        # Return the multiproccessed generated (both lookup classes have this method)
-        if (multiproc_enabled and hasattr(lookup, 'process_locations_multiproc')):
-            keys_generator = cls.get_keys_multiproc
-            kwargs['num_cores'] = multiproc_num_cores
-            kwargs['num_partitions'] = multiproc_num_partitions
-        # Return Rtree based method
-        elif isinstance(lookup, (RTreeLookup, OasisBaseLookup)):
-            keys_generator = cls.get_keys_builtin
-        # Return Interface method, same as 'OasisBaseKeysLookup' before refactor
-        elif isinstance(lookup, OasisLookupInterface):
-            keys_generator = cls.get_keys_base
-        # Fallback to trying 'get_keys_base', if that fails raise a error
+        locations = self.get_locations(location_fp)
+
+        if multiproc_enabled and hasattr(self.lookup_cls, 'process_locations_multiproc'):
+            return self.generate_key_files_multiproc(locations,
+                                                     successes_fp=successes_fp,
+                                                     errors_fp=errors_fp,
+                                                     output_format=output_format,
+                                                     keys_success_msg=keys_success_msg,
+                                                     num_cores = multiproc_num_cores,
+                                                     num_partitions = multiproc_num_partitions)
         else:
-            try:
-                keys_generator = cls.get_keys_base
-            except AttributeError:
-                raise OasisException('Unknown lookup class {}, missing default method "cls.get_keys_base"'.format(type(lookup)))
-
-        results_empty, results = cls.check_results(keys_generator(**kwargs))
-        successes = []
-        nonsuccesses = []
-
-        # Todo: Move the inside the keys_generators?  and return a tuple of (successes, nonsuccesses)
-        if results_empty == False:
-            for r in results:
-                successes.append(r) if r['status'] == OASIS_KEYS_STATUS['success']['id'] else nonsuccesses.append(r)
-
-            if format == 'json':
-                if efp:
-                    fp1, n1 = cls.write_json_keys_file(successes, sfp)
-                    fp2, n2 = cls.write_json_keys_file(nonsuccesses, efp)
-                    return fp1, n1, fp2, n2
-                return cls.write_json_keys_file(successes, sfp)
-            elif format == 'oasis':
-                if efp:
-                    fp1, n1 = cls.write_oasis_keys_file(successes, sfp, keys_success_msg)
-                    fp2, n2 = cls.write_oasis_keys_errors_file(nonsuccesses, efp)
-                    return fp1, n1, fp2, n2
-                return cls.write_oasis_keys_file(successes, sfp, keys_success_msg)
-            else:
-                raise OasisException("Unrecognised lookup file output format - valid formats are 'oasis' or 'json'")
-        else: 
-            raise OasisException("No data returned from keys service")
-                    
+            return self.generate_key_files_singleproc(locations,
+                                                      successes_fp=successes_fp,
+                                                      errors_fp=errors_fp,
+                                                      output_format=output_format,
+                                                      keys_success_msg=keys_success_msg,
+                                                      )

--- a/oasislmf/lookup/interface.py
+++ b/oasislmf/lookup/interface.py
@@ -1,4 +1,5 @@
 __all__ = [
+    'KeyServerInterface',
     'OasisLookupInterface',
 ]
 
@@ -6,18 +7,131 @@ __all__ = [
 
 
 import os
+import abc
 
 from ..utils.log import oasis_log
 from ..utils.status import OASIS_KEYS_STATUS
 
-''' Interface class for developing custom lookup code
+
+''' Interface class for developing custom key server or key lookup code
 '''
 
 
-class OasisLookupInterface(object):  # pragma: no cover
+class KeyServerInterface(metaclass=abc.ABCMeta):
+    """
+    Interface to implement to create a KeyServer
+    It define the method to be implemented to be used correctly in lookup.factory.KeyServerFactory
+    all classes must:
+     - specify the version of the interface they use
+     - implement the init method
+     - implement the generate_key_files method
+
+    """
+    interface_version = "1"
+
+    @abc.abstractmethod
+    def __init__(self, config, config_dir, user_data_dir, output_dir):
+        """
+        During the key generation step, the generic factory will call the constructor of the lookup class with the
+        following parameters.
+
+        :param config: contains all the information necessary to run the model
+        :type config: dict
+
+        :param config_dir: path to the model directory, can be used to locate relative path to all the files
+                           that serve as base for the model
+        :type config_dir: str
+
+        :param user_data_dir: Path to additional data necessary for the model that can vary from analysis to analysis
+        :type user_data_dir: str
+
+        :param output_dir: Path to the analysis output directory, can be use to write additional files that are produce
+                           during the keys file generation
+
+        """
+
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def generate_key_files(self,
+                           location_fp,
+                           successes_fp,
+                           errors_fp=None,
+                           output_format='oasis',
+                           keys_success_msg=False,
+                           multiproc_enabled=True,
+                           multiproc_num_cores=-1,
+                           multiproc_num_partitions=-1,
+                           **kwargs):
+        """
+        Writes a keys file, and optionally a keys error file.
+
+        :param location_fp: path to the locations file
+        :type location_fp: str
+
+        :param successes_fp: path to the success keys file
+        :type successes_fp: str
+
+        :param errors_fp: path to the error keys file (optional)
+        :type errors_fp: str
+
+        :param output_format: format of the keys files (oasis or json)
+        :type output_format: str
+
+        :param keys_success_msg: option to write msg for success key
+        :type keys_success_msg: bool
+
+        :param multiproc_enabled: option to run with multiple processor
+        :type multiproc_enabled: bool
+
+        :param multiproc_num_cores: number of cores to use in multiproc mode
+        :type multiproc_num_cores: int
+
+        :param multiproc_num_partitions: number of partition to create in multiproc mode
+        :type multiproc_num_partitions: int
+
+        If ``keys_errors_file_path`` is not present then the method returns a
+        pair ``(p, n)`` where ``p`` is the keys file path and ``n`` is the
+        number of "successful" keys records written to the keys file, otherwise
+        it returns a quadruple ``(p1, n1, p2, n2)`` where ``p1`` is the keys
+        file path, ``n1`` is the number of "successful" keys records written to
+        the keys file, ``p2`` is the keys errors file path and ``n2`` is the
+        number of "unsuccessful" keys records written to keys errors file.
+        """
+        raise NotImplementedError
+
+
+class KeyLookupInterface(metaclass=abc.ABCMeta):
+    """Interface for KeyLookup
+    it define the interface to be used correctly by lookup.factory.BasicKeyServer
+    all classes must:
+     - specify the version of the interface they use
+     - implement the init method
+     - implement the process_location method
+    """
+
+    interface_version = "1"
+
+    @abc.abstractmethod
+    def __init__(self, config, config_dir, user_data_dir, output_dir):
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def process_locations(self, loc_df):
+        """
+        Process location rows - passed in as a pandas dataframe.
+        """
+        raise NotImplementedError
+
+
+class OasisLookupInterface:  # pragma: no cover
     """
     Old Oasis base class -deprecated
+    If you were using this interface, you can make you class inherit from the new abstract class AbstractBasicKeyServer
+    or implement the KeyServerInterface interface
     """
+    interface_version = "0"
+
     @oasis_log()
     def __init__(
         self,

--- a/oasislmf/preparation/lookup.py
+++ b/oasislmf/preparation/lookup.py
@@ -11,7 +11,7 @@ __all__ = [
 ## This is a backwards compatibility file for lookup code based on version 1.9.0 and older
 ## Add deprecated warning, Load equiv classes from ..lookup. * 
 
-from ..lookup.factory import OasisLookupFactory
+from ..lookup.factory import KeyServerFactory as OasisLookupFactory
 from ..lookup.base import OasisBaseLookup as OasisBuiltinBaseLookup
 from ..lookup.interface import OasisLookupInterface as OasisBaseKeysLookup 
 from ..lookup.rtree import RTreeLookup as OasisLookup

--- a/oasislmf/preparation/summaries.py
+++ b/oasislmf/preparation/summaries.py
@@ -256,7 +256,7 @@ def write_summary_levels(exposure_df, accounts_fp, target_dir):
     # GUL perspective (loc columns only)
     #l_col_list = exposure_df.loc[:, exposure_df.any()].columns.to_list()
     # NOTE: work around for pandas==1.2.0, any() not returning return the 'category' field types
-    l_col_list = exposure_df.replace(0, pd.np.nan).dropna(how='any', axis=1).columns.to_list()
+    l_col_list = exposure_df.replace(0, np.nan).dropna(how='any', axis=1).columns.to_list()
 
     l_col_info = get_loc_dtypes()
     for k in list(l_col_info.keys()):

--- a/requirements-package.in
+++ b/requirements-package.in
@@ -1,6 +1,5 @@
 anytree>=2.4.3
 argparsetree>=0.0.5
-billiard>=3.6.0.0
 chainmap
 chardet
 cookiecutter>=1.6.0
@@ -16,4 +15,5 @@ requests-toolbelt
 shapely>=1.6.4.post1
 shutilwhich
 tabulate>=0.8.2
+tblib
 tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,8 +21,6 @@ babel==2.8.0
     # via sphinx
 backcall==0.1.0
     # via ipython
-billiard==3.6.0.0
-    # via -r ./requirements-package.in
 binaryornot==0.4.4
     # via cookiecutter
 certifi==2019.11.28
@@ -221,6 +219,8 @@ sphinxcontrib-qthelp==1.0.2
 sphinxcontrib-serializinghtml==1.1.3
     # via sphinx
 tabulate==0.8.6
+    # via -r ./requirements-package.in
+tblib==1.7.0
     # via -r ./requirements-package.in
 toml==0.10.0
     # via tox


### PR DESCRIPTION
### Revamping of the Key service.
For historical reason, the production of the key files were base on a module "lookup" that needed to return the keys as an iterable of dictionaries.
Although the lookup could be customized by model developer, the processing and the writing of the key file itself was part of Oasis code and therefore not changeable by model developer.
The writing itself was based on the construction of two lists for susses and error keys that could completely fill up the memory.
Finally, for model using dataframe writing the files could in fact be done directly via to_json or to_csv 

With this first part of the work we plan on the Key Generation, our goal is to allow user a total customization of the key service (responsible for the generation on the key files) and also provide an efficient built-in implementation (improving the functionality of the lookup factory) that will satisfy most use cases.

### Lookup Factory and new Key Server Interface
The key files writing process was mainly managed by the Lookup factory. We transfer this role to a new class that we call KeyServer, that will be returned by the factory and customizable in the config via the key 'key_server_module_path'.
The role of the Factory is simply to load the config and create the correct Key Server Object
To work properly, the Key Server class must implement lookup.interface.KeyServerInterface

As we simplified and generalize the lookup interface, some of the parameter passed to the Lookup Factory are now deprecated
  - complex_lookup_config_fp => pass the path to your complex lookup config directly in lookup_config_fg
  - lookup_module_path => set as key 'lookup_module_path' in the lookup config
  - model_keys_data_path => set as key 'keys_data_path' in the lookup config
  - model_version_file_path => set the model information ('supplier_id', 'model_id', 'model_version') directly
    into the config

### BasicKeyServer
this new class is the basic implementation of the Key Server interface provided as a built-in by Oasis.

- It will use built-in or custom KeyLookup to process each Locations.
These KeyLookup object must implement lookup.interface.KeyLookupInterface a merge interface between the now deprecated lookup.interface.OasisLookupInterface and the built-in lookup (for compatibility reason OasisLookupInterface is still supported).
To determine if the lookup to be used is custom or built-in, we check if lookup_module_path is provided in the config dictionary
`if self.config.get('lookup_module_path'):`
- The writing method have been adapted to be able to process the keys by chunk if applicable thus limiting the memory needed.
- It also provide a multiprocessing option that can be used if the KeyLookup has the  process_locations_multiproc method. In most case simply using the mixin class MultiprocLookupMixin should work out of the box.

### Lookup interface
Change have been done to the lookup Interface to be able to merge built-in and custom lookup. The main difference for custom  lookup is in the __init__ method.
The new interface is lookup.interface.KeyLookupInterface also BasicKeyServer still support lookup.interface.OasisLookupInterface 

we provide a mixin method MultiprocLookupMixin that provide the possibility to use multiprocessing in BasicKeyServer.
The only requirement to use this mixin is that the method process_locations always return the same keys for a location.
This should be true for most models.
