### PR TITLE
Fix for output column grouping

### DIFF
--- a/oasislmf/preparation/summaries.py
+++ b/oasislmf/preparation/summaries.py
@@ -189,7 +189,7 @@ def group_by_oed(oed_col_group, summary_map_df, exposure_df, sort_by, accounts_d
     tiv_cols = ['tiv', 'loc_id', 'coverage_type_id']
 
     # Extract mapped_cols from summary_map_df
-    summary_group_df = summary_map_df.loc[:, mapped_cols + tiv_cols]
+    summary_group_df = summary_map_df.loc[:, set(mapped_cols).union(tiv_cols)]
 
     # Search Loc / Acc files and merge in remaing
     if unmapped_cols is not []:


### PR DESCRIPTION
**Example Settings:**
```
    "gul_summaries": [
        {
            "aalcalc": true,
            "eltcalc": true,
            "id": 1,
	    "oed_fields": ["PortNumber", "AccNumber", "LocNumber","coverage_type_id"],
            "lec_output": true,
            "leccalc": {
                "full_uncertainty_aep": true,
                "full_uncertainty_oep": true,
                "return_period_file": true
            }
        }
    ]
```

**Issue:**
 
Fields required for TIV summary info create duplicated rows in the data frame when any of  `['tiv', 'loc_id', 'coverage_type_id']` are selected in the analysis settings file. 
```
ipdb> summary_group_df
    loc_idx  portnumber accnumber    locnumber  coverage_type_id  acc_idx  item_id       tiv  loc_id  coverage_type_id
0         0           1    A11111  10002082046                 1        0        1  220000.0       1                 1
1         0           1    A11111  10002082046                 1        1        1  220000.0       1                 1
2         0           1    A11111  10002082046                 1        0        2  220000.0       1                 1
   ...

```

    