### PR TITLE
Feature/ord integration

### DIFF
--- a/oasislmf/schema/analysis_settings.json
+++ b/oasislmf/schema/analysis_settings.json
@@ -186,7 +186,7 @@
                             },
                             "ept_mean_sample_oep": {
                                 "type": "boolean",
-                                "title": ""EPT - Mean Sample OEP",
+                                "title": "EPT - Mean Sample OEP",
                                 "description": "Exceedance Probability Table (option), when enable this metric is added to the EPT file",
                                 "default": false
                             },

--- a/oasislmf/schema/analysis_settings.json
+++ b/oasislmf/schema/analysis_settings.json
@@ -118,6 +118,109 @@
                                 "default": false
                             }
                         }
+                    },
+                    "ord_output": {
+                        "type": "object",
+                        "title": "ORD output settings",
+                        "description": "",
+                        "properties": {
+                            "elt_sample": {
+                                "type": "boolean",
+                                "title": "SELT",
+                                "description": "Sample Event Loss Table (ORD Output flag)",
+                                "default": false
+                            },
+                            "elt_quantile": {
+                                "type": "boolean",
+                                "title": "QELT",
+                                "description": "Quantile Event Loss Table (ORD Output flag)",
+                                "default": false
+                            },
+                            "elt_moment": {
+                                "type": "boolean",
+                                "title": "MELT",
+                                "description": "Moment Event Loss Table (ORD Output flag)",
+                                "default": false
+                            },
+                            "plt_sample": {
+                                "type": "boolean",
+                                "title": "SPLT",
+                                "description": "Sample Period Loss Table (ORD Output flag)",
+                                "default": false
+                            },
+                            "plt_quantile": {
+                                "type": "boolean",
+                                "title": "QPLT",
+                                "description": "Quantile Period Loss Table (ORD Output flag)",
+                                "default": false
+                            },
+                            "plt_moment": {
+                                "type": "boolean",
+                                "title": "MPLT",
+                                "description": "Moment Period Loss Table (ORD Output flag)",
+                                "default": false
+                            },
+                            "alt_period": {
+                                "type": "boolean",
+                                "title": "PALT",
+                                "description": "Period Average Loss Table (ORD Output flag)",
+                                "default": false
+                            },
+                            "ept_full_uncertainty_aep": {
+                                "type": "boolean",
+                                "title": "EPT - Full Uncertainty AEP",
+                                "description": "Exceedance Probability Table (option), when enable this metric is added to the EPT file",
+                                "default": false
+                            },
+                            "ept_full_uncertainty_oep": {
+                                "type": "boolean",
+                                "title": "EPT - Full Uncertainty OEP",
+                                "description": "Exceedance Probability Table (option), when enable this metric is added to the EPT file",
+                                "default": false
+                            },
+                            "ept_mean_sample_aep": {
+                                "type": "boolean",
+                                "title": "EPT - Mean Sample AEP",
+                                "description": "Exceedance Probability Table (option), when enable this metric is added to the EPT file",
+                                "default": false
+                            },
+                            "ept_mean_sample_oep": {
+                                "type": "boolean",
+                                "title": ""EPT - Mean Sample OEP",
+                                "description": "Exceedance Probability Table (option), when enable this metric is added to the EPT file",
+                                "default": false
+                            },
+                            "ept_per_sample_mean_aep": {
+                                "type": "boolean",
+                                "title": "EPT - Per Sample Mean AEP",
+                                "description": "Exceedance Probability Table (option), when enable this metric is added to the EPT file",
+                                "default": false
+                            },
+                            "ept_per_sample_mean_oep": {
+                                "type": "boolean",
+                                "title": "EPT - Per Sample Mean OEP",
+                                "description": "Exceedance Probability Table (option), when enable this metric is added to the EPT file",
+                                "default": false
+                            },
+                            "psept_aep": {
+                                "type": "boolean",
+                                "title": "PSEPT - Aggregate Loss",
+                                "description": "Per Sample Exceedance Probability Table, (option) when enable this metric is added to the PSEPT file",
+                                "default": false
+                            },
+                            "psept_oep": {
+                                "type": "boolean",
+                                "title": "PSEPT - Occurrence Loss",
+                                "description": "Per Sample Exceedance Probability Table (option), when enable this metric is added to the PSEPT file",
+                                "default": false
+                            },
+                            "return_period_file": {
+                                "type": "boolean",
+                                "title": "ORD Return period file flag",
+                                "description": "If true, a file listing the return periods will be used for EPT and PSEPT files. If false, a default set will be used.",
+                                "default": false
+                            }
+                        }
                     }
                 },
                 "required": [
@@ -173,7 +276,7 @@
             },
             "title": "User set return periods",
             "description": "List of return periods as integers '[10, 100, 1000 .. etc]'"
-        },    
+        },
         "model_settings": {
             "type": "object",
             "title": "Model settings",

--- a/oasislmf/schema/example_model_settings.json
+++ b/oasislmf/schema/example_model_settings.json
@@ -10,7 +10,7 @@
       "event_set":{
          "name":"Event Set",
          "default":"P",
-		 "desc": "Lists of event sets",
+         "desc": "Lists of event sets",
          "options":[
             {
                "id":"P",
@@ -37,6 +37,8 @@
             }
          ]
       },
+      "valid_output_perspectives": ["gul", "il"],
+      "valid_output_metrics": ["ept", "psept"],
       "string_parameters":[
         {
             "name": "option_str",
@@ -51,7 +53,7 @@
             "default": ["str1", "str2"]
         }
       ],
-      "dictionary_parameters":[ 
+      "dictionary_parameters":[
         {
             "name": "dictionary_option",
             "desc": "this Stores .. for ... etc",
@@ -102,8 +104,8 @@
                 "parameter_name_b": ["B_value"],
                 "parameter_name_c": true,
                 "parameter_name_n": {"K1": "V1"}
-            }    
-        },    
+            }
+        },
         {
             "name": "location_dependent_config_option_2",
             "desc": "param group option 2",
@@ -112,8 +114,8 @@
                 "parameter_name_b": ["B_value_2"],
                 "parameter_name_c": false,
                 "parameter_name_n": {"K2": "V2"}
-            }    
-        }    
+            }
+        }
       ],
       "parameter_groups":[
         {
@@ -152,7 +154,7 @@
         "countries": ["UK", "US"],
         "mandatory_fields": ["AreaName", "PostalCode", "OccupancyCode"],
         "additional_assets": [
-            {    
+            {
                "name": "catresponsedata",
                "version": "1.0",
                "path": "model_data/catresponse/"

--- a/oasislmf/schema/model_settings.json
+++ b/oasislmf/schema/model_settings.json
@@ -134,8 +134,8 @@
                               "items":{
                                  "type":"string",
                                  "enum":[
-                                    "aal", 
-                                    "elt", 
+                                    "aal",
+                                    "elt",
                                     "plt",
                                     "lec",
                                     "aep",
@@ -148,7 +148,26 @@
                                     "wheatsheaf_aep",
                                     "wheatsheaf_mean_aep",
                                     "wheatsheaf_mean_oep",
-                                    "wheatsheaf_oep"
+                                    "wheatsheaf_oep",
+
+                                    "ord_output",
+                                    "elt_sample",
+                                    "elt_quantile",
+                                    "elt_moment",   
+                                    "plt_sample",   
+                                    "plt_quantile",   
+                                    "plt_moment",   
+                                    "alt_period",   
+                                    "ept",
+                                    "ept_full_uncertainty_aep",
+                                    "ept_full_uncertainty_oep",
+                                    "ept_mean_sample_aep",
+                                    "ept_mean_sample_oep",
+                                    "ept_per_sample_mean_aep",
+                                    "ept_per_sample_mean_oep",
+                                    "psept",
+                                    "psept_aep",
+                                    "psept_oep"
                                  ]
                               }
                            },
@@ -256,6 +275,63 @@
                   "default",
                   "options"
                ]
+            },
+            "valid_output_perspectives":{
+               "type":"array",
+               "title":"Globally supported loss perspectives",
+               "description":"If set, the model only supports the given output perspectives. This can be overridden per event set using the 'valid_perspectives' field. 'gul': ground up losses, 'il': insured losses, 'ri': reinsurance losses.",
+               "items":{
+                  "type":"string",
+                  "enum":[
+                     "gul",
+                     "il",
+                     "ri"
+                  ]
+               }
+            },
+            "valid_output_metrics":{
+               "type":"array",
+               "title":"Globally supported output metrics",
+               "description":"If set, the model only supports the given output metrics. This can be overridden per event set using the 'valid_metrics' field. Values must match the output options in the summaries section from the `analysis_settings.json` file. Example: 'valid_output_metrics':['ptl','elt'].",
+               "items":{
+                  "type":"string",
+                  "enum":[
+                     "aal",
+                     "elt",
+                     "plt",
+                     "lec",
+                     "aep",
+                     "oep",
+                     "summarycalc",
+                     "full_uncertainty_aep",
+                     "full_uncertainty_oep",
+                     "sample_mean_aep",
+                     "sample_mean_oep",
+                     "wheatsheaf_aep",
+                     "wheatsheaf_mean_aep",
+                     "wheatsheaf_mean_oep",
+                     "wheatsheaf_oep",
+
+                     "ord_output",
+                     "elt_sample",
+                     "elt_quantile",
+                     "elt_moment",   
+                     "plt_sample",   
+                     "plt_quantile",   
+                     "plt_moment",   
+                     "alt_period",   
+                     "ept",
+                     "ept_full_uncertainty_aep",
+                     "ept_full_uncertainty_oep",
+                     "ept_mean_sample_aep",
+                     "ept_mean_sample_oep",
+                     "ept_per_sample_mean_aep",
+                     "ept_per_sample_mean_oep",
+                     "psept",
+                     "psept_aep",
+                     "psept_oep"
+                  ]
+               }
             },
             "string_parameters":{
                "title":"Single string paramters",

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ except ImportError:
     from urllib2 import urlopen, URLError
 
 
-KTOOLS_VERSION = '3.5.1'
+KTOOLS_VERSION = '3.6.0-testing'
 
 SCRIPT_DIR = os.path.abspath(os.path.dirname(__file__))
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ except ImportError:
     from urllib2 import urlopen, URLError
 
 
-KTOOLS_VERSION = '3.6.0-rc1'
+KTOOLS_VERSION = '3.6.0-rc2'
 
 SCRIPT_DIR = os.path.abspath(os.path.dirname(__file__))
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ except ImportError:
     from urllib2 import urlopen, URLError
 
 
-KTOOLS_VERSION = '3.6.0-testing'
+KTOOLS_VERSION = '3.6.0-rc1'
 
 SCRIPT_DIR = os.path.abspath(os.path.dirname(__file__))
 

--- a/tests/model_execution/cov_kparse_reference/analysis_settings_5_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/analysis_settings_5_1_reins_layer_1_partition.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+
+rm -R -f fifo/*
+rm -R -f work/*
+mkdir work/kat/
+
+mkdir work/gul_S1_summaryaalcalc
+mkdir work/il_S1_summaryleccalc
+mkdir work/ri_S1_summaryleccalc
+
+mkfifo fifo/gul_P1
+
+mkfifo fifo/gul_S1_summary_P1
+mkfifo fifo/gul_S1_eltcalc_P1
+mkfifo fifo/gul_S1_summarycalc_P1
+mkfifo fifo/gul_S1_pltcalc_P1
+
+mkfifo fifo/il_P1
+
+mkfifo fifo/il_S1_summary_P1
+
+mkfifo fifo/ri_P1
+
+mkfifo fifo/ri_S1_summary_P1
+
+
+
+# --- Do reinsurance loss computes ---
+
+
+tee < fifo/ri_S1_summary_P1 work/ri_S1_summaryleccalc/P1.bin > /dev/null & pid1=$!
+
+summarycalc -f -p RI_1 -1 fifo/ri_S1_summary_P1 < fifo/ri_P1 &
+
+# --- Do insured loss computes ---
+
+
+tee < fifo/il_S1_summary_P1 work/il_S1_summaryleccalc/P1.bin > /dev/null & pid2=$!
+
+summarycalc -f  -1 fifo/il_S1_summary_P1 < fifo/il_P1 &
+
+# --- Do ground up loss computes ---
+
+eltcalc < fifo/gul_S1_eltcalc_P1 > work/kat/gul_S1_eltcalc_P1 & pid3=$!
+summarycalctocsv < fifo/gul_S1_summarycalc_P1 > work/kat/gul_S1_summarycalc_P1 & pid4=$!
+pltcalc < fifo/gul_S1_pltcalc_P1 > work/kat/gul_S1_pltcalc_P1 & pid5=$!
+
+tee < fifo/gul_S1_summary_P1 fifo/gul_S1_eltcalc_P1 fifo/gul_S1_summarycalc_P1 fifo/gul_S1_pltcalc_P1 work/gul_S1_summaryaalcalc/P1.bin > /dev/null & pid6=$!
+
+summarycalc -g  -1 fifo/gul_S1_summary_P1 < fifo/gul_P1 &
+
+eve 1 1 | getmodel | gulcalc -S0 -L0 -r -c fifo/gul_P1 -i - | fmcalc -a2 | tee fifo/il_P1 | fmcalc -a2 -n -p RI_1 > fifo/ri_P1 &
+
+wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6
+
+
+# --- Do reinsurance loss kats ---
+
+
+# --- Do insured loss kats ---
+
+
+# --- Do ground up loss kats ---
+
+kat -s work/kat/gul_S1_eltcalc_P1 > output/gul_S1_eltcalc.csv & kpid1=$!
+kat work/kat/gul_S1_pltcalc_P1 > output/gul_S1_pltcalc.csv & kpid2=$!
+kat work/kat/gul_S1_summarycalc_P1 > output/gul_S1_summarycalc.csv & kpid3=$!
+wait $kpid1 $kpid2 $kpid3
+
+
+ordleccalc -r -Kri_S1_summaryleccalc -F -f -S -s -M -m -W -w -O output/ri_S1_ept.csv -o output/ri_S1_psept.csv & lpid1=$!
+ordleccalc  -Kil_S1_summaryleccalc -F -S -s -M -m -O output/il_S1_ept.csv & lpid2=$!
+aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv & lpid3=$!
+wait $lpid1 $lpid2 $lpid3
+
+rm -R -f work/*
+rm -R -f fifo/*

--- a/tests/model_execution/cov_kparse_reference/gul_il_ord_ept_psept_2_output_10_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_il_ord_ept_psept_2_output_10_partition.sh
@@ -1,0 +1,467 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+
+rm -R -f fifo/*
+rm -R -f work/*
+mkdir work/kat/
+
+mkdir work/gul_S1_summaryleccalc
+mkdir work/gul_S1_summaryaalcalc
+mkdir work/gul_S2_summaryleccalc
+mkdir work/gul_S2_summaryaalcalc
+mkdir work/il_S1_summaryleccalc
+mkdir work/il_S1_summaryaalcalc
+mkdir work/il_S2_summaryleccalc
+mkdir work/il_S2_summaryaalcalc
+
+mkfifo fifo/gul_P1
+mkfifo fifo/gul_P2
+mkfifo fifo/gul_P3
+mkfifo fifo/gul_P4
+mkfifo fifo/gul_P5
+mkfifo fifo/gul_P6
+mkfifo fifo/gul_P7
+mkfifo fifo/gul_P8
+mkfifo fifo/gul_P9
+mkfifo fifo/gul_P10
+
+mkfifo fifo/gul_S1_summary_P1
+mkfifo fifo/gul_S1_eltcalc_P1
+mkfifo fifo/gul_S1_summarycalc_P1
+mkfifo fifo/gul_S1_pltcalc_P1
+mkfifo fifo/gul_S2_summary_P1
+mkfifo fifo/gul_S2_eltcalc_P1
+mkfifo fifo/gul_S2_summarycalc_P1
+mkfifo fifo/gul_S2_pltcalc_P1
+
+mkfifo fifo/gul_S1_summary_P2
+mkfifo fifo/gul_S1_eltcalc_P2
+mkfifo fifo/gul_S1_summarycalc_P2
+mkfifo fifo/gul_S1_pltcalc_P2
+mkfifo fifo/gul_S2_summary_P2
+mkfifo fifo/gul_S2_eltcalc_P2
+mkfifo fifo/gul_S2_summarycalc_P2
+mkfifo fifo/gul_S2_pltcalc_P2
+
+mkfifo fifo/gul_S1_summary_P3
+mkfifo fifo/gul_S1_eltcalc_P3
+mkfifo fifo/gul_S1_summarycalc_P3
+mkfifo fifo/gul_S1_pltcalc_P3
+mkfifo fifo/gul_S2_summary_P3
+mkfifo fifo/gul_S2_eltcalc_P3
+mkfifo fifo/gul_S2_summarycalc_P3
+mkfifo fifo/gul_S2_pltcalc_P3
+
+mkfifo fifo/gul_S1_summary_P4
+mkfifo fifo/gul_S1_eltcalc_P4
+mkfifo fifo/gul_S1_summarycalc_P4
+mkfifo fifo/gul_S1_pltcalc_P4
+mkfifo fifo/gul_S2_summary_P4
+mkfifo fifo/gul_S2_eltcalc_P4
+mkfifo fifo/gul_S2_summarycalc_P4
+mkfifo fifo/gul_S2_pltcalc_P4
+
+mkfifo fifo/gul_S1_summary_P5
+mkfifo fifo/gul_S1_eltcalc_P5
+mkfifo fifo/gul_S1_summarycalc_P5
+mkfifo fifo/gul_S1_pltcalc_P5
+mkfifo fifo/gul_S2_summary_P5
+mkfifo fifo/gul_S2_eltcalc_P5
+mkfifo fifo/gul_S2_summarycalc_P5
+mkfifo fifo/gul_S2_pltcalc_P5
+
+mkfifo fifo/gul_S1_summary_P6
+mkfifo fifo/gul_S1_eltcalc_P6
+mkfifo fifo/gul_S1_summarycalc_P6
+mkfifo fifo/gul_S1_pltcalc_P6
+mkfifo fifo/gul_S2_summary_P6
+mkfifo fifo/gul_S2_eltcalc_P6
+mkfifo fifo/gul_S2_summarycalc_P6
+mkfifo fifo/gul_S2_pltcalc_P6
+
+mkfifo fifo/gul_S1_summary_P7
+mkfifo fifo/gul_S1_eltcalc_P7
+mkfifo fifo/gul_S1_summarycalc_P7
+mkfifo fifo/gul_S1_pltcalc_P7
+mkfifo fifo/gul_S2_summary_P7
+mkfifo fifo/gul_S2_eltcalc_P7
+mkfifo fifo/gul_S2_summarycalc_P7
+mkfifo fifo/gul_S2_pltcalc_P7
+
+mkfifo fifo/gul_S1_summary_P8
+mkfifo fifo/gul_S1_eltcalc_P8
+mkfifo fifo/gul_S1_summarycalc_P8
+mkfifo fifo/gul_S1_pltcalc_P8
+mkfifo fifo/gul_S2_summary_P8
+mkfifo fifo/gul_S2_eltcalc_P8
+mkfifo fifo/gul_S2_summarycalc_P8
+mkfifo fifo/gul_S2_pltcalc_P8
+
+mkfifo fifo/gul_S1_summary_P9
+mkfifo fifo/gul_S1_eltcalc_P9
+mkfifo fifo/gul_S1_summarycalc_P9
+mkfifo fifo/gul_S1_pltcalc_P9
+mkfifo fifo/gul_S2_summary_P9
+mkfifo fifo/gul_S2_eltcalc_P9
+mkfifo fifo/gul_S2_summarycalc_P9
+mkfifo fifo/gul_S2_pltcalc_P9
+
+mkfifo fifo/gul_S1_summary_P10
+mkfifo fifo/gul_S1_eltcalc_P10
+mkfifo fifo/gul_S1_summarycalc_P10
+mkfifo fifo/gul_S1_pltcalc_P10
+mkfifo fifo/gul_S2_summary_P10
+mkfifo fifo/gul_S2_eltcalc_P10
+mkfifo fifo/gul_S2_summarycalc_P10
+mkfifo fifo/gul_S2_pltcalc_P10
+
+mkfifo fifo/il_P1
+mkfifo fifo/il_P2
+mkfifo fifo/il_P3
+mkfifo fifo/il_P4
+mkfifo fifo/il_P5
+mkfifo fifo/il_P6
+mkfifo fifo/il_P7
+mkfifo fifo/il_P8
+mkfifo fifo/il_P9
+mkfifo fifo/il_P10
+
+mkfifo fifo/il_S1_summary_P1
+mkfifo fifo/il_S1_eltcalc_P1
+mkfifo fifo/il_S1_summarycalc_P1
+mkfifo fifo/il_S1_pltcalc_P1
+mkfifo fifo/il_S2_summary_P1
+mkfifo fifo/il_S2_eltcalc_P1
+mkfifo fifo/il_S2_summarycalc_P1
+mkfifo fifo/il_S2_pltcalc_P1
+
+mkfifo fifo/il_S1_summary_P2
+mkfifo fifo/il_S1_eltcalc_P2
+mkfifo fifo/il_S1_summarycalc_P2
+mkfifo fifo/il_S1_pltcalc_P2
+mkfifo fifo/il_S2_summary_P2
+mkfifo fifo/il_S2_eltcalc_P2
+mkfifo fifo/il_S2_summarycalc_P2
+mkfifo fifo/il_S2_pltcalc_P2
+
+mkfifo fifo/il_S1_summary_P3
+mkfifo fifo/il_S1_eltcalc_P3
+mkfifo fifo/il_S1_summarycalc_P3
+mkfifo fifo/il_S1_pltcalc_P3
+mkfifo fifo/il_S2_summary_P3
+mkfifo fifo/il_S2_eltcalc_P3
+mkfifo fifo/il_S2_summarycalc_P3
+mkfifo fifo/il_S2_pltcalc_P3
+
+mkfifo fifo/il_S1_summary_P4
+mkfifo fifo/il_S1_eltcalc_P4
+mkfifo fifo/il_S1_summarycalc_P4
+mkfifo fifo/il_S1_pltcalc_P4
+mkfifo fifo/il_S2_summary_P4
+mkfifo fifo/il_S2_eltcalc_P4
+mkfifo fifo/il_S2_summarycalc_P4
+mkfifo fifo/il_S2_pltcalc_P4
+
+mkfifo fifo/il_S1_summary_P5
+mkfifo fifo/il_S1_eltcalc_P5
+mkfifo fifo/il_S1_summarycalc_P5
+mkfifo fifo/il_S1_pltcalc_P5
+mkfifo fifo/il_S2_summary_P5
+mkfifo fifo/il_S2_eltcalc_P5
+mkfifo fifo/il_S2_summarycalc_P5
+mkfifo fifo/il_S2_pltcalc_P5
+
+mkfifo fifo/il_S1_summary_P6
+mkfifo fifo/il_S1_eltcalc_P6
+mkfifo fifo/il_S1_summarycalc_P6
+mkfifo fifo/il_S1_pltcalc_P6
+mkfifo fifo/il_S2_summary_P6
+mkfifo fifo/il_S2_eltcalc_P6
+mkfifo fifo/il_S2_summarycalc_P6
+mkfifo fifo/il_S2_pltcalc_P6
+
+mkfifo fifo/il_S1_summary_P7
+mkfifo fifo/il_S1_eltcalc_P7
+mkfifo fifo/il_S1_summarycalc_P7
+mkfifo fifo/il_S1_pltcalc_P7
+mkfifo fifo/il_S2_summary_P7
+mkfifo fifo/il_S2_eltcalc_P7
+mkfifo fifo/il_S2_summarycalc_P7
+mkfifo fifo/il_S2_pltcalc_P7
+
+mkfifo fifo/il_S1_summary_P8
+mkfifo fifo/il_S1_eltcalc_P8
+mkfifo fifo/il_S1_summarycalc_P8
+mkfifo fifo/il_S1_pltcalc_P8
+mkfifo fifo/il_S2_summary_P8
+mkfifo fifo/il_S2_eltcalc_P8
+mkfifo fifo/il_S2_summarycalc_P8
+mkfifo fifo/il_S2_pltcalc_P8
+
+mkfifo fifo/il_S1_summary_P9
+mkfifo fifo/il_S1_eltcalc_P9
+mkfifo fifo/il_S1_summarycalc_P9
+mkfifo fifo/il_S1_pltcalc_P9
+mkfifo fifo/il_S2_summary_P9
+mkfifo fifo/il_S2_eltcalc_P9
+mkfifo fifo/il_S2_summarycalc_P9
+mkfifo fifo/il_S2_pltcalc_P9
+
+mkfifo fifo/il_S1_summary_P10
+mkfifo fifo/il_S1_eltcalc_P10
+mkfifo fifo/il_S1_summarycalc_P10
+mkfifo fifo/il_S1_pltcalc_P10
+mkfifo fifo/il_S2_summary_P10
+mkfifo fifo/il_S2_eltcalc_P10
+mkfifo fifo/il_S2_summarycalc_P10
+mkfifo fifo/il_S2_pltcalc_P10
+
+
+
+# --- Do insured loss computes ---
+
+eltcalc < fifo/il_S1_eltcalc_P1 > work/kat/il_S1_eltcalc_P1 & pid1=$!
+summarycalctocsv < fifo/il_S1_summarycalc_P1 > work/kat/il_S1_summarycalc_P1 & pid2=$!
+pltcalc < fifo/il_S1_pltcalc_P1 > work/kat/il_S1_pltcalc_P1 & pid3=$!
+eltcalc < fifo/il_S2_eltcalc_P1 > work/kat/il_S2_eltcalc_P1 & pid4=$!
+summarycalctocsv < fifo/il_S2_summarycalc_P1 > work/kat/il_S2_summarycalc_P1 & pid5=$!
+pltcalc < fifo/il_S2_pltcalc_P1 > work/kat/il_S2_pltcalc_P1 & pid6=$!
+eltcalc -s < fifo/il_S1_eltcalc_P2 > work/kat/il_S1_eltcalc_P2 & pid7=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P2 > work/kat/il_S1_summarycalc_P2 & pid8=$!
+pltcalc -s < fifo/il_S1_pltcalc_P2 > work/kat/il_S1_pltcalc_P2 & pid9=$!
+eltcalc -s < fifo/il_S2_eltcalc_P2 > work/kat/il_S2_eltcalc_P2 & pid10=$!
+summarycalctocsv -s < fifo/il_S2_summarycalc_P2 > work/kat/il_S2_summarycalc_P2 & pid11=$!
+pltcalc -s < fifo/il_S2_pltcalc_P2 > work/kat/il_S2_pltcalc_P2 & pid12=$!
+eltcalc -s < fifo/il_S1_eltcalc_P3 > work/kat/il_S1_eltcalc_P3 & pid13=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P3 > work/kat/il_S1_summarycalc_P3 & pid14=$!
+pltcalc -s < fifo/il_S1_pltcalc_P3 > work/kat/il_S1_pltcalc_P3 & pid15=$!
+eltcalc -s < fifo/il_S2_eltcalc_P3 > work/kat/il_S2_eltcalc_P3 & pid16=$!
+summarycalctocsv -s < fifo/il_S2_summarycalc_P3 > work/kat/il_S2_summarycalc_P3 & pid17=$!
+pltcalc -s < fifo/il_S2_pltcalc_P3 > work/kat/il_S2_pltcalc_P3 & pid18=$!
+eltcalc -s < fifo/il_S1_eltcalc_P4 > work/kat/il_S1_eltcalc_P4 & pid19=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P4 > work/kat/il_S1_summarycalc_P4 & pid20=$!
+pltcalc -s < fifo/il_S1_pltcalc_P4 > work/kat/il_S1_pltcalc_P4 & pid21=$!
+eltcalc -s < fifo/il_S2_eltcalc_P4 > work/kat/il_S2_eltcalc_P4 & pid22=$!
+summarycalctocsv -s < fifo/il_S2_summarycalc_P4 > work/kat/il_S2_summarycalc_P4 & pid23=$!
+pltcalc -s < fifo/il_S2_pltcalc_P4 > work/kat/il_S2_pltcalc_P4 & pid24=$!
+eltcalc -s < fifo/il_S1_eltcalc_P5 > work/kat/il_S1_eltcalc_P5 & pid25=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P5 > work/kat/il_S1_summarycalc_P5 & pid26=$!
+pltcalc -s < fifo/il_S1_pltcalc_P5 > work/kat/il_S1_pltcalc_P5 & pid27=$!
+eltcalc -s < fifo/il_S2_eltcalc_P5 > work/kat/il_S2_eltcalc_P5 & pid28=$!
+summarycalctocsv -s < fifo/il_S2_summarycalc_P5 > work/kat/il_S2_summarycalc_P5 & pid29=$!
+pltcalc -s < fifo/il_S2_pltcalc_P5 > work/kat/il_S2_pltcalc_P5 & pid30=$!
+eltcalc -s < fifo/il_S1_eltcalc_P6 > work/kat/il_S1_eltcalc_P6 & pid31=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P6 > work/kat/il_S1_summarycalc_P6 & pid32=$!
+pltcalc -s < fifo/il_S1_pltcalc_P6 > work/kat/il_S1_pltcalc_P6 & pid33=$!
+eltcalc -s < fifo/il_S2_eltcalc_P6 > work/kat/il_S2_eltcalc_P6 & pid34=$!
+summarycalctocsv -s < fifo/il_S2_summarycalc_P6 > work/kat/il_S2_summarycalc_P6 & pid35=$!
+pltcalc -s < fifo/il_S2_pltcalc_P6 > work/kat/il_S2_pltcalc_P6 & pid36=$!
+eltcalc -s < fifo/il_S1_eltcalc_P7 > work/kat/il_S1_eltcalc_P7 & pid37=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P7 > work/kat/il_S1_summarycalc_P7 & pid38=$!
+pltcalc -s < fifo/il_S1_pltcalc_P7 > work/kat/il_S1_pltcalc_P7 & pid39=$!
+eltcalc -s < fifo/il_S2_eltcalc_P7 > work/kat/il_S2_eltcalc_P7 & pid40=$!
+summarycalctocsv -s < fifo/il_S2_summarycalc_P7 > work/kat/il_S2_summarycalc_P7 & pid41=$!
+pltcalc -s < fifo/il_S2_pltcalc_P7 > work/kat/il_S2_pltcalc_P7 & pid42=$!
+eltcalc -s < fifo/il_S1_eltcalc_P8 > work/kat/il_S1_eltcalc_P8 & pid43=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P8 > work/kat/il_S1_summarycalc_P8 & pid44=$!
+pltcalc -s < fifo/il_S1_pltcalc_P8 > work/kat/il_S1_pltcalc_P8 & pid45=$!
+eltcalc -s < fifo/il_S2_eltcalc_P8 > work/kat/il_S2_eltcalc_P8 & pid46=$!
+summarycalctocsv -s < fifo/il_S2_summarycalc_P8 > work/kat/il_S2_summarycalc_P8 & pid47=$!
+pltcalc -s < fifo/il_S2_pltcalc_P8 > work/kat/il_S2_pltcalc_P8 & pid48=$!
+eltcalc -s < fifo/il_S1_eltcalc_P9 > work/kat/il_S1_eltcalc_P9 & pid49=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P9 > work/kat/il_S1_summarycalc_P9 & pid50=$!
+pltcalc -s < fifo/il_S1_pltcalc_P9 > work/kat/il_S1_pltcalc_P9 & pid51=$!
+eltcalc -s < fifo/il_S2_eltcalc_P9 > work/kat/il_S2_eltcalc_P9 & pid52=$!
+summarycalctocsv -s < fifo/il_S2_summarycalc_P9 > work/kat/il_S2_summarycalc_P9 & pid53=$!
+pltcalc -s < fifo/il_S2_pltcalc_P9 > work/kat/il_S2_pltcalc_P9 & pid54=$!
+eltcalc -s < fifo/il_S1_eltcalc_P10 > work/kat/il_S1_eltcalc_P10 & pid55=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P10 > work/kat/il_S1_summarycalc_P10 & pid56=$!
+pltcalc -s < fifo/il_S1_pltcalc_P10 > work/kat/il_S1_pltcalc_P10 & pid57=$!
+eltcalc -s < fifo/il_S2_eltcalc_P10 > work/kat/il_S2_eltcalc_P10 & pid58=$!
+summarycalctocsv -s < fifo/il_S2_summarycalc_P10 > work/kat/il_S2_summarycalc_P10 & pid59=$!
+pltcalc -s < fifo/il_S2_pltcalc_P10 > work/kat/il_S2_pltcalc_P10 & pid60=$!
+
+tee < fifo/il_S1_summary_P1 fifo/il_S1_eltcalc_P1 fifo/il_S1_summarycalc_P1 fifo/il_S1_pltcalc_P1 work/il_S1_summaryaalcalc/P1.bin work/il_S1_summaryleccalc/P1.bin > /dev/null & pid61=$!
+tee < fifo/il_S2_summary_P1 fifo/il_S2_eltcalc_P1 fifo/il_S2_summarycalc_P1 fifo/il_S2_pltcalc_P1 work/il_S2_summaryaalcalc/P1.bin work/il_S2_summaryleccalc/P1.bin > /dev/null & pid62=$!
+tee < fifo/il_S1_summary_P2 fifo/il_S1_eltcalc_P2 fifo/il_S1_summarycalc_P2 fifo/il_S1_pltcalc_P2 work/il_S1_summaryaalcalc/P2.bin work/il_S1_summaryleccalc/P2.bin > /dev/null & pid63=$!
+tee < fifo/il_S2_summary_P2 fifo/il_S2_eltcalc_P2 fifo/il_S2_summarycalc_P2 fifo/il_S2_pltcalc_P2 work/il_S2_summaryaalcalc/P2.bin work/il_S2_summaryleccalc/P2.bin > /dev/null & pid64=$!
+tee < fifo/il_S1_summary_P3 fifo/il_S1_eltcalc_P3 fifo/il_S1_summarycalc_P3 fifo/il_S1_pltcalc_P3 work/il_S1_summaryaalcalc/P3.bin work/il_S1_summaryleccalc/P3.bin > /dev/null & pid65=$!
+tee < fifo/il_S2_summary_P3 fifo/il_S2_eltcalc_P3 fifo/il_S2_summarycalc_P3 fifo/il_S2_pltcalc_P3 work/il_S2_summaryaalcalc/P3.bin work/il_S2_summaryleccalc/P3.bin > /dev/null & pid66=$!
+tee < fifo/il_S1_summary_P4 fifo/il_S1_eltcalc_P4 fifo/il_S1_summarycalc_P4 fifo/il_S1_pltcalc_P4 work/il_S1_summaryaalcalc/P4.bin work/il_S1_summaryleccalc/P4.bin > /dev/null & pid67=$!
+tee < fifo/il_S2_summary_P4 fifo/il_S2_eltcalc_P4 fifo/il_S2_summarycalc_P4 fifo/il_S2_pltcalc_P4 work/il_S2_summaryaalcalc/P4.bin work/il_S2_summaryleccalc/P4.bin > /dev/null & pid68=$!
+tee < fifo/il_S1_summary_P5 fifo/il_S1_eltcalc_P5 fifo/il_S1_summarycalc_P5 fifo/il_S1_pltcalc_P5 work/il_S1_summaryaalcalc/P5.bin work/il_S1_summaryleccalc/P5.bin > /dev/null & pid69=$!
+tee < fifo/il_S2_summary_P5 fifo/il_S2_eltcalc_P5 fifo/il_S2_summarycalc_P5 fifo/il_S2_pltcalc_P5 work/il_S2_summaryaalcalc/P5.bin work/il_S2_summaryleccalc/P5.bin > /dev/null & pid70=$!
+tee < fifo/il_S1_summary_P6 fifo/il_S1_eltcalc_P6 fifo/il_S1_summarycalc_P6 fifo/il_S1_pltcalc_P6 work/il_S1_summaryaalcalc/P6.bin work/il_S1_summaryleccalc/P6.bin > /dev/null & pid71=$!
+tee < fifo/il_S2_summary_P6 fifo/il_S2_eltcalc_P6 fifo/il_S2_summarycalc_P6 fifo/il_S2_pltcalc_P6 work/il_S2_summaryaalcalc/P6.bin work/il_S2_summaryleccalc/P6.bin > /dev/null & pid72=$!
+tee < fifo/il_S1_summary_P7 fifo/il_S1_eltcalc_P7 fifo/il_S1_summarycalc_P7 fifo/il_S1_pltcalc_P7 work/il_S1_summaryaalcalc/P7.bin work/il_S1_summaryleccalc/P7.bin > /dev/null & pid73=$!
+tee < fifo/il_S2_summary_P7 fifo/il_S2_eltcalc_P7 fifo/il_S2_summarycalc_P7 fifo/il_S2_pltcalc_P7 work/il_S2_summaryaalcalc/P7.bin work/il_S2_summaryleccalc/P7.bin > /dev/null & pid74=$!
+tee < fifo/il_S1_summary_P8 fifo/il_S1_eltcalc_P8 fifo/il_S1_summarycalc_P8 fifo/il_S1_pltcalc_P8 work/il_S1_summaryaalcalc/P8.bin work/il_S1_summaryleccalc/P8.bin > /dev/null & pid75=$!
+tee < fifo/il_S2_summary_P8 fifo/il_S2_eltcalc_P8 fifo/il_S2_summarycalc_P8 fifo/il_S2_pltcalc_P8 work/il_S2_summaryaalcalc/P8.bin work/il_S2_summaryleccalc/P8.bin > /dev/null & pid76=$!
+tee < fifo/il_S1_summary_P9 fifo/il_S1_eltcalc_P9 fifo/il_S1_summarycalc_P9 fifo/il_S1_pltcalc_P9 work/il_S1_summaryaalcalc/P9.bin work/il_S1_summaryleccalc/P9.bin > /dev/null & pid77=$!
+tee < fifo/il_S2_summary_P9 fifo/il_S2_eltcalc_P9 fifo/il_S2_summarycalc_P9 fifo/il_S2_pltcalc_P9 work/il_S2_summaryaalcalc/P9.bin work/il_S2_summaryleccalc/P9.bin > /dev/null & pid78=$!
+tee < fifo/il_S1_summary_P10 fifo/il_S1_eltcalc_P10 fifo/il_S1_summarycalc_P10 fifo/il_S1_pltcalc_P10 work/il_S1_summaryaalcalc/P10.bin work/il_S1_summaryleccalc/P10.bin > /dev/null & pid79=$!
+tee < fifo/il_S2_summary_P10 fifo/il_S2_eltcalc_P10 fifo/il_S2_summarycalc_P10 fifo/il_S2_pltcalc_P10 work/il_S2_summaryaalcalc/P10.bin work/il_S2_summaryleccalc/P10.bin > /dev/null & pid80=$!
+
+summarycalc -f  -1 fifo/il_S1_summary_P1 -2 fifo/il_S2_summary_P1 < fifo/il_P1 &
+summarycalc -f  -1 fifo/il_S1_summary_P2 -2 fifo/il_S2_summary_P2 < fifo/il_P2 &
+summarycalc -f  -1 fifo/il_S1_summary_P3 -2 fifo/il_S2_summary_P3 < fifo/il_P3 &
+summarycalc -f  -1 fifo/il_S1_summary_P4 -2 fifo/il_S2_summary_P4 < fifo/il_P4 &
+summarycalc -f  -1 fifo/il_S1_summary_P5 -2 fifo/il_S2_summary_P5 < fifo/il_P5 &
+summarycalc -f  -1 fifo/il_S1_summary_P6 -2 fifo/il_S2_summary_P6 < fifo/il_P6 &
+summarycalc -f  -1 fifo/il_S1_summary_P7 -2 fifo/il_S2_summary_P7 < fifo/il_P7 &
+summarycalc -f  -1 fifo/il_S1_summary_P8 -2 fifo/il_S2_summary_P8 < fifo/il_P8 &
+summarycalc -f  -1 fifo/il_S1_summary_P9 -2 fifo/il_S2_summary_P9 < fifo/il_P9 &
+summarycalc -f  -1 fifo/il_S1_summary_P10 -2 fifo/il_S2_summary_P10 < fifo/il_P10 &
+
+# --- Do ground up loss computes ---
+
+eltcalc < fifo/gul_S1_eltcalc_P1 > work/kat/gul_S1_eltcalc_P1 & pid81=$!
+summarycalctocsv < fifo/gul_S1_summarycalc_P1 > work/kat/gul_S1_summarycalc_P1 & pid82=$!
+pltcalc < fifo/gul_S1_pltcalc_P1 > work/kat/gul_S1_pltcalc_P1 & pid83=$!
+eltcalc < fifo/gul_S2_eltcalc_P1 > work/kat/gul_S2_eltcalc_P1 & pid84=$!
+summarycalctocsv < fifo/gul_S2_summarycalc_P1 > work/kat/gul_S2_summarycalc_P1 & pid85=$!
+pltcalc < fifo/gul_S2_pltcalc_P1 > work/kat/gul_S2_pltcalc_P1 & pid86=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P2 > work/kat/gul_S1_eltcalc_P2 & pid87=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P2 > work/kat/gul_S1_summarycalc_P2 & pid88=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P2 > work/kat/gul_S1_pltcalc_P2 & pid89=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P2 > work/kat/gul_S2_eltcalc_P2 & pid90=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P2 > work/kat/gul_S2_summarycalc_P2 & pid91=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P2 > work/kat/gul_S2_pltcalc_P2 & pid92=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P3 > work/kat/gul_S1_eltcalc_P3 & pid93=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P3 > work/kat/gul_S1_summarycalc_P3 & pid94=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P3 > work/kat/gul_S1_pltcalc_P3 & pid95=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P3 > work/kat/gul_S2_eltcalc_P3 & pid96=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P3 > work/kat/gul_S2_summarycalc_P3 & pid97=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P3 > work/kat/gul_S2_pltcalc_P3 & pid98=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P4 > work/kat/gul_S1_eltcalc_P4 & pid99=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P4 > work/kat/gul_S1_summarycalc_P4 & pid100=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P4 > work/kat/gul_S1_pltcalc_P4 & pid101=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P4 > work/kat/gul_S2_eltcalc_P4 & pid102=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P4 > work/kat/gul_S2_summarycalc_P4 & pid103=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P4 > work/kat/gul_S2_pltcalc_P4 & pid104=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P5 > work/kat/gul_S1_eltcalc_P5 & pid105=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P5 > work/kat/gul_S1_summarycalc_P5 & pid106=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P5 > work/kat/gul_S1_pltcalc_P5 & pid107=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P5 > work/kat/gul_S2_eltcalc_P5 & pid108=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P5 > work/kat/gul_S2_summarycalc_P5 & pid109=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P5 > work/kat/gul_S2_pltcalc_P5 & pid110=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P6 > work/kat/gul_S1_eltcalc_P6 & pid111=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P6 > work/kat/gul_S1_summarycalc_P6 & pid112=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P6 > work/kat/gul_S1_pltcalc_P6 & pid113=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P6 > work/kat/gul_S2_eltcalc_P6 & pid114=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P6 > work/kat/gul_S2_summarycalc_P6 & pid115=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P6 > work/kat/gul_S2_pltcalc_P6 & pid116=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P7 > work/kat/gul_S1_eltcalc_P7 & pid117=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P7 > work/kat/gul_S1_summarycalc_P7 & pid118=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P7 > work/kat/gul_S1_pltcalc_P7 & pid119=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P7 > work/kat/gul_S2_eltcalc_P7 & pid120=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P7 > work/kat/gul_S2_summarycalc_P7 & pid121=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P7 > work/kat/gul_S2_pltcalc_P7 & pid122=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P8 > work/kat/gul_S1_eltcalc_P8 & pid123=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P8 > work/kat/gul_S1_summarycalc_P8 & pid124=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P8 > work/kat/gul_S1_pltcalc_P8 & pid125=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P8 > work/kat/gul_S2_eltcalc_P8 & pid126=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P8 > work/kat/gul_S2_summarycalc_P8 & pid127=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P8 > work/kat/gul_S2_pltcalc_P8 & pid128=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P9 > work/kat/gul_S1_eltcalc_P9 & pid129=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P9 > work/kat/gul_S1_summarycalc_P9 & pid130=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P9 > work/kat/gul_S1_pltcalc_P9 & pid131=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P9 > work/kat/gul_S2_eltcalc_P9 & pid132=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P9 > work/kat/gul_S2_summarycalc_P9 & pid133=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P9 > work/kat/gul_S2_pltcalc_P9 & pid134=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P10 > work/kat/gul_S1_eltcalc_P10 & pid135=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P10 > work/kat/gul_S1_summarycalc_P10 & pid136=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P10 > work/kat/gul_S1_pltcalc_P10 & pid137=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P10 > work/kat/gul_S2_eltcalc_P10 & pid138=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P10 > work/kat/gul_S2_summarycalc_P10 & pid139=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P10 > work/kat/gul_S2_pltcalc_P10 & pid140=$!
+
+tee < fifo/gul_S1_summary_P1 fifo/gul_S1_eltcalc_P1 fifo/gul_S1_summarycalc_P1 fifo/gul_S1_pltcalc_P1 work/gul_S1_summaryaalcalc/P1.bin work/gul_S1_summaryleccalc/P1.bin > /dev/null & pid141=$!
+tee < fifo/gul_S2_summary_P1 fifo/gul_S2_eltcalc_P1 fifo/gul_S2_summarycalc_P1 fifo/gul_S2_pltcalc_P1 work/gul_S2_summaryaalcalc/P1.bin work/gul_S2_summaryleccalc/P1.bin > /dev/null & pid142=$!
+tee < fifo/gul_S1_summary_P2 fifo/gul_S1_eltcalc_P2 fifo/gul_S1_summarycalc_P2 fifo/gul_S1_pltcalc_P2 work/gul_S1_summaryaalcalc/P2.bin work/gul_S1_summaryleccalc/P2.bin > /dev/null & pid143=$!
+tee < fifo/gul_S2_summary_P2 fifo/gul_S2_eltcalc_P2 fifo/gul_S2_summarycalc_P2 fifo/gul_S2_pltcalc_P2 work/gul_S2_summaryaalcalc/P2.bin work/gul_S2_summaryleccalc/P2.bin > /dev/null & pid144=$!
+tee < fifo/gul_S1_summary_P3 fifo/gul_S1_eltcalc_P3 fifo/gul_S1_summarycalc_P3 fifo/gul_S1_pltcalc_P3 work/gul_S1_summaryaalcalc/P3.bin work/gul_S1_summaryleccalc/P3.bin > /dev/null & pid145=$!
+tee < fifo/gul_S2_summary_P3 fifo/gul_S2_eltcalc_P3 fifo/gul_S2_summarycalc_P3 fifo/gul_S2_pltcalc_P3 work/gul_S2_summaryaalcalc/P3.bin work/gul_S2_summaryleccalc/P3.bin > /dev/null & pid146=$!
+tee < fifo/gul_S1_summary_P4 fifo/gul_S1_eltcalc_P4 fifo/gul_S1_summarycalc_P4 fifo/gul_S1_pltcalc_P4 work/gul_S1_summaryaalcalc/P4.bin work/gul_S1_summaryleccalc/P4.bin > /dev/null & pid147=$!
+tee < fifo/gul_S2_summary_P4 fifo/gul_S2_eltcalc_P4 fifo/gul_S2_summarycalc_P4 fifo/gul_S2_pltcalc_P4 work/gul_S2_summaryaalcalc/P4.bin work/gul_S2_summaryleccalc/P4.bin > /dev/null & pid148=$!
+tee < fifo/gul_S1_summary_P5 fifo/gul_S1_eltcalc_P5 fifo/gul_S1_summarycalc_P5 fifo/gul_S1_pltcalc_P5 work/gul_S1_summaryaalcalc/P5.bin work/gul_S1_summaryleccalc/P5.bin > /dev/null & pid149=$!
+tee < fifo/gul_S2_summary_P5 fifo/gul_S2_eltcalc_P5 fifo/gul_S2_summarycalc_P5 fifo/gul_S2_pltcalc_P5 work/gul_S2_summaryaalcalc/P5.bin work/gul_S2_summaryleccalc/P5.bin > /dev/null & pid150=$!
+tee < fifo/gul_S1_summary_P6 fifo/gul_S1_eltcalc_P6 fifo/gul_S1_summarycalc_P6 fifo/gul_S1_pltcalc_P6 work/gul_S1_summaryaalcalc/P6.bin work/gul_S1_summaryleccalc/P6.bin > /dev/null & pid151=$!
+tee < fifo/gul_S2_summary_P6 fifo/gul_S2_eltcalc_P6 fifo/gul_S2_summarycalc_P6 fifo/gul_S2_pltcalc_P6 work/gul_S2_summaryaalcalc/P6.bin work/gul_S2_summaryleccalc/P6.bin > /dev/null & pid152=$!
+tee < fifo/gul_S1_summary_P7 fifo/gul_S1_eltcalc_P7 fifo/gul_S1_summarycalc_P7 fifo/gul_S1_pltcalc_P7 work/gul_S1_summaryaalcalc/P7.bin work/gul_S1_summaryleccalc/P7.bin > /dev/null & pid153=$!
+tee < fifo/gul_S2_summary_P7 fifo/gul_S2_eltcalc_P7 fifo/gul_S2_summarycalc_P7 fifo/gul_S2_pltcalc_P7 work/gul_S2_summaryaalcalc/P7.bin work/gul_S2_summaryleccalc/P7.bin > /dev/null & pid154=$!
+tee < fifo/gul_S1_summary_P8 fifo/gul_S1_eltcalc_P8 fifo/gul_S1_summarycalc_P8 fifo/gul_S1_pltcalc_P8 work/gul_S1_summaryaalcalc/P8.bin work/gul_S1_summaryleccalc/P8.bin > /dev/null & pid155=$!
+tee < fifo/gul_S2_summary_P8 fifo/gul_S2_eltcalc_P8 fifo/gul_S2_summarycalc_P8 fifo/gul_S2_pltcalc_P8 work/gul_S2_summaryaalcalc/P8.bin work/gul_S2_summaryleccalc/P8.bin > /dev/null & pid156=$!
+tee < fifo/gul_S1_summary_P9 fifo/gul_S1_eltcalc_P9 fifo/gul_S1_summarycalc_P9 fifo/gul_S1_pltcalc_P9 work/gul_S1_summaryaalcalc/P9.bin work/gul_S1_summaryleccalc/P9.bin > /dev/null & pid157=$!
+tee < fifo/gul_S2_summary_P9 fifo/gul_S2_eltcalc_P9 fifo/gul_S2_summarycalc_P9 fifo/gul_S2_pltcalc_P9 work/gul_S2_summaryaalcalc/P9.bin work/gul_S2_summaryleccalc/P9.bin > /dev/null & pid158=$!
+tee < fifo/gul_S1_summary_P10 fifo/gul_S1_eltcalc_P10 fifo/gul_S1_summarycalc_P10 fifo/gul_S1_pltcalc_P10 work/gul_S1_summaryaalcalc/P10.bin work/gul_S1_summaryleccalc/P10.bin > /dev/null & pid159=$!
+tee < fifo/gul_S2_summary_P10 fifo/gul_S2_eltcalc_P10 fifo/gul_S2_summarycalc_P10 fifo/gul_S2_pltcalc_P10 work/gul_S2_summaryaalcalc/P10.bin work/gul_S2_summaryleccalc/P10.bin > /dev/null & pid160=$!
+
+summarycalc -g  -1 fifo/gul_S1_summary_P1 -2 fifo/gul_S2_summary_P1 < fifo/gul_P1 &
+summarycalc -g  -1 fifo/gul_S1_summary_P2 -2 fifo/gul_S2_summary_P2 < fifo/gul_P2 &
+summarycalc -g  -1 fifo/gul_S1_summary_P3 -2 fifo/gul_S2_summary_P3 < fifo/gul_P3 &
+summarycalc -g  -1 fifo/gul_S1_summary_P4 -2 fifo/gul_S2_summary_P4 < fifo/gul_P4 &
+summarycalc -g  -1 fifo/gul_S1_summary_P5 -2 fifo/gul_S2_summary_P5 < fifo/gul_P5 &
+summarycalc -g  -1 fifo/gul_S1_summary_P6 -2 fifo/gul_S2_summary_P6 < fifo/gul_P6 &
+summarycalc -g  -1 fifo/gul_S1_summary_P7 -2 fifo/gul_S2_summary_P7 < fifo/gul_P7 &
+summarycalc -g  -1 fifo/gul_S1_summary_P8 -2 fifo/gul_S2_summary_P8 < fifo/gul_P8 &
+summarycalc -g  -1 fifo/gul_S1_summary_P9 -2 fifo/gul_S2_summary_P9 < fifo/gul_P9 &
+summarycalc -g  -1 fifo/gul_S1_summary_P10 -2 fifo/gul_S2_summary_P10 < fifo/gul_P10 &
+
+eve 1 10 | getmodel | gulcalc -S0 -L0 -r -c fifo/gul_P1 -i - | fmcalc -a2 > fifo/il_P1  &
+eve 2 10 | getmodel | gulcalc -S0 -L0 -r -c fifo/gul_P2 -i - | fmcalc -a2 > fifo/il_P2  &
+eve 3 10 | getmodel | gulcalc -S0 -L0 -r -c fifo/gul_P3 -i - | fmcalc -a2 > fifo/il_P3  &
+eve 4 10 | getmodel | gulcalc -S0 -L0 -r -c fifo/gul_P4 -i - | fmcalc -a2 > fifo/il_P4  &
+eve 5 10 | getmodel | gulcalc -S0 -L0 -r -c fifo/gul_P5 -i - | fmcalc -a2 > fifo/il_P5  &
+eve 6 10 | getmodel | gulcalc -S0 -L0 -r -c fifo/gul_P6 -i - | fmcalc -a2 > fifo/il_P6  &
+eve 7 10 | getmodel | gulcalc -S0 -L0 -r -c fifo/gul_P7 -i - | fmcalc -a2 > fifo/il_P7  &
+eve 8 10 | getmodel | gulcalc -S0 -L0 -r -c fifo/gul_P8 -i - | fmcalc -a2 > fifo/il_P8  &
+eve 9 10 | getmodel | gulcalc -S0 -L0 -r -c fifo/gul_P9 -i - | fmcalc -a2 > fifo/il_P9  &
+eve 10 10 | getmodel | gulcalc -S0 -L0 -r -c fifo/gul_P10 -i - | fmcalc -a2 > fifo/il_P10  &
+
+wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 $pid13 $pid14 $pid15 $pid16 $pid17 $pid18 $pid19 $pid20 $pid21 $pid22 $pid23 $pid24 $pid25 $pid26 $pid27 $pid28 $pid29 $pid30 $pid31 $pid32 $pid33 $pid34 $pid35 $pid36 $pid37 $pid38 $pid39 $pid40 $pid41 $pid42 $pid43 $pid44 $pid45 $pid46 $pid47 $pid48 $pid49 $pid50 $pid51 $pid52 $pid53 $pid54 $pid55 $pid56 $pid57 $pid58 $pid59 $pid60 $pid61 $pid62 $pid63 $pid64 $pid65 $pid66 $pid67 $pid68 $pid69 $pid70 $pid71 $pid72 $pid73 $pid74 $pid75 $pid76 $pid77 $pid78 $pid79 $pid80 $pid81 $pid82 $pid83 $pid84 $pid85 $pid86 $pid87 $pid88 $pid89 $pid90 $pid91 $pid92 $pid93 $pid94 $pid95 $pid96 $pid97 $pid98 $pid99 $pid100 $pid101 $pid102 $pid103 $pid104 $pid105 $pid106 $pid107 $pid108 $pid109 $pid110 $pid111 $pid112 $pid113 $pid114 $pid115 $pid116 $pid117 $pid118 $pid119 $pid120 $pid121 $pid122 $pid123 $pid124 $pid125 $pid126 $pid127 $pid128 $pid129 $pid130 $pid131 $pid132 $pid133 $pid134 $pid135 $pid136 $pid137 $pid138 $pid139 $pid140 $pid141 $pid142 $pid143 $pid144 $pid145 $pid146 $pid147 $pid148 $pid149 $pid150 $pid151 $pid152 $pid153 $pid154 $pid155 $pid156 $pid157 $pid158 $pid159 $pid160
+
+
+# --- Do insured loss kats ---
+
+kat -s work/kat/il_S1_eltcalc_P1 work/kat/il_S1_eltcalc_P2 work/kat/il_S1_eltcalc_P3 work/kat/il_S1_eltcalc_P4 work/kat/il_S1_eltcalc_P5 work/kat/il_S1_eltcalc_P6 work/kat/il_S1_eltcalc_P7 work/kat/il_S1_eltcalc_P8 work/kat/il_S1_eltcalc_P9 work/kat/il_S1_eltcalc_P10 > output/il_S1_eltcalc.csv & kpid1=$!
+kat work/kat/il_S1_pltcalc_P1 work/kat/il_S1_pltcalc_P2 work/kat/il_S1_pltcalc_P3 work/kat/il_S1_pltcalc_P4 work/kat/il_S1_pltcalc_P5 work/kat/il_S1_pltcalc_P6 work/kat/il_S1_pltcalc_P7 work/kat/il_S1_pltcalc_P8 work/kat/il_S1_pltcalc_P9 work/kat/il_S1_pltcalc_P10 > output/il_S1_pltcalc.csv & kpid2=$!
+kat work/kat/il_S1_summarycalc_P1 work/kat/il_S1_summarycalc_P2 work/kat/il_S1_summarycalc_P3 work/kat/il_S1_summarycalc_P4 work/kat/il_S1_summarycalc_P5 work/kat/il_S1_summarycalc_P6 work/kat/il_S1_summarycalc_P7 work/kat/il_S1_summarycalc_P8 work/kat/il_S1_summarycalc_P9 work/kat/il_S1_summarycalc_P10 > output/il_S1_summarycalc.csv & kpid3=$!
+kat -s work/kat/il_S2_eltcalc_P1 work/kat/il_S2_eltcalc_P2 work/kat/il_S2_eltcalc_P3 work/kat/il_S2_eltcalc_P4 work/kat/il_S2_eltcalc_P5 work/kat/il_S2_eltcalc_P6 work/kat/il_S2_eltcalc_P7 work/kat/il_S2_eltcalc_P8 work/kat/il_S2_eltcalc_P9 work/kat/il_S2_eltcalc_P10 > output/il_S2_eltcalc.csv & kpid4=$!
+kat work/kat/il_S2_pltcalc_P1 work/kat/il_S2_pltcalc_P2 work/kat/il_S2_pltcalc_P3 work/kat/il_S2_pltcalc_P4 work/kat/il_S2_pltcalc_P5 work/kat/il_S2_pltcalc_P6 work/kat/il_S2_pltcalc_P7 work/kat/il_S2_pltcalc_P8 work/kat/il_S2_pltcalc_P9 work/kat/il_S2_pltcalc_P10 > output/il_S2_pltcalc.csv & kpid5=$!
+kat work/kat/il_S2_summarycalc_P1 work/kat/il_S2_summarycalc_P2 work/kat/il_S2_summarycalc_P3 work/kat/il_S2_summarycalc_P4 work/kat/il_S2_summarycalc_P5 work/kat/il_S2_summarycalc_P6 work/kat/il_S2_summarycalc_P7 work/kat/il_S2_summarycalc_P8 work/kat/il_S2_summarycalc_P9 work/kat/il_S2_summarycalc_P10 > output/il_S2_summarycalc.csv & kpid6=$!
+
+# --- Do ground up loss kats ---
+
+kat -s work/kat/gul_S1_eltcalc_P1 work/kat/gul_S1_eltcalc_P2 work/kat/gul_S1_eltcalc_P3 work/kat/gul_S1_eltcalc_P4 work/kat/gul_S1_eltcalc_P5 work/kat/gul_S1_eltcalc_P6 work/kat/gul_S1_eltcalc_P7 work/kat/gul_S1_eltcalc_P8 work/kat/gul_S1_eltcalc_P9 work/kat/gul_S1_eltcalc_P10 > output/gul_S1_eltcalc.csv & kpid7=$!
+kat work/kat/gul_S1_pltcalc_P1 work/kat/gul_S1_pltcalc_P2 work/kat/gul_S1_pltcalc_P3 work/kat/gul_S1_pltcalc_P4 work/kat/gul_S1_pltcalc_P5 work/kat/gul_S1_pltcalc_P6 work/kat/gul_S1_pltcalc_P7 work/kat/gul_S1_pltcalc_P8 work/kat/gul_S1_pltcalc_P9 work/kat/gul_S1_pltcalc_P10 > output/gul_S1_pltcalc.csv & kpid8=$!
+kat work/kat/gul_S1_summarycalc_P1 work/kat/gul_S1_summarycalc_P2 work/kat/gul_S1_summarycalc_P3 work/kat/gul_S1_summarycalc_P4 work/kat/gul_S1_summarycalc_P5 work/kat/gul_S1_summarycalc_P6 work/kat/gul_S1_summarycalc_P7 work/kat/gul_S1_summarycalc_P8 work/kat/gul_S1_summarycalc_P9 work/kat/gul_S1_summarycalc_P10 > output/gul_S1_summarycalc.csv & kpid9=$!
+kat -s work/kat/gul_S2_eltcalc_P1 work/kat/gul_S2_eltcalc_P2 work/kat/gul_S2_eltcalc_P3 work/kat/gul_S2_eltcalc_P4 work/kat/gul_S2_eltcalc_P5 work/kat/gul_S2_eltcalc_P6 work/kat/gul_S2_eltcalc_P7 work/kat/gul_S2_eltcalc_P8 work/kat/gul_S2_eltcalc_P9 work/kat/gul_S2_eltcalc_P10 > output/gul_S2_eltcalc.csv & kpid10=$!
+kat work/kat/gul_S2_pltcalc_P1 work/kat/gul_S2_pltcalc_P2 work/kat/gul_S2_pltcalc_P3 work/kat/gul_S2_pltcalc_P4 work/kat/gul_S2_pltcalc_P5 work/kat/gul_S2_pltcalc_P6 work/kat/gul_S2_pltcalc_P7 work/kat/gul_S2_pltcalc_P8 work/kat/gul_S2_pltcalc_P9 work/kat/gul_S2_pltcalc_P10 > output/gul_S2_pltcalc.csv & kpid11=$!
+kat work/kat/gul_S2_summarycalc_P1 work/kat/gul_S2_summarycalc_P2 work/kat/gul_S2_summarycalc_P3 work/kat/gul_S2_summarycalc_P4 work/kat/gul_S2_summarycalc_P5 work/kat/gul_S2_summarycalc_P6 work/kat/gul_S2_summarycalc_P7 work/kat/gul_S2_summarycalc_P8 work/kat/gul_S2_summarycalc_P9 work/kat/gul_S2_summarycalc_P10 > output/gul_S2_summarycalc.csv & kpid12=$!
+wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpid11 $kpid12
+
+
+aalcalc -Kil_S1_summaryaalcalc > output/il_S1_aalcalc.csv & lpid1=$!
+ordleccalc -r -Kil_S1_summaryleccalc -F -S -s -M -m -W -w -O output/il_S1_ept.csv -o output/il_S1_psept.csv & lpid2=$!
+aalcalc -Kil_S2_summaryaalcalc > output/il_S2_aalcalc.csv & lpid3=$!
+ordleccalc -r -Kil_S2_summaryleccalc -F -S -s -M -m -W -w -O output/il_S2_ept.csv -o output/il_S2_psept.csv & lpid4=$!
+aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv & lpid5=$!
+ordleccalc -r -Kgul_S1_summaryleccalc -F -S -s -M -m -W -w -O output/gul_S1_ept.csv -o output/gul_S1_psept.csv & lpid6=$!
+aalcalc -Kgul_S2_summaryaalcalc > output/gul_S2_aalcalc.csv & lpid7=$!
+ordleccalc -r -Kgul_S2_summaryleccalc -F -S -s -M -m -W -w -O output/gul_S2_ept.csv -o output/gul_S2_psept.csv & lpid8=$!
+wait $lpid1 $lpid2 $lpid3 $lpid4 $lpid5 $lpid6 $lpid7 $lpid8
+
+rm -R -f work/*
+rm -R -f fifo/*

--- a/tests/model_execution/cov_kparse_reference/gul_il_ord_psept_lec_1_output_10_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_il_ord_psept_lec_1_output_10_partition.sh
@@ -1,0 +1,295 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+
+rm -R -f fifo/*
+rm -R -f work/*
+mkdir work/kat/
+
+mkdir work/gul_S1_summaryleccalc
+mkdir work/gul_S1_summaryaalcalc
+mkdir work/il_S1_summaryleccalc
+mkdir work/il_S1_summaryaalcalc
+
+mkfifo fifo/gul_P1
+mkfifo fifo/gul_P2
+mkfifo fifo/gul_P3
+mkfifo fifo/gul_P4
+mkfifo fifo/gul_P5
+mkfifo fifo/gul_P6
+mkfifo fifo/gul_P7
+mkfifo fifo/gul_P8
+mkfifo fifo/gul_P9
+mkfifo fifo/gul_P10
+
+mkfifo fifo/gul_S1_summary_P1
+mkfifo fifo/gul_S1_eltcalc_P1
+mkfifo fifo/gul_S1_summarycalc_P1
+mkfifo fifo/gul_S1_pltcalc_P1
+
+mkfifo fifo/gul_S1_summary_P2
+mkfifo fifo/gul_S1_eltcalc_P2
+mkfifo fifo/gul_S1_summarycalc_P2
+mkfifo fifo/gul_S1_pltcalc_P2
+
+mkfifo fifo/gul_S1_summary_P3
+mkfifo fifo/gul_S1_eltcalc_P3
+mkfifo fifo/gul_S1_summarycalc_P3
+mkfifo fifo/gul_S1_pltcalc_P3
+
+mkfifo fifo/gul_S1_summary_P4
+mkfifo fifo/gul_S1_eltcalc_P4
+mkfifo fifo/gul_S1_summarycalc_P4
+mkfifo fifo/gul_S1_pltcalc_P4
+
+mkfifo fifo/gul_S1_summary_P5
+mkfifo fifo/gul_S1_eltcalc_P5
+mkfifo fifo/gul_S1_summarycalc_P5
+mkfifo fifo/gul_S1_pltcalc_P5
+
+mkfifo fifo/gul_S1_summary_P6
+mkfifo fifo/gul_S1_eltcalc_P6
+mkfifo fifo/gul_S1_summarycalc_P6
+mkfifo fifo/gul_S1_pltcalc_P6
+
+mkfifo fifo/gul_S1_summary_P7
+mkfifo fifo/gul_S1_eltcalc_P7
+mkfifo fifo/gul_S1_summarycalc_P7
+mkfifo fifo/gul_S1_pltcalc_P7
+
+mkfifo fifo/gul_S1_summary_P8
+mkfifo fifo/gul_S1_eltcalc_P8
+mkfifo fifo/gul_S1_summarycalc_P8
+mkfifo fifo/gul_S1_pltcalc_P8
+
+mkfifo fifo/gul_S1_summary_P9
+mkfifo fifo/gul_S1_eltcalc_P9
+mkfifo fifo/gul_S1_summarycalc_P9
+mkfifo fifo/gul_S1_pltcalc_P9
+
+mkfifo fifo/gul_S1_summary_P10
+mkfifo fifo/gul_S1_eltcalc_P10
+mkfifo fifo/gul_S1_summarycalc_P10
+mkfifo fifo/gul_S1_pltcalc_P10
+
+mkfifo fifo/il_P1
+mkfifo fifo/il_P2
+mkfifo fifo/il_P3
+mkfifo fifo/il_P4
+mkfifo fifo/il_P5
+mkfifo fifo/il_P6
+mkfifo fifo/il_P7
+mkfifo fifo/il_P8
+mkfifo fifo/il_P9
+mkfifo fifo/il_P10
+
+mkfifo fifo/il_S1_summary_P1
+mkfifo fifo/il_S1_eltcalc_P1
+mkfifo fifo/il_S1_summarycalc_P1
+mkfifo fifo/il_S1_pltcalc_P1
+
+mkfifo fifo/il_S1_summary_P2
+mkfifo fifo/il_S1_eltcalc_P2
+mkfifo fifo/il_S1_summarycalc_P2
+mkfifo fifo/il_S1_pltcalc_P2
+
+mkfifo fifo/il_S1_summary_P3
+mkfifo fifo/il_S1_eltcalc_P3
+mkfifo fifo/il_S1_summarycalc_P3
+mkfifo fifo/il_S1_pltcalc_P3
+
+mkfifo fifo/il_S1_summary_P4
+mkfifo fifo/il_S1_eltcalc_P4
+mkfifo fifo/il_S1_summarycalc_P4
+mkfifo fifo/il_S1_pltcalc_P4
+
+mkfifo fifo/il_S1_summary_P5
+mkfifo fifo/il_S1_eltcalc_P5
+mkfifo fifo/il_S1_summarycalc_P5
+mkfifo fifo/il_S1_pltcalc_P5
+
+mkfifo fifo/il_S1_summary_P6
+mkfifo fifo/il_S1_eltcalc_P6
+mkfifo fifo/il_S1_summarycalc_P6
+mkfifo fifo/il_S1_pltcalc_P6
+
+mkfifo fifo/il_S1_summary_P7
+mkfifo fifo/il_S1_eltcalc_P7
+mkfifo fifo/il_S1_summarycalc_P7
+mkfifo fifo/il_S1_pltcalc_P7
+
+mkfifo fifo/il_S1_summary_P8
+mkfifo fifo/il_S1_eltcalc_P8
+mkfifo fifo/il_S1_summarycalc_P8
+mkfifo fifo/il_S1_pltcalc_P8
+
+mkfifo fifo/il_S1_summary_P9
+mkfifo fifo/il_S1_eltcalc_P9
+mkfifo fifo/il_S1_summarycalc_P9
+mkfifo fifo/il_S1_pltcalc_P9
+
+mkfifo fifo/il_S1_summary_P10
+mkfifo fifo/il_S1_eltcalc_P10
+mkfifo fifo/il_S1_summarycalc_P10
+mkfifo fifo/il_S1_pltcalc_P10
+
+
+
+# --- Do insured loss computes ---
+
+eltcalc < fifo/il_S1_eltcalc_P1 > work/kat/il_S1_eltcalc_P1 & pid1=$!
+summarycalctocsv < fifo/il_S1_summarycalc_P1 > work/kat/il_S1_summarycalc_P1 & pid2=$!
+pltcalc < fifo/il_S1_pltcalc_P1 > work/kat/il_S1_pltcalc_P1 & pid3=$!
+eltcalc -s < fifo/il_S1_eltcalc_P2 > work/kat/il_S1_eltcalc_P2 & pid4=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P2 > work/kat/il_S1_summarycalc_P2 & pid5=$!
+pltcalc -s < fifo/il_S1_pltcalc_P2 > work/kat/il_S1_pltcalc_P2 & pid6=$!
+eltcalc -s < fifo/il_S1_eltcalc_P3 > work/kat/il_S1_eltcalc_P3 & pid7=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P3 > work/kat/il_S1_summarycalc_P3 & pid8=$!
+pltcalc -s < fifo/il_S1_pltcalc_P3 > work/kat/il_S1_pltcalc_P3 & pid9=$!
+eltcalc -s < fifo/il_S1_eltcalc_P4 > work/kat/il_S1_eltcalc_P4 & pid10=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P4 > work/kat/il_S1_summarycalc_P4 & pid11=$!
+pltcalc -s < fifo/il_S1_pltcalc_P4 > work/kat/il_S1_pltcalc_P4 & pid12=$!
+eltcalc -s < fifo/il_S1_eltcalc_P5 > work/kat/il_S1_eltcalc_P5 & pid13=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P5 > work/kat/il_S1_summarycalc_P5 & pid14=$!
+pltcalc -s < fifo/il_S1_pltcalc_P5 > work/kat/il_S1_pltcalc_P5 & pid15=$!
+eltcalc -s < fifo/il_S1_eltcalc_P6 > work/kat/il_S1_eltcalc_P6 & pid16=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P6 > work/kat/il_S1_summarycalc_P6 & pid17=$!
+pltcalc -s < fifo/il_S1_pltcalc_P6 > work/kat/il_S1_pltcalc_P6 & pid18=$!
+eltcalc -s < fifo/il_S1_eltcalc_P7 > work/kat/il_S1_eltcalc_P7 & pid19=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P7 > work/kat/il_S1_summarycalc_P7 & pid20=$!
+pltcalc -s < fifo/il_S1_pltcalc_P7 > work/kat/il_S1_pltcalc_P7 & pid21=$!
+eltcalc -s < fifo/il_S1_eltcalc_P8 > work/kat/il_S1_eltcalc_P8 & pid22=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P8 > work/kat/il_S1_summarycalc_P8 & pid23=$!
+pltcalc -s < fifo/il_S1_pltcalc_P8 > work/kat/il_S1_pltcalc_P8 & pid24=$!
+eltcalc -s < fifo/il_S1_eltcalc_P9 > work/kat/il_S1_eltcalc_P9 & pid25=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P9 > work/kat/il_S1_summarycalc_P9 & pid26=$!
+pltcalc -s < fifo/il_S1_pltcalc_P9 > work/kat/il_S1_pltcalc_P9 & pid27=$!
+eltcalc -s < fifo/il_S1_eltcalc_P10 > work/kat/il_S1_eltcalc_P10 & pid28=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P10 > work/kat/il_S1_summarycalc_P10 & pid29=$!
+pltcalc -s < fifo/il_S1_pltcalc_P10 > work/kat/il_S1_pltcalc_P10 & pid30=$!
+
+tee < fifo/il_S1_summary_P1 fifo/il_S1_eltcalc_P1 fifo/il_S1_summarycalc_P1 fifo/il_S1_pltcalc_P1 work/il_S1_summaryaalcalc/P1.bin work/il_S1_summaryleccalc/P1.bin > /dev/null & pid31=$!
+tee < fifo/il_S1_summary_P2 fifo/il_S1_eltcalc_P2 fifo/il_S1_summarycalc_P2 fifo/il_S1_pltcalc_P2 work/il_S1_summaryaalcalc/P2.bin work/il_S1_summaryleccalc/P2.bin > /dev/null & pid32=$!
+tee < fifo/il_S1_summary_P3 fifo/il_S1_eltcalc_P3 fifo/il_S1_summarycalc_P3 fifo/il_S1_pltcalc_P3 work/il_S1_summaryaalcalc/P3.bin work/il_S1_summaryleccalc/P3.bin > /dev/null & pid33=$!
+tee < fifo/il_S1_summary_P4 fifo/il_S1_eltcalc_P4 fifo/il_S1_summarycalc_P4 fifo/il_S1_pltcalc_P4 work/il_S1_summaryaalcalc/P4.bin work/il_S1_summaryleccalc/P4.bin > /dev/null & pid34=$!
+tee < fifo/il_S1_summary_P5 fifo/il_S1_eltcalc_P5 fifo/il_S1_summarycalc_P5 fifo/il_S1_pltcalc_P5 work/il_S1_summaryaalcalc/P5.bin work/il_S1_summaryleccalc/P5.bin > /dev/null & pid35=$!
+tee < fifo/il_S1_summary_P6 fifo/il_S1_eltcalc_P6 fifo/il_S1_summarycalc_P6 fifo/il_S1_pltcalc_P6 work/il_S1_summaryaalcalc/P6.bin work/il_S1_summaryleccalc/P6.bin > /dev/null & pid36=$!
+tee < fifo/il_S1_summary_P7 fifo/il_S1_eltcalc_P7 fifo/il_S1_summarycalc_P7 fifo/il_S1_pltcalc_P7 work/il_S1_summaryaalcalc/P7.bin work/il_S1_summaryleccalc/P7.bin > /dev/null & pid37=$!
+tee < fifo/il_S1_summary_P8 fifo/il_S1_eltcalc_P8 fifo/il_S1_summarycalc_P8 fifo/il_S1_pltcalc_P8 work/il_S1_summaryaalcalc/P8.bin work/il_S1_summaryleccalc/P8.bin > /dev/null & pid38=$!
+tee < fifo/il_S1_summary_P9 fifo/il_S1_eltcalc_P9 fifo/il_S1_summarycalc_P9 fifo/il_S1_pltcalc_P9 work/il_S1_summaryaalcalc/P9.bin work/il_S1_summaryleccalc/P9.bin > /dev/null & pid39=$!
+tee < fifo/il_S1_summary_P10 fifo/il_S1_eltcalc_P10 fifo/il_S1_summarycalc_P10 fifo/il_S1_pltcalc_P10 work/il_S1_summaryaalcalc/P10.bin work/il_S1_summaryleccalc/P10.bin > /dev/null & pid40=$!
+
+summarycalc -f  -1 fifo/il_S1_summary_P1 < fifo/il_P1 &
+summarycalc -f  -1 fifo/il_S1_summary_P2 < fifo/il_P2 &
+summarycalc -f  -1 fifo/il_S1_summary_P3 < fifo/il_P3 &
+summarycalc -f  -1 fifo/il_S1_summary_P4 < fifo/il_P4 &
+summarycalc -f  -1 fifo/il_S1_summary_P5 < fifo/il_P5 &
+summarycalc -f  -1 fifo/il_S1_summary_P6 < fifo/il_P6 &
+summarycalc -f  -1 fifo/il_S1_summary_P7 < fifo/il_P7 &
+summarycalc -f  -1 fifo/il_S1_summary_P8 < fifo/il_P8 &
+summarycalc -f  -1 fifo/il_S1_summary_P9 < fifo/il_P9 &
+summarycalc -f  -1 fifo/il_S1_summary_P10 < fifo/il_P10 &
+
+# --- Do ground up loss computes ---
+
+eltcalc < fifo/gul_S1_eltcalc_P1 > work/kat/gul_S1_eltcalc_P1 & pid41=$!
+summarycalctocsv < fifo/gul_S1_summarycalc_P1 > work/kat/gul_S1_summarycalc_P1 & pid42=$!
+pltcalc < fifo/gul_S1_pltcalc_P1 > work/kat/gul_S1_pltcalc_P1 & pid43=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P2 > work/kat/gul_S1_eltcalc_P2 & pid44=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P2 > work/kat/gul_S1_summarycalc_P2 & pid45=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P2 > work/kat/gul_S1_pltcalc_P2 & pid46=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P3 > work/kat/gul_S1_eltcalc_P3 & pid47=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P3 > work/kat/gul_S1_summarycalc_P3 & pid48=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P3 > work/kat/gul_S1_pltcalc_P3 & pid49=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P4 > work/kat/gul_S1_eltcalc_P4 & pid50=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P4 > work/kat/gul_S1_summarycalc_P4 & pid51=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P4 > work/kat/gul_S1_pltcalc_P4 & pid52=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P5 > work/kat/gul_S1_eltcalc_P5 & pid53=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P5 > work/kat/gul_S1_summarycalc_P5 & pid54=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P5 > work/kat/gul_S1_pltcalc_P5 & pid55=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P6 > work/kat/gul_S1_eltcalc_P6 & pid56=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P6 > work/kat/gul_S1_summarycalc_P6 & pid57=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P6 > work/kat/gul_S1_pltcalc_P6 & pid58=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P7 > work/kat/gul_S1_eltcalc_P7 & pid59=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P7 > work/kat/gul_S1_summarycalc_P7 & pid60=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P7 > work/kat/gul_S1_pltcalc_P7 & pid61=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P8 > work/kat/gul_S1_eltcalc_P8 & pid62=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P8 > work/kat/gul_S1_summarycalc_P8 & pid63=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P8 > work/kat/gul_S1_pltcalc_P8 & pid64=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P9 > work/kat/gul_S1_eltcalc_P9 & pid65=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P9 > work/kat/gul_S1_summarycalc_P9 & pid66=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P9 > work/kat/gul_S1_pltcalc_P9 & pid67=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P10 > work/kat/gul_S1_eltcalc_P10 & pid68=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P10 > work/kat/gul_S1_summarycalc_P10 & pid69=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P10 > work/kat/gul_S1_pltcalc_P10 & pid70=$!
+
+tee < fifo/gul_S1_summary_P1 fifo/gul_S1_eltcalc_P1 fifo/gul_S1_summarycalc_P1 fifo/gul_S1_pltcalc_P1 work/gul_S1_summaryaalcalc/P1.bin work/gul_S1_summaryleccalc/P1.bin > /dev/null & pid71=$!
+tee < fifo/gul_S1_summary_P2 fifo/gul_S1_eltcalc_P2 fifo/gul_S1_summarycalc_P2 fifo/gul_S1_pltcalc_P2 work/gul_S1_summaryaalcalc/P2.bin work/gul_S1_summaryleccalc/P2.bin > /dev/null & pid72=$!
+tee < fifo/gul_S1_summary_P3 fifo/gul_S1_eltcalc_P3 fifo/gul_S1_summarycalc_P3 fifo/gul_S1_pltcalc_P3 work/gul_S1_summaryaalcalc/P3.bin work/gul_S1_summaryleccalc/P3.bin > /dev/null & pid73=$!
+tee < fifo/gul_S1_summary_P4 fifo/gul_S1_eltcalc_P4 fifo/gul_S1_summarycalc_P4 fifo/gul_S1_pltcalc_P4 work/gul_S1_summaryaalcalc/P4.bin work/gul_S1_summaryleccalc/P4.bin > /dev/null & pid74=$!
+tee < fifo/gul_S1_summary_P5 fifo/gul_S1_eltcalc_P5 fifo/gul_S1_summarycalc_P5 fifo/gul_S1_pltcalc_P5 work/gul_S1_summaryaalcalc/P5.bin work/gul_S1_summaryleccalc/P5.bin > /dev/null & pid75=$!
+tee < fifo/gul_S1_summary_P6 fifo/gul_S1_eltcalc_P6 fifo/gul_S1_summarycalc_P6 fifo/gul_S1_pltcalc_P6 work/gul_S1_summaryaalcalc/P6.bin work/gul_S1_summaryleccalc/P6.bin > /dev/null & pid76=$!
+tee < fifo/gul_S1_summary_P7 fifo/gul_S1_eltcalc_P7 fifo/gul_S1_summarycalc_P7 fifo/gul_S1_pltcalc_P7 work/gul_S1_summaryaalcalc/P7.bin work/gul_S1_summaryleccalc/P7.bin > /dev/null & pid77=$!
+tee < fifo/gul_S1_summary_P8 fifo/gul_S1_eltcalc_P8 fifo/gul_S1_summarycalc_P8 fifo/gul_S1_pltcalc_P8 work/gul_S1_summaryaalcalc/P8.bin work/gul_S1_summaryleccalc/P8.bin > /dev/null & pid78=$!
+tee < fifo/gul_S1_summary_P9 fifo/gul_S1_eltcalc_P9 fifo/gul_S1_summarycalc_P9 fifo/gul_S1_pltcalc_P9 work/gul_S1_summaryaalcalc/P9.bin work/gul_S1_summaryleccalc/P9.bin > /dev/null & pid79=$!
+tee < fifo/gul_S1_summary_P10 fifo/gul_S1_eltcalc_P10 fifo/gul_S1_summarycalc_P10 fifo/gul_S1_pltcalc_P10 work/gul_S1_summaryaalcalc/P10.bin work/gul_S1_summaryleccalc/P10.bin > /dev/null & pid80=$!
+
+summarycalc -g  -1 fifo/gul_S1_summary_P1 < fifo/gul_P1 &
+summarycalc -g  -1 fifo/gul_S1_summary_P2 < fifo/gul_P2 &
+summarycalc -g  -1 fifo/gul_S1_summary_P3 < fifo/gul_P3 &
+summarycalc -g  -1 fifo/gul_S1_summary_P4 < fifo/gul_P4 &
+summarycalc -g  -1 fifo/gul_S1_summary_P5 < fifo/gul_P5 &
+summarycalc -g  -1 fifo/gul_S1_summary_P6 < fifo/gul_P6 &
+summarycalc -g  -1 fifo/gul_S1_summary_P7 < fifo/gul_P7 &
+summarycalc -g  -1 fifo/gul_S1_summary_P8 < fifo/gul_P8 &
+summarycalc -g  -1 fifo/gul_S1_summary_P9 < fifo/gul_P9 &
+summarycalc -g  -1 fifo/gul_S1_summary_P10 < fifo/gul_P10 &
+
+eve 1 10 | getmodel | gulcalc -S0 -L0 -r -c fifo/gul_P1 -i - | fmcalc -a2 > fifo/il_P1  &
+eve 2 10 | getmodel | gulcalc -S0 -L0 -r -c fifo/gul_P2 -i - | fmcalc -a2 > fifo/il_P2  &
+eve 3 10 | getmodel | gulcalc -S0 -L0 -r -c fifo/gul_P3 -i - | fmcalc -a2 > fifo/il_P3  &
+eve 4 10 | getmodel | gulcalc -S0 -L0 -r -c fifo/gul_P4 -i - | fmcalc -a2 > fifo/il_P4  &
+eve 5 10 | getmodel | gulcalc -S0 -L0 -r -c fifo/gul_P5 -i - | fmcalc -a2 > fifo/il_P5  &
+eve 6 10 | getmodel | gulcalc -S0 -L0 -r -c fifo/gul_P6 -i - | fmcalc -a2 > fifo/il_P6  &
+eve 7 10 | getmodel | gulcalc -S0 -L0 -r -c fifo/gul_P7 -i - | fmcalc -a2 > fifo/il_P7  &
+eve 8 10 | getmodel | gulcalc -S0 -L0 -r -c fifo/gul_P8 -i - | fmcalc -a2 > fifo/il_P8  &
+eve 9 10 | getmodel | gulcalc -S0 -L0 -r -c fifo/gul_P9 -i - | fmcalc -a2 > fifo/il_P9  &
+eve 10 10 | getmodel | gulcalc -S0 -L0 -r -c fifo/gul_P10 -i - | fmcalc -a2 > fifo/il_P10  &
+
+wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 $pid13 $pid14 $pid15 $pid16 $pid17 $pid18 $pid19 $pid20 $pid21 $pid22 $pid23 $pid24 $pid25 $pid26 $pid27 $pid28 $pid29 $pid30 $pid31 $pid32 $pid33 $pid34 $pid35 $pid36 $pid37 $pid38 $pid39 $pid40 $pid41 $pid42 $pid43 $pid44 $pid45 $pid46 $pid47 $pid48 $pid49 $pid50 $pid51 $pid52 $pid53 $pid54 $pid55 $pid56 $pid57 $pid58 $pid59 $pid60 $pid61 $pid62 $pid63 $pid64 $pid65 $pid66 $pid67 $pid68 $pid69 $pid70 $pid71 $pid72 $pid73 $pid74 $pid75 $pid76 $pid77 $pid78 $pid79 $pid80
+
+
+# --- Do insured loss kats ---
+
+kat -s work/kat/il_S1_eltcalc_P1 work/kat/il_S1_eltcalc_P2 work/kat/il_S1_eltcalc_P3 work/kat/il_S1_eltcalc_P4 work/kat/il_S1_eltcalc_P5 work/kat/il_S1_eltcalc_P6 work/kat/il_S1_eltcalc_P7 work/kat/il_S1_eltcalc_P8 work/kat/il_S1_eltcalc_P9 work/kat/il_S1_eltcalc_P10 > output/il_S1_eltcalc.csv & kpid1=$!
+kat work/kat/il_S1_pltcalc_P1 work/kat/il_S1_pltcalc_P2 work/kat/il_S1_pltcalc_P3 work/kat/il_S1_pltcalc_P4 work/kat/il_S1_pltcalc_P5 work/kat/il_S1_pltcalc_P6 work/kat/il_S1_pltcalc_P7 work/kat/il_S1_pltcalc_P8 work/kat/il_S1_pltcalc_P9 work/kat/il_S1_pltcalc_P10 > output/il_S1_pltcalc.csv & kpid2=$!
+kat work/kat/il_S1_summarycalc_P1 work/kat/il_S1_summarycalc_P2 work/kat/il_S1_summarycalc_P3 work/kat/il_S1_summarycalc_P4 work/kat/il_S1_summarycalc_P5 work/kat/il_S1_summarycalc_P6 work/kat/il_S1_summarycalc_P7 work/kat/il_S1_summarycalc_P8 work/kat/il_S1_summarycalc_P9 work/kat/il_S1_summarycalc_P10 > output/il_S1_summarycalc.csv & kpid3=$!
+
+# --- Do ground up loss kats ---
+
+kat -s work/kat/gul_S1_eltcalc_P1 work/kat/gul_S1_eltcalc_P2 work/kat/gul_S1_eltcalc_P3 work/kat/gul_S1_eltcalc_P4 work/kat/gul_S1_eltcalc_P5 work/kat/gul_S1_eltcalc_P6 work/kat/gul_S1_eltcalc_P7 work/kat/gul_S1_eltcalc_P8 work/kat/gul_S1_eltcalc_P9 work/kat/gul_S1_eltcalc_P10 > output/gul_S1_eltcalc.csv & kpid4=$!
+kat work/kat/gul_S1_pltcalc_P1 work/kat/gul_S1_pltcalc_P2 work/kat/gul_S1_pltcalc_P3 work/kat/gul_S1_pltcalc_P4 work/kat/gul_S1_pltcalc_P5 work/kat/gul_S1_pltcalc_P6 work/kat/gul_S1_pltcalc_P7 work/kat/gul_S1_pltcalc_P8 work/kat/gul_S1_pltcalc_P9 work/kat/gul_S1_pltcalc_P10 > output/gul_S1_pltcalc.csv & kpid5=$!
+kat work/kat/gul_S1_summarycalc_P1 work/kat/gul_S1_summarycalc_P2 work/kat/gul_S1_summarycalc_P3 work/kat/gul_S1_summarycalc_P4 work/kat/gul_S1_summarycalc_P5 work/kat/gul_S1_summarycalc_P6 work/kat/gul_S1_summarycalc_P7 work/kat/gul_S1_summarycalc_P8 work/kat/gul_S1_summarycalc_P9 work/kat/gul_S1_summarycalc_P10 > output/gul_S1_summarycalc.csv & kpid6=$!
+wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
+
+
+aalcalc -Kil_S1_summaryaalcalc > output/il_S1_aalcalc.csv & lpid1=$!
+ordleccalc -r -Kil_S1_summaryleccalc -W -w -o output/il_S1_psept.csv & lpid2=$!
+leccalc -r -Kil_S1_summaryleccalc -F output/il_S1_leccalc_full_uncertainty_aep.csv -f output/il_S1_leccalc_full_uncertainty_oep.csv -S output/il_S1_leccalc_sample_mean_aep.csv -s output/il_S1_leccalc_sample_mean_oep.csv -W output/il_S1_leccalc_wheatsheaf_aep.csv -M output/il_S1_leccalc_wheatsheaf_mean_aep.csv -m output/il_S1_leccalc_wheatsheaf_mean_oep.csv -w output/il_S1_leccalc_wheatsheaf_oep.csv & lpid3=$!
+aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv & lpid4=$!
+ordleccalc  -Kgul_S1_summaryleccalc -W -w -o output/gul_S1_psept.csv & lpid5=$!
+leccalc -r -Kgul_S1_summaryleccalc -F output/gul_S1_leccalc_full_uncertainty_aep.csv -f output/gul_S1_leccalc_full_uncertainty_oep.csv -S output/gul_S1_leccalc_sample_mean_aep.csv -s output/gul_S1_leccalc_sample_mean_oep.csv -W output/gul_S1_leccalc_wheatsheaf_aep.csv -M output/gul_S1_leccalc_wheatsheaf_mean_aep.csv -m output/gul_S1_leccalc_wheatsheaf_mean_oep.csv -w output/gul_S1_leccalc_wheatsheaf_oep.csv & lpid6=$!
+wait $lpid1 $lpid2 $lpid3 $lpid4 $lpid5 $lpid6
+
+rm -R -f work/*
+rm -R -f fifo/*

--- a/tests/model_execution/cov_kparse_reference/gul_ord_ept_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_ord_ept_1_output_1_partition.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+
+rm -R -f fifo/*
+rm -R -f work/*
+mkdir work/kat/
+
+mkdir work/gul_S1_summaryleccalc
+
+mkfifo fifo/gul_P1
+
+mkfifo fifo/gul_S1_summary_P1
+
+
+
+# --- Do ground up loss computes ---
+
+
+tee < fifo/gul_S1_summary_P1 work/gul_S1_summaryleccalc/P1.bin > /dev/null & pid1=$!
+
+summarycalc -g  -1 fifo/gul_S1_summary_P1 < fifo/gul_P1 &
+
+eve 1 1 | getmodel | gulcalc -S0 -L0 -r -c - > fifo/gul_P1  &
+
+wait $pid1
+
+
+# --- Do ground up loss kats ---
+
+
+ordleccalc -r -Kgul_S1_summaryleccalc -F -f -S -s -M -m -O output/gul_S1_ept.csv & lpid1=$!
+wait $lpid1
+
+rm -R -f work/*
+rm -R -f fifo/*

--- a/tests/model_execution/cov_kparse_reference/gul_ord_ept_1_output_20_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_ord_ept_1_output_20_partition.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+
+rm -R -f fifo/*
+rm -R -f work/*
+mkdir work/kat/
+
+mkdir work/gul_S1_summaryleccalc
+
+mkfifo fifo/gul_P1
+mkfifo fifo/gul_P2
+mkfifo fifo/gul_P3
+mkfifo fifo/gul_P4
+mkfifo fifo/gul_P5
+mkfifo fifo/gul_P6
+mkfifo fifo/gul_P7
+mkfifo fifo/gul_P8
+mkfifo fifo/gul_P9
+mkfifo fifo/gul_P10
+mkfifo fifo/gul_P11
+mkfifo fifo/gul_P12
+mkfifo fifo/gul_P13
+mkfifo fifo/gul_P14
+mkfifo fifo/gul_P15
+mkfifo fifo/gul_P16
+mkfifo fifo/gul_P17
+mkfifo fifo/gul_P18
+mkfifo fifo/gul_P19
+mkfifo fifo/gul_P20
+
+mkfifo fifo/gul_S1_summary_P1
+
+mkfifo fifo/gul_S1_summary_P2
+
+mkfifo fifo/gul_S1_summary_P3
+
+mkfifo fifo/gul_S1_summary_P4
+
+mkfifo fifo/gul_S1_summary_P5
+
+mkfifo fifo/gul_S1_summary_P6
+
+mkfifo fifo/gul_S1_summary_P7
+
+mkfifo fifo/gul_S1_summary_P8
+
+mkfifo fifo/gul_S1_summary_P9
+
+mkfifo fifo/gul_S1_summary_P10
+
+mkfifo fifo/gul_S1_summary_P11
+
+mkfifo fifo/gul_S1_summary_P12
+
+mkfifo fifo/gul_S1_summary_P13
+
+mkfifo fifo/gul_S1_summary_P14
+
+mkfifo fifo/gul_S1_summary_P15
+
+mkfifo fifo/gul_S1_summary_P16
+
+mkfifo fifo/gul_S1_summary_P17
+
+mkfifo fifo/gul_S1_summary_P18
+
+mkfifo fifo/gul_S1_summary_P19
+
+mkfifo fifo/gul_S1_summary_P20
+
+
+
+# --- Do ground up loss computes ---
+
+
+tee < fifo/gul_S1_summary_P1 work/gul_S1_summaryleccalc/P1.bin > /dev/null & pid1=$!
+tee < fifo/gul_S1_summary_P2 work/gul_S1_summaryleccalc/P2.bin > /dev/null & pid2=$!
+tee < fifo/gul_S1_summary_P3 work/gul_S1_summaryleccalc/P3.bin > /dev/null & pid3=$!
+tee < fifo/gul_S1_summary_P4 work/gul_S1_summaryleccalc/P4.bin > /dev/null & pid4=$!
+tee < fifo/gul_S1_summary_P5 work/gul_S1_summaryleccalc/P5.bin > /dev/null & pid5=$!
+tee < fifo/gul_S1_summary_P6 work/gul_S1_summaryleccalc/P6.bin > /dev/null & pid6=$!
+tee < fifo/gul_S1_summary_P7 work/gul_S1_summaryleccalc/P7.bin > /dev/null & pid7=$!
+tee < fifo/gul_S1_summary_P8 work/gul_S1_summaryleccalc/P8.bin > /dev/null & pid8=$!
+tee < fifo/gul_S1_summary_P9 work/gul_S1_summaryleccalc/P9.bin > /dev/null & pid9=$!
+tee < fifo/gul_S1_summary_P10 work/gul_S1_summaryleccalc/P10.bin > /dev/null & pid10=$!
+tee < fifo/gul_S1_summary_P11 work/gul_S1_summaryleccalc/P11.bin > /dev/null & pid11=$!
+tee < fifo/gul_S1_summary_P12 work/gul_S1_summaryleccalc/P12.bin > /dev/null & pid12=$!
+tee < fifo/gul_S1_summary_P13 work/gul_S1_summaryleccalc/P13.bin > /dev/null & pid13=$!
+tee < fifo/gul_S1_summary_P14 work/gul_S1_summaryleccalc/P14.bin > /dev/null & pid14=$!
+tee < fifo/gul_S1_summary_P15 work/gul_S1_summaryleccalc/P15.bin > /dev/null & pid15=$!
+tee < fifo/gul_S1_summary_P16 work/gul_S1_summaryleccalc/P16.bin > /dev/null & pid16=$!
+tee < fifo/gul_S1_summary_P17 work/gul_S1_summaryleccalc/P17.bin > /dev/null & pid17=$!
+tee < fifo/gul_S1_summary_P18 work/gul_S1_summaryleccalc/P18.bin > /dev/null & pid18=$!
+tee < fifo/gul_S1_summary_P19 work/gul_S1_summaryleccalc/P19.bin > /dev/null & pid19=$!
+tee < fifo/gul_S1_summary_P20 work/gul_S1_summaryleccalc/P20.bin > /dev/null & pid20=$!
+
+summarycalc -g  -1 fifo/gul_S1_summary_P1 < fifo/gul_P1 &
+summarycalc -g  -1 fifo/gul_S1_summary_P2 < fifo/gul_P2 &
+summarycalc -g  -1 fifo/gul_S1_summary_P3 < fifo/gul_P3 &
+summarycalc -g  -1 fifo/gul_S1_summary_P4 < fifo/gul_P4 &
+summarycalc -g  -1 fifo/gul_S1_summary_P5 < fifo/gul_P5 &
+summarycalc -g  -1 fifo/gul_S1_summary_P6 < fifo/gul_P6 &
+summarycalc -g  -1 fifo/gul_S1_summary_P7 < fifo/gul_P7 &
+summarycalc -g  -1 fifo/gul_S1_summary_P8 < fifo/gul_P8 &
+summarycalc -g  -1 fifo/gul_S1_summary_P9 < fifo/gul_P9 &
+summarycalc -g  -1 fifo/gul_S1_summary_P10 < fifo/gul_P10 &
+summarycalc -g  -1 fifo/gul_S1_summary_P11 < fifo/gul_P11 &
+summarycalc -g  -1 fifo/gul_S1_summary_P12 < fifo/gul_P12 &
+summarycalc -g  -1 fifo/gul_S1_summary_P13 < fifo/gul_P13 &
+summarycalc -g  -1 fifo/gul_S1_summary_P14 < fifo/gul_P14 &
+summarycalc -g  -1 fifo/gul_S1_summary_P15 < fifo/gul_P15 &
+summarycalc -g  -1 fifo/gul_S1_summary_P16 < fifo/gul_P16 &
+summarycalc -g  -1 fifo/gul_S1_summary_P17 < fifo/gul_P17 &
+summarycalc -g  -1 fifo/gul_S1_summary_P18 < fifo/gul_P18 &
+summarycalc -g  -1 fifo/gul_S1_summary_P19 < fifo/gul_P19 &
+summarycalc -g  -1 fifo/gul_S1_summary_P20 < fifo/gul_P20 &
+
+eve 1 20 | getmodel | gulcalc -S0 -L0 -r -c - > fifo/gul_P1  &
+eve 2 20 | getmodel | gulcalc -S0 -L0 -r -c - > fifo/gul_P2  &
+eve 3 20 | getmodel | gulcalc -S0 -L0 -r -c - > fifo/gul_P3  &
+eve 4 20 | getmodel | gulcalc -S0 -L0 -r -c - > fifo/gul_P4  &
+eve 5 20 | getmodel | gulcalc -S0 -L0 -r -c - > fifo/gul_P5  &
+eve 6 20 | getmodel | gulcalc -S0 -L0 -r -c - > fifo/gul_P6  &
+eve 7 20 | getmodel | gulcalc -S0 -L0 -r -c - > fifo/gul_P7  &
+eve 8 20 | getmodel | gulcalc -S0 -L0 -r -c - > fifo/gul_P8  &
+eve 9 20 | getmodel | gulcalc -S0 -L0 -r -c - > fifo/gul_P9  &
+eve 10 20 | getmodel | gulcalc -S0 -L0 -r -c - > fifo/gul_P10  &
+eve 11 20 | getmodel | gulcalc -S0 -L0 -r -c - > fifo/gul_P11  &
+eve 12 20 | getmodel | gulcalc -S0 -L0 -r -c - > fifo/gul_P12  &
+eve 13 20 | getmodel | gulcalc -S0 -L0 -r -c - > fifo/gul_P13  &
+eve 14 20 | getmodel | gulcalc -S0 -L0 -r -c - > fifo/gul_P14  &
+eve 15 20 | getmodel | gulcalc -S0 -L0 -r -c - > fifo/gul_P15  &
+eve 16 20 | getmodel | gulcalc -S0 -L0 -r -c - > fifo/gul_P16  &
+eve 17 20 | getmodel | gulcalc -S0 -L0 -r -c - > fifo/gul_P17  &
+eve 18 20 | getmodel | gulcalc -S0 -L0 -r -c - > fifo/gul_P18  &
+eve 19 20 | getmodel | gulcalc -S0 -L0 -r -c - > fifo/gul_P19  &
+eve 20 20 | getmodel | gulcalc -S0 -L0 -r -c - > fifo/gul_P20  &
+
+wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 $pid13 $pid14 $pid15 $pid16 $pid17 $pid18 $pid19 $pid20
+
+
+# --- Do ground up loss kats ---
+
+
+ordleccalc -r -Kgul_S1_summaryleccalc -F -f -S -s -M -m -O output/gul_S1_ept.csv & lpid1=$!
+wait $lpid1
+
+rm -R -f work/*
+rm -R -f fifo/*

--- a/tests/model_execution/cov_kparse_reference/gul_ord_ept_psept_lec_2_output_10_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_ord_ept_psept_lec_2_output_10_partition.sh
@@ -1,0 +1,256 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+
+rm -R -f fifo/*
+rm -R -f work/*
+mkdir work/kat/
+
+mkdir work/gul_S1_summaryleccalc
+mkdir work/gul_S1_summaryaalcalc
+mkdir work/gul_S2_summaryleccalc
+mkdir work/gul_S2_summaryaalcalc
+
+mkfifo fifo/gul_P1
+mkfifo fifo/gul_P2
+mkfifo fifo/gul_P3
+mkfifo fifo/gul_P4
+mkfifo fifo/gul_P5
+mkfifo fifo/gul_P6
+mkfifo fifo/gul_P7
+mkfifo fifo/gul_P8
+mkfifo fifo/gul_P9
+mkfifo fifo/gul_P10
+
+mkfifo fifo/gul_S1_summary_P1
+mkfifo fifo/gul_S1_eltcalc_P1
+mkfifo fifo/gul_S1_summarycalc_P1
+mkfifo fifo/gul_S1_pltcalc_P1
+mkfifo fifo/gul_S2_summary_P1
+mkfifo fifo/gul_S2_eltcalc_P1
+mkfifo fifo/gul_S2_summarycalc_P1
+mkfifo fifo/gul_S2_pltcalc_P1
+
+mkfifo fifo/gul_S1_summary_P2
+mkfifo fifo/gul_S1_eltcalc_P2
+mkfifo fifo/gul_S1_summarycalc_P2
+mkfifo fifo/gul_S1_pltcalc_P2
+mkfifo fifo/gul_S2_summary_P2
+mkfifo fifo/gul_S2_eltcalc_P2
+mkfifo fifo/gul_S2_summarycalc_P2
+mkfifo fifo/gul_S2_pltcalc_P2
+
+mkfifo fifo/gul_S1_summary_P3
+mkfifo fifo/gul_S1_eltcalc_P3
+mkfifo fifo/gul_S1_summarycalc_P3
+mkfifo fifo/gul_S1_pltcalc_P3
+mkfifo fifo/gul_S2_summary_P3
+mkfifo fifo/gul_S2_eltcalc_P3
+mkfifo fifo/gul_S2_summarycalc_P3
+mkfifo fifo/gul_S2_pltcalc_P3
+
+mkfifo fifo/gul_S1_summary_P4
+mkfifo fifo/gul_S1_eltcalc_P4
+mkfifo fifo/gul_S1_summarycalc_P4
+mkfifo fifo/gul_S1_pltcalc_P4
+mkfifo fifo/gul_S2_summary_P4
+mkfifo fifo/gul_S2_eltcalc_P4
+mkfifo fifo/gul_S2_summarycalc_P4
+mkfifo fifo/gul_S2_pltcalc_P4
+
+mkfifo fifo/gul_S1_summary_P5
+mkfifo fifo/gul_S1_eltcalc_P5
+mkfifo fifo/gul_S1_summarycalc_P5
+mkfifo fifo/gul_S1_pltcalc_P5
+mkfifo fifo/gul_S2_summary_P5
+mkfifo fifo/gul_S2_eltcalc_P5
+mkfifo fifo/gul_S2_summarycalc_P5
+mkfifo fifo/gul_S2_pltcalc_P5
+
+mkfifo fifo/gul_S1_summary_P6
+mkfifo fifo/gul_S1_eltcalc_P6
+mkfifo fifo/gul_S1_summarycalc_P6
+mkfifo fifo/gul_S1_pltcalc_P6
+mkfifo fifo/gul_S2_summary_P6
+mkfifo fifo/gul_S2_eltcalc_P6
+mkfifo fifo/gul_S2_summarycalc_P6
+mkfifo fifo/gul_S2_pltcalc_P6
+
+mkfifo fifo/gul_S1_summary_P7
+mkfifo fifo/gul_S1_eltcalc_P7
+mkfifo fifo/gul_S1_summarycalc_P7
+mkfifo fifo/gul_S1_pltcalc_P7
+mkfifo fifo/gul_S2_summary_P7
+mkfifo fifo/gul_S2_eltcalc_P7
+mkfifo fifo/gul_S2_summarycalc_P7
+mkfifo fifo/gul_S2_pltcalc_P7
+
+mkfifo fifo/gul_S1_summary_P8
+mkfifo fifo/gul_S1_eltcalc_P8
+mkfifo fifo/gul_S1_summarycalc_P8
+mkfifo fifo/gul_S1_pltcalc_P8
+mkfifo fifo/gul_S2_summary_P8
+mkfifo fifo/gul_S2_eltcalc_P8
+mkfifo fifo/gul_S2_summarycalc_P8
+mkfifo fifo/gul_S2_pltcalc_P8
+
+mkfifo fifo/gul_S1_summary_P9
+mkfifo fifo/gul_S1_eltcalc_P9
+mkfifo fifo/gul_S1_summarycalc_P9
+mkfifo fifo/gul_S1_pltcalc_P9
+mkfifo fifo/gul_S2_summary_P9
+mkfifo fifo/gul_S2_eltcalc_P9
+mkfifo fifo/gul_S2_summarycalc_P9
+mkfifo fifo/gul_S2_pltcalc_P9
+
+mkfifo fifo/gul_S1_summary_P10
+mkfifo fifo/gul_S1_eltcalc_P10
+mkfifo fifo/gul_S1_summarycalc_P10
+mkfifo fifo/gul_S1_pltcalc_P10
+mkfifo fifo/gul_S2_summary_P10
+mkfifo fifo/gul_S2_eltcalc_P10
+mkfifo fifo/gul_S2_summarycalc_P10
+mkfifo fifo/gul_S2_pltcalc_P10
+
+
+
+# --- Do ground up loss computes ---
+
+eltcalc < fifo/gul_S1_eltcalc_P1 > work/kat/gul_S1_eltcalc_P1 & pid1=$!
+summarycalctocsv < fifo/gul_S1_summarycalc_P1 > work/kat/gul_S1_summarycalc_P1 & pid2=$!
+pltcalc < fifo/gul_S1_pltcalc_P1 > work/kat/gul_S1_pltcalc_P1 & pid3=$!
+eltcalc < fifo/gul_S2_eltcalc_P1 > work/kat/gul_S2_eltcalc_P1 & pid4=$!
+summarycalctocsv < fifo/gul_S2_summarycalc_P1 > work/kat/gul_S2_summarycalc_P1 & pid5=$!
+pltcalc < fifo/gul_S2_pltcalc_P1 > work/kat/gul_S2_pltcalc_P1 & pid6=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P2 > work/kat/gul_S1_eltcalc_P2 & pid7=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P2 > work/kat/gul_S1_summarycalc_P2 & pid8=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P2 > work/kat/gul_S1_pltcalc_P2 & pid9=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P2 > work/kat/gul_S2_eltcalc_P2 & pid10=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P2 > work/kat/gul_S2_summarycalc_P2 & pid11=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P2 > work/kat/gul_S2_pltcalc_P2 & pid12=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P3 > work/kat/gul_S1_eltcalc_P3 & pid13=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P3 > work/kat/gul_S1_summarycalc_P3 & pid14=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P3 > work/kat/gul_S1_pltcalc_P3 & pid15=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P3 > work/kat/gul_S2_eltcalc_P3 & pid16=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P3 > work/kat/gul_S2_summarycalc_P3 & pid17=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P3 > work/kat/gul_S2_pltcalc_P3 & pid18=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P4 > work/kat/gul_S1_eltcalc_P4 & pid19=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P4 > work/kat/gul_S1_summarycalc_P4 & pid20=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P4 > work/kat/gul_S1_pltcalc_P4 & pid21=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P4 > work/kat/gul_S2_eltcalc_P4 & pid22=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P4 > work/kat/gul_S2_summarycalc_P4 & pid23=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P4 > work/kat/gul_S2_pltcalc_P4 & pid24=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P5 > work/kat/gul_S1_eltcalc_P5 & pid25=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P5 > work/kat/gul_S1_summarycalc_P5 & pid26=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P5 > work/kat/gul_S1_pltcalc_P5 & pid27=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P5 > work/kat/gul_S2_eltcalc_P5 & pid28=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P5 > work/kat/gul_S2_summarycalc_P5 & pid29=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P5 > work/kat/gul_S2_pltcalc_P5 & pid30=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P6 > work/kat/gul_S1_eltcalc_P6 & pid31=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P6 > work/kat/gul_S1_summarycalc_P6 & pid32=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P6 > work/kat/gul_S1_pltcalc_P6 & pid33=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P6 > work/kat/gul_S2_eltcalc_P6 & pid34=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P6 > work/kat/gul_S2_summarycalc_P6 & pid35=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P6 > work/kat/gul_S2_pltcalc_P6 & pid36=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P7 > work/kat/gul_S1_eltcalc_P7 & pid37=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P7 > work/kat/gul_S1_summarycalc_P7 & pid38=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P7 > work/kat/gul_S1_pltcalc_P7 & pid39=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P7 > work/kat/gul_S2_eltcalc_P7 & pid40=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P7 > work/kat/gul_S2_summarycalc_P7 & pid41=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P7 > work/kat/gul_S2_pltcalc_P7 & pid42=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P8 > work/kat/gul_S1_eltcalc_P8 & pid43=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P8 > work/kat/gul_S1_summarycalc_P8 & pid44=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P8 > work/kat/gul_S1_pltcalc_P8 & pid45=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P8 > work/kat/gul_S2_eltcalc_P8 & pid46=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P8 > work/kat/gul_S2_summarycalc_P8 & pid47=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P8 > work/kat/gul_S2_pltcalc_P8 & pid48=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P9 > work/kat/gul_S1_eltcalc_P9 & pid49=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P9 > work/kat/gul_S1_summarycalc_P9 & pid50=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P9 > work/kat/gul_S1_pltcalc_P9 & pid51=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P9 > work/kat/gul_S2_eltcalc_P9 & pid52=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P9 > work/kat/gul_S2_summarycalc_P9 & pid53=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P9 > work/kat/gul_S2_pltcalc_P9 & pid54=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P10 > work/kat/gul_S1_eltcalc_P10 & pid55=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P10 > work/kat/gul_S1_summarycalc_P10 & pid56=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P10 > work/kat/gul_S1_pltcalc_P10 & pid57=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P10 > work/kat/gul_S2_eltcalc_P10 & pid58=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P10 > work/kat/gul_S2_summarycalc_P10 & pid59=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P10 > work/kat/gul_S2_pltcalc_P10 & pid60=$!
+
+tee < fifo/gul_S1_summary_P1 fifo/gul_S1_eltcalc_P1 fifo/gul_S1_summarycalc_P1 fifo/gul_S1_pltcalc_P1 work/gul_S1_summaryaalcalc/P1.bin work/gul_S1_summaryleccalc/P1.bin > /dev/null & pid61=$!
+tee < fifo/gul_S2_summary_P1 fifo/gul_S2_eltcalc_P1 fifo/gul_S2_summarycalc_P1 fifo/gul_S2_pltcalc_P1 work/gul_S2_summaryaalcalc/P1.bin work/gul_S2_summaryleccalc/P1.bin > /dev/null & pid62=$!
+tee < fifo/gul_S1_summary_P2 fifo/gul_S1_eltcalc_P2 fifo/gul_S1_summarycalc_P2 fifo/gul_S1_pltcalc_P2 work/gul_S1_summaryaalcalc/P2.bin work/gul_S1_summaryleccalc/P2.bin > /dev/null & pid63=$!
+tee < fifo/gul_S2_summary_P2 fifo/gul_S2_eltcalc_P2 fifo/gul_S2_summarycalc_P2 fifo/gul_S2_pltcalc_P2 work/gul_S2_summaryaalcalc/P2.bin work/gul_S2_summaryleccalc/P2.bin > /dev/null & pid64=$!
+tee < fifo/gul_S1_summary_P3 fifo/gul_S1_eltcalc_P3 fifo/gul_S1_summarycalc_P3 fifo/gul_S1_pltcalc_P3 work/gul_S1_summaryaalcalc/P3.bin work/gul_S1_summaryleccalc/P3.bin > /dev/null & pid65=$!
+tee < fifo/gul_S2_summary_P3 fifo/gul_S2_eltcalc_P3 fifo/gul_S2_summarycalc_P3 fifo/gul_S2_pltcalc_P3 work/gul_S2_summaryaalcalc/P3.bin work/gul_S2_summaryleccalc/P3.bin > /dev/null & pid66=$!
+tee < fifo/gul_S1_summary_P4 fifo/gul_S1_eltcalc_P4 fifo/gul_S1_summarycalc_P4 fifo/gul_S1_pltcalc_P4 work/gul_S1_summaryaalcalc/P4.bin work/gul_S1_summaryleccalc/P4.bin > /dev/null & pid67=$!
+tee < fifo/gul_S2_summary_P4 fifo/gul_S2_eltcalc_P4 fifo/gul_S2_summarycalc_P4 fifo/gul_S2_pltcalc_P4 work/gul_S2_summaryaalcalc/P4.bin work/gul_S2_summaryleccalc/P4.bin > /dev/null & pid68=$!
+tee < fifo/gul_S1_summary_P5 fifo/gul_S1_eltcalc_P5 fifo/gul_S1_summarycalc_P5 fifo/gul_S1_pltcalc_P5 work/gul_S1_summaryaalcalc/P5.bin work/gul_S1_summaryleccalc/P5.bin > /dev/null & pid69=$!
+tee < fifo/gul_S2_summary_P5 fifo/gul_S2_eltcalc_P5 fifo/gul_S2_summarycalc_P5 fifo/gul_S2_pltcalc_P5 work/gul_S2_summaryaalcalc/P5.bin work/gul_S2_summaryleccalc/P5.bin > /dev/null & pid70=$!
+tee < fifo/gul_S1_summary_P6 fifo/gul_S1_eltcalc_P6 fifo/gul_S1_summarycalc_P6 fifo/gul_S1_pltcalc_P6 work/gul_S1_summaryaalcalc/P6.bin work/gul_S1_summaryleccalc/P6.bin > /dev/null & pid71=$!
+tee < fifo/gul_S2_summary_P6 fifo/gul_S2_eltcalc_P6 fifo/gul_S2_summarycalc_P6 fifo/gul_S2_pltcalc_P6 work/gul_S2_summaryaalcalc/P6.bin work/gul_S2_summaryleccalc/P6.bin > /dev/null & pid72=$!
+tee < fifo/gul_S1_summary_P7 fifo/gul_S1_eltcalc_P7 fifo/gul_S1_summarycalc_P7 fifo/gul_S1_pltcalc_P7 work/gul_S1_summaryaalcalc/P7.bin work/gul_S1_summaryleccalc/P7.bin > /dev/null & pid73=$!
+tee < fifo/gul_S2_summary_P7 fifo/gul_S2_eltcalc_P7 fifo/gul_S2_summarycalc_P7 fifo/gul_S2_pltcalc_P7 work/gul_S2_summaryaalcalc/P7.bin work/gul_S2_summaryleccalc/P7.bin > /dev/null & pid74=$!
+tee < fifo/gul_S1_summary_P8 fifo/gul_S1_eltcalc_P8 fifo/gul_S1_summarycalc_P8 fifo/gul_S1_pltcalc_P8 work/gul_S1_summaryaalcalc/P8.bin work/gul_S1_summaryleccalc/P8.bin > /dev/null & pid75=$!
+tee < fifo/gul_S2_summary_P8 fifo/gul_S2_eltcalc_P8 fifo/gul_S2_summarycalc_P8 fifo/gul_S2_pltcalc_P8 work/gul_S2_summaryaalcalc/P8.bin work/gul_S2_summaryleccalc/P8.bin > /dev/null & pid76=$!
+tee < fifo/gul_S1_summary_P9 fifo/gul_S1_eltcalc_P9 fifo/gul_S1_summarycalc_P9 fifo/gul_S1_pltcalc_P9 work/gul_S1_summaryaalcalc/P9.bin work/gul_S1_summaryleccalc/P9.bin > /dev/null & pid77=$!
+tee < fifo/gul_S2_summary_P9 fifo/gul_S2_eltcalc_P9 fifo/gul_S2_summarycalc_P9 fifo/gul_S2_pltcalc_P9 work/gul_S2_summaryaalcalc/P9.bin work/gul_S2_summaryleccalc/P9.bin > /dev/null & pid78=$!
+tee < fifo/gul_S1_summary_P10 fifo/gul_S1_eltcalc_P10 fifo/gul_S1_summarycalc_P10 fifo/gul_S1_pltcalc_P10 work/gul_S1_summaryaalcalc/P10.bin work/gul_S1_summaryleccalc/P10.bin > /dev/null & pid79=$!
+tee < fifo/gul_S2_summary_P10 fifo/gul_S2_eltcalc_P10 fifo/gul_S2_summarycalc_P10 fifo/gul_S2_pltcalc_P10 work/gul_S2_summaryaalcalc/P10.bin work/gul_S2_summaryleccalc/P10.bin > /dev/null & pid80=$!
+
+summarycalc -g  -1 fifo/gul_S1_summary_P1 -2 fifo/gul_S2_summary_P1 < fifo/gul_P1 &
+summarycalc -g  -1 fifo/gul_S1_summary_P2 -2 fifo/gul_S2_summary_P2 < fifo/gul_P2 &
+summarycalc -g  -1 fifo/gul_S1_summary_P3 -2 fifo/gul_S2_summary_P3 < fifo/gul_P3 &
+summarycalc -g  -1 fifo/gul_S1_summary_P4 -2 fifo/gul_S2_summary_P4 < fifo/gul_P4 &
+summarycalc -g  -1 fifo/gul_S1_summary_P5 -2 fifo/gul_S2_summary_P5 < fifo/gul_P5 &
+summarycalc -g  -1 fifo/gul_S1_summary_P6 -2 fifo/gul_S2_summary_P6 < fifo/gul_P6 &
+summarycalc -g  -1 fifo/gul_S1_summary_P7 -2 fifo/gul_S2_summary_P7 < fifo/gul_P7 &
+summarycalc -g  -1 fifo/gul_S1_summary_P8 -2 fifo/gul_S2_summary_P8 < fifo/gul_P8 &
+summarycalc -g  -1 fifo/gul_S1_summary_P9 -2 fifo/gul_S2_summary_P9 < fifo/gul_P9 &
+summarycalc -g  -1 fifo/gul_S1_summary_P10 -2 fifo/gul_S2_summary_P10 < fifo/gul_P10 &
+
+eve 1 10 | getmodel | gulcalc -S0 -L0 -r -c - > fifo/gul_P1  &
+eve 2 10 | getmodel | gulcalc -S0 -L0 -r -c - > fifo/gul_P2  &
+eve 3 10 | getmodel | gulcalc -S0 -L0 -r -c - > fifo/gul_P3  &
+eve 4 10 | getmodel | gulcalc -S0 -L0 -r -c - > fifo/gul_P4  &
+eve 5 10 | getmodel | gulcalc -S0 -L0 -r -c - > fifo/gul_P5  &
+eve 6 10 | getmodel | gulcalc -S0 -L0 -r -c - > fifo/gul_P6  &
+eve 7 10 | getmodel | gulcalc -S0 -L0 -r -c - > fifo/gul_P7  &
+eve 8 10 | getmodel | gulcalc -S0 -L0 -r -c - > fifo/gul_P8  &
+eve 9 10 | getmodel | gulcalc -S0 -L0 -r -c - > fifo/gul_P9  &
+eve 10 10 | getmodel | gulcalc -S0 -L0 -r -c - > fifo/gul_P10  &
+
+wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 $pid13 $pid14 $pid15 $pid16 $pid17 $pid18 $pid19 $pid20 $pid21 $pid22 $pid23 $pid24 $pid25 $pid26 $pid27 $pid28 $pid29 $pid30 $pid31 $pid32 $pid33 $pid34 $pid35 $pid36 $pid37 $pid38 $pid39 $pid40 $pid41 $pid42 $pid43 $pid44 $pid45 $pid46 $pid47 $pid48 $pid49 $pid50 $pid51 $pid52 $pid53 $pid54 $pid55 $pid56 $pid57 $pid58 $pid59 $pid60 $pid61 $pid62 $pid63 $pid64 $pid65 $pid66 $pid67 $pid68 $pid69 $pid70 $pid71 $pid72 $pid73 $pid74 $pid75 $pid76 $pid77 $pid78 $pid79 $pid80
+
+
+# --- Do ground up loss kats ---
+
+kat -s work/kat/gul_S1_eltcalc_P1 work/kat/gul_S1_eltcalc_P2 work/kat/gul_S1_eltcalc_P3 work/kat/gul_S1_eltcalc_P4 work/kat/gul_S1_eltcalc_P5 work/kat/gul_S1_eltcalc_P6 work/kat/gul_S1_eltcalc_P7 work/kat/gul_S1_eltcalc_P8 work/kat/gul_S1_eltcalc_P9 work/kat/gul_S1_eltcalc_P10 > output/gul_S1_eltcalc.csv & kpid1=$!
+kat work/kat/gul_S1_pltcalc_P1 work/kat/gul_S1_pltcalc_P2 work/kat/gul_S1_pltcalc_P3 work/kat/gul_S1_pltcalc_P4 work/kat/gul_S1_pltcalc_P5 work/kat/gul_S1_pltcalc_P6 work/kat/gul_S1_pltcalc_P7 work/kat/gul_S1_pltcalc_P8 work/kat/gul_S1_pltcalc_P9 work/kat/gul_S1_pltcalc_P10 > output/gul_S1_pltcalc.csv & kpid2=$!
+kat work/kat/gul_S1_summarycalc_P1 work/kat/gul_S1_summarycalc_P2 work/kat/gul_S1_summarycalc_P3 work/kat/gul_S1_summarycalc_P4 work/kat/gul_S1_summarycalc_P5 work/kat/gul_S1_summarycalc_P6 work/kat/gul_S1_summarycalc_P7 work/kat/gul_S1_summarycalc_P8 work/kat/gul_S1_summarycalc_P9 work/kat/gul_S1_summarycalc_P10 > output/gul_S1_summarycalc.csv & kpid3=$!
+kat -s work/kat/gul_S2_eltcalc_P1 work/kat/gul_S2_eltcalc_P2 work/kat/gul_S2_eltcalc_P3 work/kat/gul_S2_eltcalc_P4 work/kat/gul_S2_eltcalc_P5 work/kat/gul_S2_eltcalc_P6 work/kat/gul_S2_eltcalc_P7 work/kat/gul_S2_eltcalc_P8 work/kat/gul_S2_eltcalc_P9 work/kat/gul_S2_eltcalc_P10 > output/gul_S2_eltcalc.csv & kpid4=$!
+kat work/kat/gul_S2_pltcalc_P1 work/kat/gul_S2_pltcalc_P2 work/kat/gul_S2_pltcalc_P3 work/kat/gul_S2_pltcalc_P4 work/kat/gul_S2_pltcalc_P5 work/kat/gul_S2_pltcalc_P6 work/kat/gul_S2_pltcalc_P7 work/kat/gul_S2_pltcalc_P8 work/kat/gul_S2_pltcalc_P9 work/kat/gul_S2_pltcalc_P10 > output/gul_S2_pltcalc.csv & kpid5=$!
+kat work/kat/gul_S2_summarycalc_P1 work/kat/gul_S2_summarycalc_P2 work/kat/gul_S2_summarycalc_P3 work/kat/gul_S2_summarycalc_P4 work/kat/gul_S2_summarycalc_P5 work/kat/gul_S2_summarycalc_P6 work/kat/gul_S2_summarycalc_P7 work/kat/gul_S2_summarycalc_P8 work/kat/gul_S2_summarycalc_P9 work/kat/gul_S2_summarycalc_P10 > output/gul_S2_summarycalc.csv & kpid6=$!
+wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
+
+
+aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv & lpid1=$!
+ordleccalc -r -Kgul_S1_summaryleccalc -F -S -s -M -m -W -w -O output/gul_S1_ept.csv -o output/gul_S1_psept.csv & lpid2=$!
+leccalc -r -Kgul_S1_summaryleccalc -F output/gul_S1_leccalc_full_uncertainty_aep.csv -f output/gul_S1_leccalc_full_uncertainty_oep.csv -S output/gul_S1_leccalc_sample_mean_aep.csv -s output/gul_S1_leccalc_sample_mean_oep.csv -W output/gul_S1_leccalc_wheatsheaf_aep.csv -M output/gul_S1_leccalc_wheatsheaf_mean_aep.csv -m output/gul_S1_leccalc_wheatsheaf_mean_oep.csv -w output/gul_S1_leccalc_wheatsheaf_oep.csv & lpid3=$!
+aalcalc -Kgul_S2_summaryaalcalc > output/gul_S2_aalcalc.csv & lpid4=$!
+ordleccalc -r -Kgul_S2_summaryleccalc -F -S -s -M -m -W -w -O output/gul_S2_ept.csv -o output/gul_S2_psept.csv & lpid5=$!
+leccalc -r -Kgul_S2_summaryleccalc -F output/gul_S2_leccalc_full_uncertainty_aep.csv -f output/gul_S2_leccalc_full_uncertainty_oep.csv -S output/gul_S2_leccalc_sample_mean_aep.csv -s output/gul_S2_leccalc_sample_mean_oep.csv -W output/gul_S2_leccalc_wheatsheaf_aep.csv -M output/gul_S2_leccalc_wheatsheaf_mean_aep.csv -m output/gul_S2_leccalc_wheatsheaf_mean_oep.csv -w output/gul_S2_leccalc_wheatsheaf_oep.csv & lpid6=$!
+wait $lpid1 $lpid2 $lpid3 $lpid4 $lpid5 $lpid6
+
+rm -R -f work/*
+rm -R -f fifo/*

--- a/tests/model_execution/cov_kparse_reference/gul_ord_psept_2_output_10_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_ord_psept_2_output_10_partition.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+
+rm -R -f fifo/*
+rm -R -f work/*
+mkdir work/kat/
+
+mkdir work/gul_S1_summaryleccalc
+mkdir work/gul_S2_summaryleccalc
+
+mkfifo fifo/gul_P1
+mkfifo fifo/gul_P2
+mkfifo fifo/gul_P3
+mkfifo fifo/gul_P4
+mkfifo fifo/gul_P5
+mkfifo fifo/gul_P6
+mkfifo fifo/gul_P7
+mkfifo fifo/gul_P8
+mkfifo fifo/gul_P9
+mkfifo fifo/gul_P10
+
+mkfifo fifo/gul_S1_summary_P1
+mkfifo fifo/gul_S2_summary_P1
+
+mkfifo fifo/gul_S1_summary_P2
+mkfifo fifo/gul_S2_summary_P2
+
+mkfifo fifo/gul_S1_summary_P3
+mkfifo fifo/gul_S2_summary_P3
+
+mkfifo fifo/gul_S1_summary_P4
+mkfifo fifo/gul_S2_summary_P4
+
+mkfifo fifo/gul_S1_summary_P5
+mkfifo fifo/gul_S2_summary_P5
+
+mkfifo fifo/gul_S1_summary_P6
+mkfifo fifo/gul_S2_summary_P6
+
+mkfifo fifo/gul_S1_summary_P7
+mkfifo fifo/gul_S2_summary_P7
+
+mkfifo fifo/gul_S1_summary_P8
+mkfifo fifo/gul_S2_summary_P8
+
+mkfifo fifo/gul_S1_summary_P9
+mkfifo fifo/gul_S2_summary_P9
+
+mkfifo fifo/gul_S1_summary_P10
+mkfifo fifo/gul_S2_summary_P10
+
+
+
+# --- Do ground up loss computes ---
+
+
+tee < fifo/gul_S1_summary_P1 work/gul_S1_summaryleccalc/P1.bin > /dev/null & pid1=$!
+tee < fifo/gul_S2_summary_P1 work/gul_S2_summaryleccalc/P1.bin > /dev/null & pid2=$!
+tee < fifo/gul_S1_summary_P2 work/gul_S1_summaryleccalc/P2.bin > /dev/null & pid3=$!
+tee < fifo/gul_S2_summary_P2 work/gul_S2_summaryleccalc/P2.bin > /dev/null & pid4=$!
+tee < fifo/gul_S1_summary_P3 work/gul_S1_summaryleccalc/P3.bin > /dev/null & pid5=$!
+tee < fifo/gul_S2_summary_P3 work/gul_S2_summaryleccalc/P3.bin > /dev/null & pid6=$!
+tee < fifo/gul_S1_summary_P4 work/gul_S1_summaryleccalc/P4.bin > /dev/null & pid7=$!
+tee < fifo/gul_S2_summary_P4 work/gul_S2_summaryleccalc/P4.bin > /dev/null & pid8=$!
+tee < fifo/gul_S1_summary_P5 work/gul_S1_summaryleccalc/P5.bin > /dev/null & pid9=$!
+tee < fifo/gul_S2_summary_P5 work/gul_S2_summaryleccalc/P5.bin > /dev/null & pid10=$!
+tee < fifo/gul_S1_summary_P6 work/gul_S1_summaryleccalc/P6.bin > /dev/null & pid11=$!
+tee < fifo/gul_S2_summary_P6 work/gul_S2_summaryleccalc/P6.bin > /dev/null & pid12=$!
+tee < fifo/gul_S1_summary_P7 work/gul_S1_summaryleccalc/P7.bin > /dev/null & pid13=$!
+tee < fifo/gul_S2_summary_P7 work/gul_S2_summaryleccalc/P7.bin > /dev/null & pid14=$!
+tee < fifo/gul_S1_summary_P8 work/gul_S1_summaryleccalc/P8.bin > /dev/null & pid15=$!
+tee < fifo/gul_S2_summary_P8 work/gul_S2_summaryleccalc/P8.bin > /dev/null & pid16=$!
+tee < fifo/gul_S1_summary_P9 work/gul_S1_summaryleccalc/P9.bin > /dev/null & pid17=$!
+tee < fifo/gul_S2_summary_P9 work/gul_S2_summaryleccalc/P9.bin > /dev/null & pid18=$!
+tee < fifo/gul_S1_summary_P10 work/gul_S1_summaryleccalc/P10.bin > /dev/null & pid19=$!
+tee < fifo/gul_S2_summary_P10 work/gul_S2_summaryleccalc/P10.bin > /dev/null & pid20=$!
+
+summarycalc -g  -1 fifo/gul_S1_summary_P1 -2 fifo/gul_S2_summary_P1 < fifo/gul_P1 &
+summarycalc -g  -1 fifo/gul_S1_summary_P2 -2 fifo/gul_S2_summary_P2 < fifo/gul_P2 &
+summarycalc -g  -1 fifo/gul_S1_summary_P3 -2 fifo/gul_S2_summary_P3 < fifo/gul_P3 &
+summarycalc -g  -1 fifo/gul_S1_summary_P4 -2 fifo/gul_S2_summary_P4 < fifo/gul_P4 &
+summarycalc -g  -1 fifo/gul_S1_summary_P5 -2 fifo/gul_S2_summary_P5 < fifo/gul_P5 &
+summarycalc -g  -1 fifo/gul_S1_summary_P6 -2 fifo/gul_S2_summary_P6 < fifo/gul_P6 &
+summarycalc -g  -1 fifo/gul_S1_summary_P7 -2 fifo/gul_S2_summary_P7 < fifo/gul_P7 &
+summarycalc -g  -1 fifo/gul_S1_summary_P8 -2 fifo/gul_S2_summary_P8 < fifo/gul_P8 &
+summarycalc -g  -1 fifo/gul_S1_summary_P9 -2 fifo/gul_S2_summary_P9 < fifo/gul_P9 &
+summarycalc -g  -1 fifo/gul_S1_summary_P10 -2 fifo/gul_S2_summary_P10 < fifo/gul_P10 &
+
+eve 1 10 | getmodel | gulcalc -S0 -L0 -r -c - > fifo/gul_P1  &
+eve 2 10 | getmodel | gulcalc -S0 -L0 -r -c - > fifo/gul_P2  &
+eve 3 10 | getmodel | gulcalc -S0 -L0 -r -c - > fifo/gul_P3  &
+eve 4 10 | getmodel | gulcalc -S0 -L0 -r -c - > fifo/gul_P4  &
+eve 5 10 | getmodel | gulcalc -S0 -L0 -r -c - > fifo/gul_P5  &
+eve 6 10 | getmodel | gulcalc -S0 -L0 -r -c - > fifo/gul_P6  &
+eve 7 10 | getmodel | gulcalc -S0 -L0 -r -c - > fifo/gul_P7  &
+eve 8 10 | getmodel | gulcalc -S0 -L0 -r -c - > fifo/gul_P8  &
+eve 9 10 | getmodel | gulcalc -S0 -L0 -r -c - > fifo/gul_P9  &
+eve 10 10 | getmodel | gulcalc -S0 -L0 -r -c - > fifo/gul_P10  &
+
+wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 $pid13 $pid14 $pid15 $pid16 $pid17 $pid18 $pid19 $pid20
+
+
+# --- Do ground up loss kats ---
+
+
+ordleccalc  -Kgul_S1_summaryleccalc -W -w -o output/gul_S1_psept.csv & lpid1=$!
+ordleccalc -r -Kgul_S2_summaryleccalc -W -w -o output/gul_S2_psept.csv & lpid2=$!
+wait $lpid1 $lpid2
+
+rm -R -f work/*
+rm -R -f fifo/*

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/analysis_settings_1_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/analysis_settings_1_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/analysis_settings_2_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/analysis_settings_2_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/analysis_settings_5_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/analysis_settings_5_1_reins_layer_1_partition.sh
@@ -1,0 +1,202 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+
+touch log/stderror.err
+ktools_monitor.sh $$ & pid0=$!
+
+exit_handler(){
+   exit_code=$?
+   kill -9 $pid0 2> /dev/null
+   if [ "$exit_code" -gt 0 ]; then
+       echo 'Ktools Run Error - exitcode='$exit_code
+   else
+       echo 'Run Completed'
+   fi
+
+   set +x
+   group_pid=$(ps -p $$ -o pgid --no-headers)
+   sess_pid=$(ps -p $$ -o sess --no-headers)
+   script_pid=$$
+   printf "Script PID:%d, GPID:%s, SPID:%d
+" $script_pid $group_pid $sess_pid >> log/killout.txt
+
+   ps f -g $sess_pid > log/subprocess_list
+   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk -F: '$1>$script_pid' | grep -v celery | grep -v python | grep -v $group_pid | grep -v run_ktools)
+   echo "$PIDS_KILL" >> log/killout.txt
+   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+   exit $exit_code
+}
+trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
+
+check_complete(){
+    set +e
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
+    has_error=0
+    for p in $proc_list; do
+        started=$(find log -name "$p*.log" | wc -l)
+        finished=$(find log -name "$p*.log" -exec grep -l "finish" {} + | wc -l)
+        if [ "$finished" -lt "$started" ]; then
+            echo "[ERROR] $p - $((started-finished)) processes lost"
+            has_error=1
+        elif [ "$started" -gt 0 ]; then
+            echo "[OK] $p"
+        fi
+    done
+    if [ "$has_error" -ne 0 ]; then
+        false # raise non-zero exit code
+    fi
+}
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+mkdir output/full_correlation/
+
+rm -R -f fifo/*
+mkdir fifo/full_correlation/
+rm -R -f work/*
+mkdir work/kat/
+mkdir work/full_correlation/
+mkdir work/full_correlation/kat/
+
+mkdir work/gul_S1_summaryaalcalc
+mkdir work/full_correlation/gul_S1_summaryaalcalc
+mkdir work/il_S1_summaryleccalc
+mkdir work/full_correlation/il_S1_summaryleccalc
+mkdir work/ri_S1_summaryleccalc
+mkdir work/full_correlation/ri_S1_summaryleccalc
+
+mkfifo fifo/full_correlation/gul_fc_P1
+
+mkfifo fifo/gul_P1
+
+mkfifo fifo/gul_S1_summary_P1
+mkfifo fifo/gul_S1_eltcalc_P1
+mkfifo fifo/gul_S1_summarycalc_P1
+mkfifo fifo/gul_S1_pltcalc_P1
+
+mkfifo fifo/il_P1
+
+mkfifo fifo/il_S1_summary_P1
+
+mkfifo fifo/ri_P1
+
+mkfifo fifo/ri_S1_summary_P1
+
+mkfifo fifo/full_correlation/gul_P1
+
+mkfifo fifo/full_correlation/gul_S1_summary_P1
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P1
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P1
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P1
+
+mkfifo fifo/full_correlation/il_P1
+
+mkfifo fifo/full_correlation/il_S1_summary_P1
+
+mkfifo fifo/full_correlation/ri_P1
+
+mkfifo fifo/full_correlation/ri_S1_summary_P1
+
+
+
+# --- Do reinsurance loss computes ---
+
+
+tee < fifo/ri_S1_summary_P1 work/ri_S1_summaryleccalc/P1.bin > /dev/null & pid1=$!
+
+( summarycalc -f -p RI_1 -1 fifo/ri_S1_summary_P1 < fifo/ri_P1 ) 2>> log/stderror.err  &
+
+# --- Do insured loss computes ---
+
+
+tee < fifo/il_S1_summary_P1 work/il_S1_summaryleccalc/P1.bin > /dev/null & pid2=$!
+
+( summarycalc -f  -1 fifo/il_S1_summary_P1 < fifo/il_P1 ) 2>> log/stderror.err  &
+
+# --- Do ground up loss computes ---
+
+( eltcalc < fifo/gul_S1_eltcalc_P1 > work/kat/gul_S1_eltcalc_P1 ) 2>> log/stderror.err & pid3=$!
+( summarycalctocsv < fifo/gul_S1_summarycalc_P1 > work/kat/gul_S1_summarycalc_P1 ) 2>> log/stderror.err & pid4=$!
+( pltcalc < fifo/gul_S1_pltcalc_P1 > work/kat/gul_S1_pltcalc_P1 ) 2>> log/stderror.err & pid5=$!
+
+tee < fifo/gul_S1_summary_P1 fifo/gul_S1_eltcalc_P1 fifo/gul_S1_summarycalc_P1 fifo/gul_S1_pltcalc_P1 work/gul_S1_summaryaalcalc/P1.bin > /dev/null & pid6=$!
+
+( summarycalc -i  -1 fifo/gul_S1_summary_P1 < fifo/gul_P1 ) 2>> log/stderror.err  &
+
+# --- Do reinsurance loss computes ---
+
+
+tee < fifo/full_correlation/ri_S1_summary_P1 work/full_correlation/ri_S1_summaryleccalc/P1.bin > /dev/null & pid7=$!
+
+( summarycalc -f -p RI_1 -1 fifo/full_correlation/ri_S1_summary_P1 < fifo/full_correlation/ri_P1 ) 2>> log/stderror.err  &
+
+# --- Do insured loss computes ---
+
+
+tee < fifo/full_correlation/il_S1_summary_P1 work/full_correlation/il_S1_summaryleccalc/P1.bin > /dev/null & pid8=$!
+
+( summarycalc -f  -1 fifo/full_correlation/il_S1_summary_P1 < fifo/full_correlation/il_P1 ) 2>> log/stderror.err  &
+
+# --- Do ground up loss computes ---
+
+( eltcalc < fifo/full_correlation/gul_S1_eltcalc_P1 > work/full_correlation/kat/gul_S1_eltcalc_P1 ) 2>> log/stderror.err & pid9=$!
+( summarycalctocsv < fifo/full_correlation/gul_S1_summarycalc_P1 > work/full_correlation/kat/gul_S1_summarycalc_P1 ) 2>> log/stderror.err & pid10=$!
+( pltcalc < fifo/full_correlation/gul_S1_pltcalc_P1 > work/full_correlation/kat/gul_S1_pltcalc_P1 ) 2>> log/stderror.err & pid11=$!
+
+tee < fifo/full_correlation/gul_S1_summary_P1 fifo/full_correlation/gul_S1_eltcalc_P1 fifo/full_correlation/gul_S1_summarycalc_P1 fifo/full_correlation/gul_S1_pltcalc_P1 work/full_correlation/gul_S1_summaryaalcalc/P1.bin > /dev/null & pid12=$!
+
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P1 < fifo/full_correlation/gul_P1 ) 2>> log/stderror.err  &
+
+( tee < fifo/full_correlation/gul_fc_P1 fifo/full_correlation/gul_P1  | fmcalc -a2 | tee fifo/full_correlation/il_P1 | fmcalc -a3 -n -p RI_1 > fifo/full_correlation/ri_P1 ) 2>> log/stderror.err &
+( eve 1 1 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_fc_P1 -a1 -i - | tee fifo/gul_P1 | fmcalc -a2 | tee fifo/il_P1 | fmcalc -a3 -n -p RI_1 > fifo/ri_P1 ) 2>> log/stderror.err &
+
+wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12
+
+
+# --- Do reinsurance loss kats ---
+
+
+# --- Do reinsurance loss kats for fully correlated output ---
+
+
+# --- Do insured loss kats ---
+
+
+# --- Do insured loss kats for fully correlated output ---
+
+
+# --- Do ground up loss kats ---
+
+kat -s work/kat/gul_S1_eltcalc_P1 > output/gul_S1_eltcalc.csv & kpid1=$!
+kat work/kat/gul_S1_pltcalc_P1 > output/gul_S1_pltcalc.csv & kpid2=$!
+kat work/kat/gul_S1_summarycalc_P1 > output/gul_S1_summarycalc.csv & kpid3=$!
+
+# --- Do ground up loss kats for fully correlated output ---
+
+kat -s work/full_correlation/kat/gul_S1_eltcalc_P1 > output/full_correlation/gul_S1_eltcalc.csv & kpid4=$!
+kat work/full_correlation/kat/gul_S1_pltcalc_P1 > output/full_correlation/gul_S1_pltcalc.csv & kpid5=$!
+kat work/full_correlation/kat/gul_S1_summarycalc_P1 > output/full_correlation/gul_S1_summarycalc.csv & kpid6=$!
+wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
+
+
+( ordleccalc -r -Kri_S1_summaryleccalc -F -f -S -s -M -m -W -w -O output/ri_S1_ept.csv -o output/ri_S1_psept.csv ) 2>> log/stderror.err & lpid1=$!
+( ordleccalc  -Kil_S1_summaryleccalc -F -S -s -M -m -O output/il_S1_ept.csv ) 2>> log/stderror.err & lpid2=$!
+( aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv ) 2>> log/stderror.err & lpid3=$!
+( ordleccalc -r -Kfull_correlation/ri_S1_summaryleccalc -F -f -S -s -M -m -W -w -O output/full_correlation/ri_S1_ept.csv -o output/full_correlation/ri_S1_psept.csv ) 2>> log/stderror.err & lpid4=$!
+( ordleccalc  -Kfull_correlation/il_S1_summaryleccalc -F -S -s -M -m -O output/full_correlation/il_S1_ept.csv ) 2>> log/stderror.err & lpid5=$!
+( aalcalc -Kfull_correlation/gul_S1_summaryaalcalc > output/full_correlation/gul_S1_aalcalc.csv ) 2>> log/stderror.err & lpid6=$!
+wait $lpid1 $lpid2 $lpid3 $lpid4 $lpid5 $lpid6
+
+rm -R -f work/*
+rm -R -f fifo/*
+
+check_complete
+exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/analysis_settings_5_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/analysis_settings_5_1_reins_layer_1_partition.sh
@@ -29,7 +29,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
    ps f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk -F: '$1>$script_pid' | grep -v celery | grep -v python | grep -v $group_pid | grep -v run_ktools)
+   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | grep -v *.sh)
    echo "$PIDS_KILL" >> log/killout.txt
    kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
    exit $exit_code

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_1_output_2_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_1_output_2_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_2_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_2_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_1_output_2_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_2_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_2_output_2_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_ord_ept_psept_2_output_10_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_ord_ept_psept_2_output_10_partition.sh
@@ -1,0 +1,967 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+
+touch log/stderror.err
+ktools_monitor.sh $$ & pid0=$!
+
+exit_handler(){
+   exit_code=$?
+   kill -9 $pid0 2> /dev/null
+   if [ "$exit_code" -gt 0 ]; then
+       echo 'Ktools Run Error - exitcode='$exit_code
+   else
+       echo 'Run Completed'
+   fi
+
+   set +x
+   group_pid=$(ps -p $$ -o pgid --no-headers)
+   sess_pid=$(ps -p $$ -o sess --no-headers)
+   script_pid=$$
+   printf "Script PID:%d, GPID:%s, SPID:%d
+" $script_pid $group_pid $sess_pid >> log/killout.txt
+
+   ps f -g $sess_pid > log/subprocess_list
+   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk -F: '$1>$script_pid' | grep -v celery | grep -v python | grep -v $group_pid | grep -v run_ktools)
+   echo "$PIDS_KILL" >> log/killout.txt
+   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+   exit $exit_code
+}
+trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
+
+check_complete(){
+    set +e
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
+    has_error=0
+    for p in $proc_list; do
+        started=$(find log -name "$p*.log" | wc -l)
+        finished=$(find log -name "$p*.log" -exec grep -l "finish" {} + | wc -l)
+        if [ "$finished" -lt "$started" ]; then
+            echo "[ERROR] $p - $((started-finished)) processes lost"
+            has_error=1
+        elif [ "$started" -gt 0 ]; then
+            echo "[OK] $p"
+        fi
+    done
+    if [ "$has_error" -ne 0 ]; then
+        false # raise non-zero exit code
+    fi
+}
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+mkdir output/full_correlation/
+
+rm -R -f fifo/*
+mkdir fifo/full_correlation/
+rm -R -f work/*
+mkdir work/kat/
+mkdir work/full_correlation/
+mkdir work/full_correlation/kat/
+
+mkdir work/gul_S1_summaryleccalc
+mkdir work/gul_S1_summaryaalcalc
+mkdir work/gul_S2_summaryleccalc
+mkdir work/gul_S2_summaryaalcalc
+mkdir work/full_correlation/gul_S1_summaryleccalc
+mkdir work/full_correlation/gul_S1_summaryaalcalc
+mkdir work/full_correlation/gul_S2_summaryleccalc
+mkdir work/full_correlation/gul_S2_summaryaalcalc
+mkdir work/il_S1_summaryleccalc
+mkdir work/il_S1_summaryaalcalc
+mkdir work/il_S2_summaryleccalc
+mkdir work/il_S2_summaryaalcalc
+mkdir work/full_correlation/il_S1_summaryleccalc
+mkdir work/full_correlation/il_S1_summaryaalcalc
+mkdir work/full_correlation/il_S2_summaryleccalc
+mkdir work/full_correlation/il_S2_summaryaalcalc
+
+mkfifo fifo/full_correlation/gul_fc_P1
+mkfifo fifo/full_correlation/gul_fc_P2
+mkfifo fifo/full_correlation/gul_fc_P3
+mkfifo fifo/full_correlation/gul_fc_P4
+mkfifo fifo/full_correlation/gul_fc_P5
+mkfifo fifo/full_correlation/gul_fc_P6
+mkfifo fifo/full_correlation/gul_fc_P7
+mkfifo fifo/full_correlation/gul_fc_P8
+mkfifo fifo/full_correlation/gul_fc_P9
+mkfifo fifo/full_correlation/gul_fc_P10
+
+mkfifo fifo/gul_P1
+mkfifo fifo/gul_P2
+mkfifo fifo/gul_P3
+mkfifo fifo/gul_P4
+mkfifo fifo/gul_P5
+mkfifo fifo/gul_P6
+mkfifo fifo/gul_P7
+mkfifo fifo/gul_P8
+mkfifo fifo/gul_P9
+mkfifo fifo/gul_P10
+
+mkfifo fifo/gul_S1_summary_P1
+mkfifo fifo/gul_S1_eltcalc_P1
+mkfifo fifo/gul_S1_summarycalc_P1
+mkfifo fifo/gul_S1_pltcalc_P1
+mkfifo fifo/gul_S2_summary_P1
+mkfifo fifo/gul_S2_eltcalc_P1
+mkfifo fifo/gul_S2_summarycalc_P1
+mkfifo fifo/gul_S2_pltcalc_P1
+
+mkfifo fifo/gul_S1_summary_P2
+mkfifo fifo/gul_S1_eltcalc_P2
+mkfifo fifo/gul_S1_summarycalc_P2
+mkfifo fifo/gul_S1_pltcalc_P2
+mkfifo fifo/gul_S2_summary_P2
+mkfifo fifo/gul_S2_eltcalc_P2
+mkfifo fifo/gul_S2_summarycalc_P2
+mkfifo fifo/gul_S2_pltcalc_P2
+
+mkfifo fifo/gul_S1_summary_P3
+mkfifo fifo/gul_S1_eltcalc_P3
+mkfifo fifo/gul_S1_summarycalc_P3
+mkfifo fifo/gul_S1_pltcalc_P3
+mkfifo fifo/gul_S2_summary_P3
+mkfifo fifo/gul_S2_eltcalc_P3
+mkfifo fifo/gul_S2_summarycalc_P3
+mkfifo fifo/gul_S2_pltcalc_P3
+
+mkfifo fifo/gul_S1_summary_P4
+mkfifo fifo/gul_S1_eltcalc_P4
+mkfifo fifo/gul_S1_summarycalc_P4
+mkfifo fifo/gul_S1_pltcalc_P4
+mkfifo fifo/gul_S2_summary_P4
+mkfifo fifo/gul_S2_eltcalc_P4
+mkfifo fifo/gul_S2_summarycalc_P4
+mkfifo fifo/gul_S2_pltcalc_P4
+
+mkfifo fifo/gul_S1_summary_P5
+mkfifo fifo/gul_S1_eltcalc_P5
+mkfifo fifo/gul_S1_summarycalc_P5
+mkfifo fifo/gul_S1_pltcalc_P5
+mkfifo fifo/gul_S2_summary_P5
+mkfifo fifo/gul_S2_eltcalc_P5
+mkfifo fifo/gul_S2_summarycalc_P5
+mkfifo fifo/gul_S2_pltcalc_P5
+
+mkfifo fifo/gul_S1_summary_P6
+mkfifo fifo/gul_S1_eltcalc_P6
+mkfifo fifo/gul_S1_summarycalc_P6
+mkfifo fifo/gul_S1_pltcalc_P6
+mkfifo fifo/gul_S2_summary_P6
+mkfifo fifo/gul_S2_eltcalc_P6
+mkfifo fifo/gul_S2_summarycalc_P6
+mkfifo fifo/gul_S2_pltcalc_P6
+
+mkfifo fifo/gul_S1_summary_P7
+mkfifo fifo/gul_S1_eltcalc_P7
+mkfifo fifo/gul_S1_summarycalc_P7
+mkfifo fifo/gul_S1_pltcalc_P7
+mkfifo fifo/gul_S2_summary_P7
+mkfifo fifo/gul_S2_eltcalc_P7
+mkfifo fifo/gul_S2_summarycalc_P7
+mkfifo fifo/gul_S2_pltcalc_P7
+
+mkfifo fifo/gul_S1_summary_P8
+mkfifo fifo/gul_S1_eltcalc_P8
+mkfifo fifo/gul_S1_summarycalc_P8
+mkfifo fifo/gul_S1_pltcalc_P8
+mkfifo fifo/gul_S2_summary_P8
+mkfifo fifo/gul_S2_eltcalc_P8
+mkfifo fifo/gul_S2_summarycalc_P8
+mkfifo fifo/gul_S2_pltcalc_P8
+
+mkfifo fifo/gul_S1_summary_P9
+mkfifo fifo/gul_S1_eltcalc_P9
+mkfifo fifo/gul_S1_summarycalc_P9
+mkfifo fifo/gul_S1_pltcalc_P9
+mkfifo fifo/gul_S2_summary_P9
+mkfifo fifo/gul_S2_eltcalc_P9
+mkfifo fifo/gul_S2_summarycalc_P9
+mkfifo fifo/gul_S2_pltcalc_P9
+
+mkfifo fifo/gul_S1_summary_P10
+mkfifo fifo/gul_S1_eltcalc_P10
+mkfifo fifo/gul_S1_summarycalc_P10
+mkfifo fifo/gul_S1_pltcalc_P10
+mkfifo fifo/gul_S2_summary_P10
+mkfifo fifo/gul_S2_eltcalc_P10
+mkfifo fifo/gul_S2_summarycalc_P10
+mkfifo fifo/gul_S2_pltcalc_P10
+
+mkfifo fifo/il_P1
+mkfifo fifo/il_P2
+mkfifo fifo/il_P3
+mkfifo fifo/il_P4
+mkfifo fifo/il_P5
+mkfifo fifo/il_P6
+mkfifo fifo/il_P7
+mkfifo fifo/il_P8
+mkfifo fifo/il_P9
+mkfifo fifo/il_P10
+
+mkfifo fifo/il_S1_summary_P1
+mkfifo fifo/il_S1_eltcalc_P1
+mkfifo fifo/il_S1_summarycalc_P1
+mkfifo fifo/il_S1_pltcalc_P1
+mkfifo fifo/il_S2_summary_P1
+mkfifo fifo/il_S2_eltcalc_P1
+mkfifo fifo/il_S2_summarycalc_P1
+mkfifo fifo/il_S2_pltcalc_P1
+
+mkfifo fifo/il_S1_summary_P2
+mkfifo fifo/il_S1_eltcalc_P2
+mkfifo fifo/il_S1_summarycalc_P2
+mkfifo fifo/il_S1_pltcalc_P2
+mkfifo fifo/il_S2_summary_P2
+mkfifo fifo/il_S2_eltcalc_P2
+mkfifo fifo/il_S2_summarycalc_P2
+mkfifo fifo/il_S2_pltcalc_P2
+
+mkfifo fifo/il_S1_summary_P3
+mkfifo fifo/il_S1_eltcalc_P3
+mkfifo fifo/il_S1_summarycalc_P3
+mkfifo fifo/il_S1_pltcalc_P3
+mkfifo fifo/il_S2_summary_P3
+mkfifo fifo/il_S2_eltcalc_P3
+mkfifo fifo/il_S2_summarycalc_P3
+mkfifo fifo/il_S2_pltcalc_P3
+
+mkfifo fifo/il_S1_summary_P4
+mkfifo fifo/il_S1_eltcalc_P4
+mkfifo fifo/il_S1_summarycalc_P4
+mkfifo fifo/il_S1_pltcalc_P4
+mkfifo fifo/il_S2_summary_P4
+mkfifo fifo/il_S2_eltcalc_P4
+mkfifo fifo/il_S2_summarycalc_P4
+mkfifo fifo/il_S2_pltcalc_P4
+
+mkfifo fifo/il_S1_summary_P5
+mkfifo fifo/il_S1_eltcalc_P5
+mkfifo fifo/il_S1_summarycalc_P5
+mkfifo fifo/il_S1_pltcalc_P5
+mkfifo fifo/il_S2_summary_P5
+mkfifo fifo/il_S2_eltcalc_P5
+mkfifo fifo/il_S2_summarycalc_P5
+mkfifo fifo/il_S2_pltcalc_P5
+
+mkfifo fifo/il_S1_summary_P6
+mkfifo fifo/il_S1_eltcalc_P6
+mkfifo fifo/il_S1_summarycalc_P6
+mkfifo fifo/il_S1_pltcalc_P6
+mkfifo fifo/il_S2_summary_P6
+mkfifo fifo/il_S2_eltcalc_P6
+mkfifo fifo/il_S2_summarycalc_P6
+mkfifo fifo/il_S2_pltcalc_P6
+
+mkfifo fifo/il_S1_summary_P7
+mkfifo fifo/il_S1_eltcalc_P7
+mkfifo fifo/il_S1_summarycalc_P7
+mkfifo fifo/il_S1_pltcalc_P7
+mkfifo fifo/il_S2_summary_P7
+mkfifo fifo/il_S2_eltcalc_P7
+mkfifo fifo/il_S2_summarycalc_P7
+mkfifo fifo/il_S2_pltcalc_P7
+
+mkfifo fifo/il_S1_summary_P8
+mkfifo fifo/il_S1_eltcalc_P8
+mkfifo fifo/il_S1_summarycalc_P8
+mkfifo fifo/il_S1_pltcalc_P8
+mkfifo fifo/il_S2_summary_P8
+mkfifo fifo/il_S2_eltcalc_P8
+mkfifo fifo/il_S2_summarycalc_P8
+mkfifo fifo/il_S2_pltcalc_P8
+
+mkfifo fifo/il_S1_summary_P9
+mkfifo fifo/il_S1_eltcalc_P9
+mkfifo fifo/il_S1_summarycalc_P9
+mkfifo fifo/il_S1_pltcalc_P9
+mkfifo fifo/il_S2_summary_P9
+mkfifo fifo/il_S2_eltcalc_P9
+mkfifo fifo/il_S2_summarycalc_P9
+mkfifo fifo/il_S2_pltcalc_P9
+
+mkfifo fifo/il_S1_summary_P10
+mkfifo fifo/il_S1_eltcalc_P10
+mkfifo fifo/il_S1_summarycalc_P10
+mkfifo fifo/il_S1_pltcalc_P10
+mkfifo fifo/il_S2_summary_P10
+mkfifo fifo/il_S2_eltcalc_P10
+mkfifo fifo/il_S2_summarycalc_P10
+mkfifo fifo/il_S2_pltcalc_P10
+
+mkfifo fifo/full_correlation/gul_P1
+mkfifo fifo/full_correlation/gul_P2
+mkfifo fifo/full_correlation/gul_P3
+mkfifo fifo/full_correlation/gul_P4
+mkfifo fifo/full_correlation/gul_P5
+mkfifo fifo/full_correlation/gul_P6
+mkfifo fifo/full_correlation/gul_P7
+mkfifo fifo/full_correlation/gul_P8
+mkfifo fifo/full_correlation/gul_P9
+mkfifo fifo/full_correlation/gul_P10
+
+mkfifo fifo/full_correlation/gul_S1_summary_P1
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P1
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P1
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P1
+mkfifo fifo/full_correlation/gul_S2_summary_P1
+mkfifo fifo/full_correlation/gul_S2_eltcalc_P1
+mkfifo fifo/full_correlation/gul_S2_summarycalc_P1
+mkfifo fifo/full_correlation/gul_S2_pltcalc_P1
+
+mkfifo fifo/full_correlation/gul_S1_summary_P2
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P2
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P2
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P2
+mkfifo fifo/full_correlation/gul_S2_summary_P2
+mkfifo fifo/full_correlation/gul_S2_eltcalc_P2
+mkfifo fifo/full_correlation/gul_S2_summarycalc_P2
+mkfifo fifo/full_correlation/gul_S2_pltcalc_P2
+
+mkfifo fifo/full_correlation/gul_S1_summary_P3
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P3
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P3
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P3
+mkfifo fifo/full_correlation/gul_S2_summary_P3
+mkfifo fifo/full_correlation/gul_S2_eltcalc_P3
+mkfifo fifo/full_correlation/gul_S2_summarycalc_P3
+mkfifo fifo/full_correlation/gul_S2_pltcalc_P3
+
+mkfifo fifo/full_correlation/gul_S1_summary_P4
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P4
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P4
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P4
+mkfifo fifo/full_correlation/gul_S2_summary_P4
+mkfifo fifo/full_correlation/gul_S2_eltcalc_P4
+mkfifo fifo/full_correlation/gul_S2_summarycalc_P4
+mkfifo fifo/full_correlation/gul_S2_pltcalc_P4
+
+mkfifo fifo/full_correlation/gul_S1_summary_P5
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P5
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P5
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P5
+mkfifo fifo/full_correlation/gul_S2_summary_P5
+mkfifo fifo/full_correlation/gul_S2_eltcalc_P5
+mkfifo fifo/full_correlation/gul_S2_summarycalc_P5
+mkfifo fifo/full_correlation/gul_S2_pltcalc_P5
+
+mkfifo fifo/full_correlation/gul_S1_summary_P6
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P6
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P6
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P6
+mkfifo fifo/full_correlation/gul_S2_summary_P6
+mkfifo fifo/full_correlation/gul_S2_eltcalc_P6
+mkfifo fifo/full_correlation/gul_S2_summarycalc_P6
+mkfifo fifo/full_correlation/gul_S2_pltcalc_P6
+
+mkfifo fifo/full_correlation/gul_S1_summary_P7
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P7
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P7
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P7
+mkfifo fifo/full_correlation/gul_S2_summary_P7
+mkfifo fifo/full_correlation/gul_S2_eltcalc_P7
+mkfifo fifo/full_correlation/gul_S2_summarycalc_P7
+mkfifo fifo/full_correlation/gul_S2_pltcalc_P7
+
+mkfifo fifo/full_correlation/gul_S1_summary_P8
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P8
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P8
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P8
+mkfifo fifo/full_correlation/gul_S2_summary_P8
+mkfifo fifo/full_correlation/gul_S2_eltcalc_P8
+mkfifo fifo/full_correlation/gul_S2_summarycalc_P8
+mkfifo fifo/full_correlation/gul_S2_pltcalc_P8
+
+mkfifo fifo/full_correlation/gul_S1_summary_P9
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P9
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P9
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P9
+mkfifo fifo/full_correlation/gul_S2_summary_P9
+mkfifo fifo/full_correlation/gul_S2_eltcalc_P9
+mkfifo fifo/full_correlation/gul_S2_summarycalc_P9
+mkfifo fifo/full_correlation/gul_S2_pltcalc_P9
+
+mkfifo fifo/full_correlation/gul_S1_summary_P10
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P10
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P10
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P10
+mkfifo fifo/full_correlation/gul_S2_summary_P10
+mkfifo fifo/full_correlation/gul_S2_eltcalc_P10
+mkfifo fifo/full_correlation/gul_S2_summarycalc_P10
+mkfifo fifo/full_correlation/gul_S2_pltcalc_P10
+
+mkfifo fifo/full_correlation/il_P1
+mkfifo fifo/full_correlation/il_P2
+mkfifo fifo/full_correlation/il_P3
+mkfifo fifo/full_correlation/il_P4
+mkfifo fifo/full_correlation/il_P5
+mkfifo fifo/full_correlation/il_P6
+mkfifo fifo/full_correlation/il_P7
+mkfifo fifo/full_correlation/il_P8
+mkfifo fifo/full_correlation/il_P9
+mkfifo fifo/full_correlation/il_P10
+
+mkfifo fifo/full_correlation/il_S1_summary_P1
+mkfifo fifo/full_correlation/il_S1_eltcalc_P1
+mkfifo fifo/full_correlation/il_S1_summarycalc_P1
+mkfifo fifo/full_correlation/il_S1_pltcalc_P1
+mkfifo fifo/full_correlation/il_S2_summary_P1
+mkfifo fifo/full_correlation/il_S2_eltcalc_P1
+mkfifo fifo/full_correlation/il_S2_summarycalc_P1
+mkfifo fifo/full_correlation/il_S2_pltcalc_P1
+
+mkfifo fifo/full_correlation/il_S1_summary_P2
+mkfifo fifo/full_correlation/il_S1_eltcalc_P2
+mkfifo fifo/full_correlation/il_S1_summarycalc_P2
+mkfifo fifo/full_correlation/il_S1_pltcalc_P2
+mkfifo fifo/full_correlation/il_S2_summary_P2
+mkfifo fifo/full_correlation/il_S2_eltcalc_P2
+mkfifo fifo/full_correlation/il_S2_summarycalc_P2
+mkfifo fifo/full_correlation/il_S2_pltcalc_P2
+
+mkfifo fifo/full_correlation/il_S1_summary_P3
+mkfifo fifo/full_correlation/il_S1_eltcalc_P3
+mkfifo fifo/full_correlation/il_S1_summarycalc_P3
+mkfifo fifo/full_correlation/il_S1_pltcalc_P3
+mkfifo fifo/full_correlation/il_S2_summary_P3
+mkfifo fifo/full_correlation/il_S2_eltcalc_P3
+mkfifo fifo/full_correlation/il_S2_summarycalc_P3
+mkfifo fifo/full_correlation/il_S2_pltcalc_P3
+
+mkfifo fifo/full_correlation/il_S1_summary_P4
+mkfifo fifo/full_correlation/il_S1_eltcalc_P4
+mkfifo fifo/full_correlation/il_S1_summarycalc_P4
+mkfifo fifo/full_correlation/il_S1_pltcalc_P4
+mkfifo fifo/full_correlation/il_S2_summary_P4
+mkfifo fifo/full_correlation/il_S2_eltcalc_P4
+mkfifo fifo/full_correlation/il_S2_summarycalc_P4
+mkfifo fifo/full_correlation/il_S2_pltcalc_P4
+
+mkfifo fifo/full_correlation/il_S1_summary_P5
+mkfifo fifo/full_correlation/il_S1_eltcalc_P5
+mkfifo fifo/full_correlation/il_S1_summarycalc_P5
+mkfifo fifo/full_correlation/il_S1_pltcalc_P5
+mkfifo fifo/full_correlation/il_S2_summary_P5
+mkfifo fifo/full_correlation/il_S2_eltcalc_P5
+mkfifo fifo/full_correlation/il_S2_summarycalc_P5
+mkfifo fifo/full_correlation/il_S2_pltcalc_P5
+
+mkfifo fifo/full_correlation/il_S1_summary_P6
+mkfifo fifo/full_correlation/il_S1_eltcalc_P6
+mkfifo fifo/full_correlation/il_S1_summarycalc_P6
+mkfifo fifo/full_correlation/il_S1_pltcalc_P6
+mkfifo fifo/full_correlation/il_S2_summary_P6
+mkfifo fifo/full_correlation/il_S2_eltcalc_P6
+mkfifo fifo/full_correlation/il_S2_summarycalc_P6
+mkfifo fifo/full_correlation/il_S2_pltcalc_P6
+
+mkfifo fifo/full_correlation/il_S1_summary_P7
+mkfifo fifo/full_correlation/il_S1_eltcalc_P7
+mkfifo fifo/full_correlation/il_S1_summarycalc_P7
+mkfifo fifo/full_correlation/il_S1_pltcalc_P7
+mkfifo fifo/full_correlation/il_S2_summary_P7
+mkfifo fifo/full_correlation/il_S2_eltcalc_P7
+mkfifo fifo/full_correlation/il_S2_summarycalc_P7
+mkfifo fifo/full_correlation/il_S2_pltcalc_P7
+
+mkfifo fifo/full_correlation/il_S1_summary_P8
+mkfifo fifo/full_correlation/il_S1_eltcalc_P8
+mkfifo fifo/full_correlation/il_S1_summarycalc_P8
+mkfifo fifo/full_correlation/il_S1_pltcalc_P8
+mkfifo fifo/full_correlation/il_S2_summary_P8
+mkfifo fifo/full_correlation/il_S2_eltcalc_P8
+mkfifo fifo/full_correlation/il_S2_summarycalc_P8
+mkfifo fifo/full_correlation/il_S2_pltcalc_P8
+
+mkfifo fifo/full_correlation/il_S1_summary_P9
+mkfifo fifo/full_correlation/il_S1_eltcalc_P9
+mkfifo fifo/full_correlation/il_S1_summarycalc_P9
+mkfifo fifo/full_correlation/il_S1_pltcalc_P9
+mkfifo fifo/full_correlation/il_S2_summary_P9
+mkfifo fifo/full_correlation/il_S2_eltcalc_P9
+mkfifo fifo/full_correlation/il_S2_summarycalc_P9
+mkfifo fifo/full_correlation/il_S2_pltcalc_P9
+
+mkfifo fifo/full_correlation/il_S1_summary_P10
+mkfifo fifo/full_correlation/il_S1_eltcalc_P10
+mkfifo fifo/full_correlation/il_S1_summarycalc_P10
+mkfifo fifo/full_correlation/il_S1_pltcalc_P10
+mkfifo fifo/full_correlation/il_S2_summary_P10
+mkfifo fifo/full_correlation/il_S2_eltcalc_P10
+mkfifo fifo/full_correlation/il_S2_summarycalc_P10
+mkfifo fifo/full_correlation/il_S2_pltcalc_P10
+
+
+
+# --- Do insured loss computes ---
+
+( eltcalc < fifo/il_S1_eltcalc_P1 > work/kat/il_S1_eltcalc_P1 ) 2>> log/stderror.err & pid1=$!
+( summarycalctocsv < fifo/il_S1_summarycalc_P1 > work/kat/il_S1_summarycalc_P1 ) 2>> log/stderror.err & pid2=$!
+( pltcalc < fifo/il_S1_pltcalc_P1 > work/kat/il_S1_pltcalc_P1 ) 2>> log/stderror.err & pid3=$!
+( eltcalc < fifo/il_S2_eltcalc_P1 > work/kat/il_S2_eltcalc_P1 ) 2>> log/stderror.err & pid4=$!
+( summarycalctocsv < fifo/il_S2_summarycalc_P1 > work/kat/il_S2_summarycalc_P1 ) 2>> log/stderror.err & pid5=$!
+( pltcalc < fifo/il_S2_pltcalc_P1 > work/kat/il_S2_pltcalc_P1 ) 2>> log/stderror.err & pid6=$!
+( eltcalc -s < fifo/il_S1_eltcalc_P2 > work/kat/il_S1_eltcalc_P2 ) 2>> log/stderror.err & pid7=$!
+( summarycalctocsv -s < fifo/il_S1_summarycalc_P2 > work/kat/il_S1_summarycalc_P2 ) 2>> log/stderror.err & pid8=$!
+( pltcalc -s < fifo/il_S1_pltcalc_P2 > work/kat/il_S1_pltcalc_P2 ) 2>> log/stderror.err & pid9=$!
+( eltcalc -s < fifo/il_S2_eltcalc_P2 > work/kat/il_S2_eltcalc_P2 ) 2>> log/stderror.err & pid10=$!
+( summarycalctocsv -s < fifo/il_S2_summarycalc_P2 > work/kat/il_S2_summarycalc_P2 ) 2>> log/stderror.err & pid11=$!
+( pltcalc -s < fifo/il_S2_pltcalc_P2 > work/kat/il_S2_pltcalc_P2 ) 2>> log/stderror.err & pid12=$!
+( eltcalc -s < fifo/il_S1_eltcalc_P3 > work/kat/il_S1_eltcalc_P3 ) 2>> log/stderror.err & pid13=$!
+( summarycalctocsv -s < fifo/il_S1_summarycalc_P3 > work/kat/il_S1_summarycalc_P3 ) 2>> log/stderror.err & pid14=$!
+( pltcalc -s < fifo/il_S1_pltcalc_P3 > work/kat/il_S1_pltcalc_P3 ) 2>> log/stderror.err & pid15=$!
+( eltcalc -s < fifo/il_S2_eltcalc_P3 > work/kat/il_S2_eltcalc_P3 ) 2>> log/stderror.err & pid16=$!
+( summarycalctocsv -s < fifo/il_S2_summarycalc_P3 > work/kat/il_S2_summarycalc_P3 ) 2>> log/stderror.err & pid17=$!
+( pltcalc -s < fifo/il_S2_pltcalc_P3 > work/kat/il_S2_pltcalc_P3 ) 2>> log/stderror.err & pid18=$!
+( eltcalc -s < fifo/il_S1_eltcalc_P4 > work/kat/il_S1_eltcalc_P4 ) 2>> log/stderror.err & pid19=$!
+( summarycalctocsv -s < fifo/il_S1_summarycalc_P4 > work/kat/il_S1_summarycalc_P4 ) 2>> log/stderror.err & pid20=$!
+( pltcalc -s < fifo/il_S1_pltcalc_P4 > work/kat/il_S1_pltcalc_P4 ) 2>> log/stderror.err & pid21=$!
+( eltcalc -s < fifo/il_S2_eltcalc_P4 > work/kat/il_S2_eltcalc_P4 ) 2>> log/stderror.err & pid22=$!
+( summarycalctocsv -s < fifo/il_S2_summarycalc_P4 > work/kat/il_S2_summarycalc_P4 ) 2>> log/stderror.err & pid23=$!
+( pltcalc -s < fifo/il_S2_pltcalc_P4 > work/kat/il_S2_pltcalc_P4 ) 2>> log/stderror.err & pid24=$!
+( eltcalc -s < fifo/il_S1_eltcalc_P5 > work/kat/il_S1_eltcalc_P5 ) 2>> log/stderror.err & pid25=$!
+( summarycalctocsv -s < fifo/il_S1_summarycalc_P5 > work/kat/il_S1_summarycalc_P5 ) 2>> log/stderror.err & pid26=$!
+( pltcalc -s < fifo/il_S1_pltcalc_P5 > work/kat/il_S1_pltcalc_P5 ) 2>> log/stderror.err & pid27=$!
+( eltcalc -s < fifo/il_S2_eltcalc_P5 > work/kat/il_S2_eltcalc_P5 ) 2>> log/stderror.err & pid28=$!
+( summarycalctocsv -s < fifo/il_S2_summarycalc_P5 > work/kat/il_S2_summarycalc_P5 ) 2>> log/stderror.err & pid29=$!
+( pltcalc -s < fifo/il_S2_pltcalc_P5 > work/kat/il_S2_pltcalc_P5 ) 2>> log/stderror.err & pid30=$!
+( eltcalc -s < fifo/il_S1_eltcalc_P6 > work/kat/il_S1_eltcalc_P6 ) 2>> log/stderror.err & pid31=$!
+( summarycalctocsv -s < fifo/il_S1_summarycalc_P6 > work/kat/il_S1_summarycalc_P6 ) 2>> log/stderror.err & pid32=$!
+( pltcalc -s < fifo/il_S1_pltcalc_P6 > work/kat/il_S1_pltcalc_P6 ) 2>> log/stderror.err & pid33=$!
+( eltcalc -s < fifo/il_S2_eltcalc_P6 > work/kat/il_S2_eltcalc_P6 ) 2>> log/stderror.err & pid34=$!
+( summarycalctocsv -s < fifo/il_S2_summarycalc_P6 > work/kat/il_S2_summarycalc_P6 ) 2>> log/stderror.err & pid35=$!
+( pltcalc -s < fifo/il_S2_pltcalc_P6 > work/kat/il_S2_pltcalc_P6 ) 2>> log/stderror.err & pid36=$!
+( eltcalc -s < fifo/il_S1_eltcalc_P7 > work/kat/il_S1_eltcalc_P7 ) 2>> log/stderror.err & pid37=$!
+( summarycalctocsv -s < fifo/il_S1_summarycalc_P7 > work/kat/il_S1_summarycalc_P7 ) 2>> log/stderror.err & pid38=$!
+( pltcalc -s < fifo/il_S1_pltcalc_P7 > work/kat/il_S1_pltcalc_P7 ) 2>> log/stderror.err & pid39=$!
+( eltcalc -s < fifo/il_S2_eltcalc_P7 > work/kat/il_S2_eltcalc_P7 ) 2>> log/stderror.err & pid40=$!
+( summarycalctocsv -s < fifo/il_S2_summarycalc_P7 > work/kat/il_S2_summarycalc_P7 ) 2>> log/stderror.err & pid41=$!
+( pltcalc -s < fifo/il_S2_pltcalc_P7 > work/kat/il_S2_pltcalc_P7 ) 2>> log/stderror.err & pid42=$!
+( eltcalc -s < fifo/il_S1_eltcalc_P8 > work/kat/il_S1_eltcalc_P8 ) 2>> log/stderror.err & pid43=$!
+( summarycalctocsv -s < fifo/il_S1_summarycalc_P8 > work/kat/il_S1_summarycalc_P8 ) 2>> log/stderror.err & pid44=$!
+( pltcalc -s < fifo/il_S1_pltcalc_P8 > work/kat/il_S1_pltcalc_P8 ) 2>> log/stderror.err & pid45=$!
+( eltcalc -s < fifo/il_S2_eltcalc_P8 > work/kat/il_S2_eltcalc_P8 ) 2>> log/stderror.err & pid46=$!
+( summarycalctocsv -s < fifo/il_S2_summarycalc_P8 > work/kat/il_S2_summarycalc_P8 ) 2>> log/stderror.err & pid47=$!
+( pltcalc -s < fifo/il_S2_pltcalc_P8 > work/kat/il_S2_pltcalc_P8 ) 2>> log/stderror.err & pid48=$!
+( eltcalc -s < fifo/il_S1_eltcalc_P9 > work/kat/il_S1_eltcalc_P9 ) 2>> log/stderror.err & pid49=$!
+( summarycalctocsv -s < fifo/il_S1_summarycalc_P9 > work/kat/il_S1_summarycalc_P9 ) 2>> log/stderror.err & pid50=$!
+( pltcalc -s < fifo/il_S1_pltcalc_P9 > work/kat/il_S1_pltcalc_P9 ) 2>> log/stderror.err & pid51=$!
+( eltcalc -s < fifo/il_S2_eltcalc_P9 > work/kat/il_S2_eltcalc_P9 ) 2>> log/stderror.err & pid52=$!
+( summarycalctocsv -s < fifo/il_S2_summarycalc_P9 > work/kat/il_S2_summarycalc_P9 ) 2>> log/stderror.err & pid53=$!
+( pltcalc -s < fifo/il_S2_pltcalc_P9 > work/kat/il_S2_pltcalc_P9 ) 2>> log/stderror.err & pid54=$!
+( eltcalc -s < fifo/il_S1_eltcalc_P10 > work/kat/il_S1_eltcalc_P10 ) 2>> log/stderror.err & pid55=$!
+( summarycalctocsv -s < fifo/il_S1_summarycalc_P10 > work/kat/il_S1_summarycalc_P10 ) 2>> log/stderror.err & pid56=$!
+( pltcalc -s < fifo/il_S1_pltcalc_P10 > work/kat/il_S1_pltcalc_P10 ) 2>> log/stderror.err & pid57=$!
+( eltcalc -s < fifo/il_S2_eltcalc_P10 > work/kat/il_S2_eltcalc_P10 ) 2>> log/stderror.err & pid58=$!
+( summarycalctocsv -s < fifo/il_S2_summarycalc_P10 > work/kat/il_S2_summarycalc_P10 ) 2>> log/stderror.err & pid59=$!
+( pltcalc -s < fifo/il_S2_pltcalc_P10 > work/kat/il_S2_pltcalc_P10 ) 2>> log/stderror.err & pid60=$!
+
+tee < fifo/il_S1_summary_P1 fifo/il_S1_eltcalc_P1 fifo/il_S1_summarycalc_P1 fifo/il_S1_pltcalc_P1 work/il_S1_summaryaalcalc/P1.bin work/il_S1_summaryleccalc/P1.bin > /dev/null & pid61=$!
+tee < fifo/il_S2_summary_P1 fifo/il_S2_eltcalc_P1 fifo/il_S2_summarycalc_P1 fifo/il_S2_pltcalc_P1 work/il_S2_summaryaalcalc/P1.bin work/il_S2_summaryleccalc/P1.bin > /dev/null & pid62=$!
+tee < fifo/il_S1_summary_P2 fifo/il_S1_eltcalc_P2 fifo/il_S1_summarycalc_P2 fifo/il_S1_pltcalc_P2 work/il_S1_summaryaalcalc/P2.bin work/il_S1_summaryleccalc/P2.bin > /dev/null & pid63=$!
+tee < fifo/il_S2_summary_P2 fifo/il_S2_eltcalc_P2 fifo/il_S2_summarycalc_P2 fifo/il_S2_pltcalc_P2 work/il_S2_summaryaalcalc/P2.bin work/il_S2_summaryleccalc/P2.bin > /dev/null & pid64=$!
+tee < fifo/il_S1_summary_P3 fifo/il_S1_eltcalc_P3 fifo/il_S1_summarycalc_P3 fifo/il_S1_pltcalc_P3 work/il_S1_summaryaalcalc/P3.bin work/il_S1_summaryleccalc/P3.bin > /dev/null & pid65=$!
+tee < fifo/il_S2_summary_P3 fifo/il_S2_eltcalc_P3 fifo/il_S2_summarycalc_P3 fifo/il_S2_pltcalc_P3 work/il_S2_summaryaalcalc/P3.bin work/il_S2_summaryleccalc/P3.bin > /dev/null & pid66=$!
+tee < fifo/il_S1_summary_P4 fifo/il_S1_eltcalc_P4 fifo/il_S1_summarycalc_P4 fifo/il_S1_pltcalc_P4 work/il_S1_summaryaalcalc/P4.bin work/il_S1_summaryleccalc/P4.bin > /dev/null & pid67=$!
+tee < fifo/il_S2_summary_P4 fifo/il_S2_eltcalc_P4 fifo/il_S2_summarycalc_P4 fifo/il_S2_pltcalc_P4 work/il_S2_summaryaalcalc/P4.bin work/il_S2_summaryleccalc/P4.bin > /dev/null & pid68=$!
+tee < fifo/il_S1_summary_P5 fifo/il_S1_eltcalc_P5 fifo/il_S1_summarycalc_P5 fifo/il_S1_pltcalc_P5 work/il_S1_summaryaalcalc/P5.bin work/il_S1_summaryleccalc/P5.bin > /dev/null & pid69=$!
+tee < fifo/il_S2_summary_P5 fifo/il_S2_eltcalc_P5 fifo/il_S2_summarycalc_P5 fifo/il_S2_pltcalc_P5 work/il_S2_summaryaalcalc/P5.bin work/il_S2_summaryleccalc/P5.bin > /dev/null & pid70=$!
+tee < fifo/il_S1_summary_P6 fifo/il_S1_eltcalc_P6 fifo/il_S1_summarycalc_P6 fifo/il_S1_pltcalc_P6 work/il_S1_summaryaalcalc/P6.bin work/il_S1_summaryleccalc/P6.bin > /dev/null & pid71=$!
+tee < fifo/il_S2_summary_P6 fifo/il_S2_eltcalc_P6 fifo/il_S2_summarycalc_P6 fifo/il_S2_pltcalc_P6 work/il_S2_summaryaalcalc/P6.bin work/il_S2_summaryleccalc/P6.bin > /dev/null & pid72=$!
+tee < fifo/il_S1_summary_P7 fifo/il_S1_eltcalc_P7 fifo/il_S1_summarycalc_P7 fifo/il_S1_pltcalc_P7 work/il_S1_summaryaalcalc/P7.bin work/il_S1_summaryleccalc/P7.bin > /dev/null & pid73=$!
+tee < fifo/il_S2_summary_P7 fifo/il_S2_eltcalc_P7 fifo/il_S2_summarycalc_P7 fifo/il_S2_pltcalc_P7 work/il_S2_summaryaalcalc/P7.bin work/il_S2_summaryleccalc/P7.bin > /dev/null & pid74=$!
+tee < fifo/il_S1_summary_P8 fifo/il_S1_eltcalc_P8 fifo/il_S1_summarycalc_P8 fifo/il_S1_pltcalc_P8 work/il_S1_summaryaalcalc/P8.bin work/il_S1_summaryleccalc/P8.bin > /dev/null & pid75=$!
+tee < fifo/il_S2_summary_P8 fifo/il_S2_eltcalc_P8 fifo/il_S2_summarycalc_P8 fifo/il_S2_pltcalc_P8 work/il_S2_summaryaalcalc/P8.bin work/il_S2_summaryleccalc/P8.bin > /dev/null & pid76=$!
+tee < fifo/il_S1_summary_P9 fifo/il_S1_eltcalc_P9 fifo/il_S1_summarycalc_P9 fifo/il_S1_pltcalc_P9 work/il_S1_summaryaalcalc/P9.bin work/il_S1_summaryleccalc/P9.bin > /dev/null & pid77=$!
+tee < fifo/il_S2_summary_P9 fifo/il_S2_eltcalc_P9 fifo/il_S2_summarycalc_P9 fifo/il_S2_pltcalc_P9 work/il_S2_summaryaalcalc/P9.bin work/il_S2_summaryleccalc/P9.bin > /dev/null & pid78=$!
+tee < fifo/il_S1_summary_P10 fifo/il_S1_eltcalc_P10 fifo/il_S1_summarycalc_P10 fifo/il_S1_pltcalc_P10 work/il_S1_summaryaalcalc/P10.bin work/il_S1_summaryleccalc/P10.bin > /dev/null & pid79=$!
+tee < fifo/il_S2_summary_P10 fifo/il_S2_eltcalc_P10 fifo/il_S2_summarycalc_P10 fifo/il_S2_pltcalc_P10 work/il_S2_summaryaalcalc/P10.bin work/il_S2_summaryleccalc/P10.bin > /dev/null & pid80=$!
+
+( summarycalc -f  -1 fifo/il_S1_summary_P1 -2 fifo/il_S2_summary_P1 < fifo/il_P1 ) 2>> log/stderror.err  &
+( summarycalc -f  -1 fifo/il_S1_summary_P2 -2 fifo/il_S2_summary_P2 < fifo/il_P2 ) 2>> log/stderror.err  &
+( summarycalc -f  -1 fifo/il_S1_summary_P3 -2 fifo/il_S2_summary_P3 < fifo/il_P3 ) 2>> log/stderror.err  &
+( summarycalc -f  -1 fifo/il_S1_summary_P4 -2 fifo/il_S2_summary_P4 < fifo/il_P4 ) 2>> log/stderror.err  &
+( summarycalc -f  -1 fifo/il_S1_summary_P5 -2 fifo/il_S2_summary_P5 < fifo/il_P5 ) 2>> log/stderror.err  &
+( summarycalc -f  -1 fifo/il_S1_summary_P6 -2 fifo/il_S2_summary_P6 < fifo/il_P6 ) 2>> log/stderror.err  &
+( summarycalc -f  -1 fifo/il_S1_summary_P7 -2 fifo/il_S2_summary_P7 < fifo/il_P7 ) 2>> log/stderror.err  &
+( summarycalc -f  -1 fifo/il_S1_summary_P8 -2 fifo/il_S2_summary_P8 < fifo/il_P8 ) 2>> log/stderror.err  &
+( summarycalc -f  -1 fifo/il_S1_summary_P9 -2 fifo/il_S2_summary_P9 < fifo/il_P9 ) 2>> log/stderror.err  &
+( summarycalc -f  -1 fifo/il_S1_summary_P10 -2 fifo/il_S2_summary_P10 < fifo/il_P10 ) 2>> log/stderror.err  &
+
+# --- Do ground up loss computes ---
+
+( eltcalc < fifo/gul_S1_eltcalc_P1 > work/kat/gul_S1_eltcalc_P1 ) 2>> log/stderror.err & pid81=$!
+( summarycalctocsv < fifo/gul_S1_summarycalc_P1 > work/kat/gul_S1_summarycalc_P1 ) 2>> log/stderror.err & pid82=$!
+( pltcalc < fifo/gul_S1_pltcalc_P1 > work/kat/gul_S1_pltcalc_P1 ) 2>> log/stderror.err & pid83=$!
+( eltcalc < fifo/gul_S2_eltcalc_P1 > work/kat/gul_S2_eltcalc_P1 ) 2>> log/stderror.err & pid84=$!
+( summarycalctocsv < fifo/gul_S2_summarycalc_P1 > work/kat/gul_S2_summarycalc_P1 ) 2>> log/stderror.err & pid85=$!
+( pltcalc < fifo/gul_S2_pltcalc_P1 > work/kat/gul_S2_pltcalc_P1 ) 2>> log/stderror.err & pid86=$!
+( eltcalc -s < fifo/gul_S1_eltcalc_P2 > work/kat/gul_S1_eltcalc_P2 ) 2>> log/stderror.err & pid87=$!
+( summarycalctocsv -s < fifo/gul_S1_summarycalc_P2 > work/kat/gul_S1_summarycalc_P2 ) 2>> log/stderror.err & pid88=$!
+( pltcalc -s < fifo/gul_S1_pltcalc_P2 > work/kat/gul_S1_pltcalc_P2 ) 2>> log/stderror.err & pid89=$!
+( eltcalc -s < fifo/gul_S2_eltcalc_P2 > work/kat/gul_S2_eltcalc_P2 ) 2>> log/stderror.err & pid90=$!
+( summarycalctocsv -s < fifo/gul_S2_summarycalc_P2 > work/kat/gul_S2_summarycalc_P2 ) 2>> log/stderror.err & pid91=$!
+( pltcalc -s < fifo/gul_S2_pltcalc_P2 > work/kat/gul_S2_pltcalc_P2 ) 2>> log/stderror.err & pid92=$!
+( eltcalc -s < fifo/gul_S1_eltcalc_P3 > work/kat/gul_S1_eltcalc_P3 ) 2>> log/stderror.err & pid93=$!
+( summarycalctocsv -s < fifo/gul_S1_summarycalc_P3 > work/kat/gul_S1_summarycalc_P3 ) 2>> log/stderror.err & pid94=$!
+( pltcalc -s < fifo/gul_S1_pltcalc_P3 > work/kat/gul_S1_pltcalc_P3 ) 2>> log/stderror.err & pid95=$!
+( eltcalc -s < fifo/gul_S2_eltcalc_P3 > work/kat/gul_S2_eltcalc_P3 ) 2>> log/stderror.err & pid96=$!
+( summarycalctocsv -s < fifo/gul_S2_summarycalc_P3 > work/kat/gul_S2_summarycalc_P3 ) 2>> log/stderror.err & pid97=$!
+( pltcalc -s < fifo/gul_S2_pltcalc_P3 > work/kat/gul_S2_pltcalc_P3 ) 2>> log/stderror.err & pid98=$!
+( eltcalc -s < fifo/gul_S1_eltcalc_P4 > work/kat/gul_S1_eltcalc_P4 ) 2>> log/stderror.err & pid99=$!
+( summarycalctocsv -s < fifo/gul_S1_summarycalc_P4 > work/kat/gul_S1_summarycalc_P4 ) 2>> log/stderror.err & pid100=$!
+( pltcalc -s < fifo/gul_S1_pltcalc_P4 > work/kat/gul_S1_pltcalc_P4 ) 2>> log/stderror.err & pid101=$!
+( eltcalc -s < fifo/gul_S2_eltcalc_P4 > work/kat/gul_S2_eltcalc_P4 ) 2>> log/stderror.err & pid102=$!
+( summarycalctocsv -s < fifo/gul_S2_summarycalc_P4 > work/kat/gul_S2_summarycalc_P4 ) 2>> log/stderror.err & pid103=$!
+( pltcalc -s < fifo/gul_S2_pltcalc_P4 > work/kat/gul_S2_pltcalc_P4 ) 2>> log/stderror.err & pid104=$!
+( eltcalc -s < fifo/gul_S1_eltcalc_P5 > work/kat/gul_S1_eltcalc_P5 ) 2>> log/stderror.err & pid105=$!
+( summarycalctocsv -s < fifo/gul_S1_summarycalc_P5 > work/kat/gul_S1_summarycalc_P5 ) 2>> log/stderror.err & pid106=$!
+( pltcalc -s < fifo/gul_S1_pltcalc_P5 > work/kat/gul_S1_pltcalc_P5 ) 2>> log/stderror.err & pid107=$!
+( eltcalc -s < fifo/gul_S2_eltcalc_P5 > work/kat/gul_S2_eltcalc_P5 ) 2>> log/stderror.err & pid108=$!
+( summarycalctocsv -s < fifo/gul_S2_summarycalc_P5 > work/kat/gul_S2_summarycalc_P5 ) 2>> log/stderror.err & pid109=$!
+( pltcalc -s < fifo/gul_S2_pltcalc_P5 > work/kat/gul_S2_pltcalc_P5 ) 2>> log/stderror.err & pid110=$!
+( eltcalc -s < fifo/gul_S1_eltcalc_P6 > work/kat/gul_S1_eltcalc_P6 ) 2>> log/stderror.err & pid111=$!
+( summarycalctocsv -s < fifo/gul_S1_summarycalc_P6 > work/kat/gul_S1_summarycalc_P6 ) 2>> log/stderror.err & pid112=$!
+( pltcalc -s < fifo/gul_S1_pltcalc_P6 > work/kat/gul_S1_pltcalc_P6 ) 2>> log/stderror.err & pid113=$!
+( eltcalc -s < fifo/gul_S2_eltcalc_P6 > work/kat/gul_S2_eltcalc_P6 ) 2>> log/stderror.err & pid114=$!
+( summarycalctocsv -s < fifo/gul_S2_summarycalc_P6 > work/kat/gul_S2_summarycalc_P6 ) 2>> log/stderror.err & pid115=$!
+( pltcalc -s < fifo/gul_S2_pltcalc_P6 > work/kat/gul_S2_pltcalc_P6 ) 2>> log/stderror.err & pid116=$!
+( eltcalc -s < fifo/gul_S1_eltcalc_P7 > work/kat/gul_S1_eltcalc_P7 ) 2>> log/stderror.err & pid117=$!
+( summarycalctocsv -s < fifo/gul_S1_summarycalc_P7 > work/kat/gul_S1_summarycalc_P7 ) 2>> log/stderror.err & pid118=$!
+( pltcalc -s < fifo/gul_S1_pltcalc_P7 > work/kat/gul_S1_pltcalc_P7 ) 2>> log/stderror.err & pid119=$!
+( eltcalc -s < fifo/gul_S2_eltcalc_P7 > work/kat/gul_S2_eltcalc_P7 ) 2>> log/stderror.err & pid120=$!
+( summarycalctocsv -s < fifo/gul_S2_summarycalc_P7 > work/kat/gul_S2_summarycalc_P7 ) 2>> log/stderror.err & pid121=$!
+( pltcalc -s < fifo/gul_S2_pltcalc_P7 > work/kat/gul_S2_pltcalc_P7 ) 2>> log/stderror.err & pid122=$!
+( eltcalc -s < fifo/gul_S1_eltcalc_P8 > work/kat/gul_S1_eltcalc_P8 ) 2>> log/stderror.err & pid123=$!
+( summarycalctocsv -s < fifo/gul_S1_summarycalc_P8 > work/kat/gul_S1_summarycalc_P8 ) 2>> log/stderror.err & pid124=$!
+( pltcalc -s < fifo/gul_S1_pltcalc_P8 > work/kat/gul_S1_pltcalc_P8 ) 2>> log/stderror.err & pid125=$!
+( eltcalc -s < fifo/gul_S2_eltcalc_P8 > work/kat/gul_S2_eltcalc_P8 ) 2>> log/stderror.err & pid126=$!
+( summarycalctocsv -s < fifo/gul_S2_summarycalc_P8 > work/kat/gul_S2_summarycalc_P8 ) 2>> log/stderror.err & pid127=$!
+( pltcalc -s < fifo/gul_S2_pltcalc_P8 > work/kat/gul_S2_pltcalc_P8 ) 2>> log/stderror.err & pid128=$!
+( eltcalc -s < fifo/gul_S1_eltcalc_P9 > work/kat/gul_S1_eltcalc_P9 ) 2>> log/stderror.err & pid129=$!
+( summarycalctocsv -s < fifo/gul_S1_summarycalc_P9 > work/kat/gul_S1_summarycalc_P9 ) 2>> log/stderror.err & pid130=$!
+( pltcalc -s < fifo/gul_S1_pltcalc_P9 > work/kat/gul_S1_pltcalc_P9 ) 2>> log/stderror.err & pid131=$!
+( eltcalc -s < fifo/gul_S2_eltcalc_P9 > work/kat/gul_S2_eltcalc_P9 ) 2>> log/stderror.err & pid132=$!
+( summarycalctocsv -s < fifo/gul_S2_summarycalc_P9 > work/kat/gul_S2_summarycalc_P9 ) 2>> log/stderror.err & pid133=$!
+( pltcalc -s < fifo/gul_S2_pltcalc_P9 > work/kat/gul_S2_pltcalc_P9 ) 2>> log/stderror.err & pid134=$!
+( eltcalc -s < fifo/gul_S1_eltcalc_P10 > work/kat/gul_S1_eltcalc_P10 ) 2>> log/stderror.err & pid135=$!
+( summarycalctocsv -s < fifo/gul_S1_summarycalc_P10 > work/kat/gul_S1_summarycalc_P10 ) 2>> log/stderror.err & pid136=$!
+( pltcalc -s < fifo/gul_S1_pltcalc_P10 > work/kat/gul_S1_pltcalc_P10 ) 2>> log/stderror.err & pid137=$!
+( eltcalc -s < fifo/gul_S2_eltcalc_P10 > work/kat/gul_S2_eltcalc_P10 ) 2>> log/stderror.err & pid138=$!
+( summarycalctocsv -s < fifo/gul_S2_summarycalc_P10 > work/kat/gul_S2_summarycalc_P10 ) 2>> log/stderror.err & pid139=$!
+( pltcalc -s < fifo/gul_S2_pltcalc_P10 > work/kat/gul_S2_pltcalc_P10 ) 2>> log/stderror.err & pid140=$!
+
+tee < fifo/gul_S1_summary_P1 fifo/gul_S1_eltcalc_P1 fifo/gul_S1_summarycalc_P1 fifo/gul_S1_pltcalc_P1 work/gul_S1_summaryaalcalc/P1.bin work/gul_S1_summaryleccalc/P1.bin > /dev/null & pid141=$!
+tee < fifo/gul_S2_summary_P1 fifo/gul_S2_eltcalc_P1 fifo/gul_S2_summarycalc_P1 fifo/gul_S2_pltcalc_P1 work/gul_S2_summaryaalcalc/P1.bin work/gul_S2_summaryleccalc/P1.bin > /dev/null & pid142=$!
+tee < fifo/gul_S1_summary_P2 fifo/gul_S1_eltcalc_P2 fifo/gul_S1_summarycalc_P2 fifo/gul_S1_pltcalc_P2 work/gul_S1_summaryaalcalc/P2.bin work/gul_S1_summaryleccalc/P2.bin > /dev/null & pid143=$!
+tee < fifo/gul_S2_summary_P2 fifo/gul_S2_eltcalc_P2 fifo/gul_S2_summarycalc_P2 fifo/gul_S2_pltcalc_P2 work/gul_S2_summaryaalcalc/P2.bin work/gul_S2_summaryleccalc/P2.bin > /dev/null & pid144=$!
+tee < fifo/gul_S1_summary_P3 fifo/gul_S1_eltcalc_P3 fifo/gul_S1_summarycalc_P3 fifo/gul_S1_pltcalc_P3 work/gul_S1_summaryaalcalc/P3.bin work/gul_S1_summaryleccalc/P3.bin > /dev/null & pid145=$!
+tee < fifo/gul_S2_summary_P3 fifo/gul_S2_eltcalc_P3 fifo/gul_S2_summarycalc_P3 fifo/gul_S2_pltcalc_P3 work/gul_S2_summaryaalcalc/P3.bin work/gul_S2_summaryleccalc/P3.bin > /dev/null & pid146=$!
+tee < fifo/gul_S1_summary_P4 fifo/gul_S1_eltcalc_P4 fifo/gul_S1_summarycalc_P4 fifo/gul_S1_pltcalc_P4 work/gul_S1_summaryaalcalc/P4.bin work/gul_S1_summaryleccalc/P4.bin > /dev/null & pid147=$!
+tee < fifo/gul_S2_summary_P4 fifo/gul_S2_eltcalc_P4 fifo/gul_S2_summarycalc_P4 fifo/gul_S2_pltcalc_P4 work/gul_S2_summaryaalcalc/P4.bin work/gul_S2_summaryleccalc/P4.bin > /dev/null & pid148=$!
+tee < fifo/gul_S1_summary_P5 fifo/gul_S1_eltcalc_P5 fifo/gul_S1_summarycalc_P5 fifo/gul_S1_pltcalc_P5 work/gul_S1_summaryaalcalc/P5.bin work/gul_S1_summaryleccalc/P5.bin > /dev/null & pid149=$!
+tee < fifo/gul_S2_summary_P5 fifo/gul_S2_eltcalc_P5 fifo/gul_S2_summarycalc_P5 fifo/gul_S2_pltcalc_P5 work/gul_S2_summaryaalcalc/P5.bin work/gul_S2_summaryleccalc/P5.bin > /dev/null & pid150=$!
+tee < fifo/gul_S1_summary_P6 fifo/gul_S1_eltcalc_P6 fifo/gul_S1_summarycalc_P6 fifo/gul_S1_pltcalc_P6 work/gul_S1_summaryaalcalc/P6.bin work/gul_S1_summaryleccalc/P6.bin > /dev/null & pid151=$!
+tee < fifo/gul_S2_summary_P6 fifo/gul_S2_eltcalc_P6 fifo/gul_S2_summarycalc_P6 fifo/gul_S2_pltcalc_P6 work/gul_S2_summaryaalcalc/P6.bin work/gul_S2_summaryleccalc/P6.bin > /dev/null & pid152=$!
+tee < fifo/gul_S1_summary_P7 fifo/gul_S1_eltcalc_P7 fifo/gul_S1_summarycalc_P7 fifo/gul_S1_pltcalc_P7 work/gul_S1_summaryaalcalc/P7.bin work/gul_S1_summaryleccalc/P7.bin > /dev/null & pid153=$!
+tee < fifo/gul_S2_summary_P7 fifo/gul_S2_eltcalc_P7 fifo/gul_S2_summarycalc_P7 fifo/gul_S2_pltcalc_P7 work/gul_S2_summaryaalcalc/P7.bin work/gul_S2_summaryleccalc/P7.bin > /dev/null & pid154=$!
+tee < fifo/gul_S1_summary_P8 fifo/gul_S1_eltcalc_P8 fifo/gul_S1_summarycalc_P8 fifo/gul_S1_pltcalc_P8 work/gul_S1_summaryaalcalc/P8.bin work/gul_S1_summaryleccalc/P8.bin > /dev/null & pid155=$!
+tee < fifo/gul_S2_summary_P8 fifo/gul_S2_eltcalc_P8 fifo/gul_S2_summarycalc_P8 fifo/gul_S2_pltcalc_P8 work/gul_S2_summaryaalcalc/P8.bin work/gul_S2_summaryleccalc/P8.bin > /dev/null & pid156=$!
+tee < fifo/gul_S1_summary_P9 fifo/gul_S1_eltcalc_P9 fifo/gul_S1_summarycalc_P9 fifo/gul_S1_pltcalc_P9 work/gul_S1_summaryaalcalc/P9.bin work/gul_S1_summaryleccalc/P9.bin > /dev/null & pid157=$!
+tee < fifo/gul_S2_summary_P9 fifo/gul_S2_eltcalc_P9 fifo/gul_S2_summarycalc_P9 fifo/gul_S2_pltcalc_P9 work/gul_S2_summaryaalcalc/P9.bin work/gul_S2_summaryleccalc/P9.bin > /dev/null & pid158=$!
+tee < fifo/gul_S1_summary_P10 fifo/gul_S1_eltcalc_P10 fifo/gul_S1_summarycalc_P10 fifo/gul_S1_pltcalc_P10 work/gul_S1_summaryaalcalc/P10.bin work/gul_S1_summaryleccalc/P10.bin > /dev/null & pid159=$!
+tee < fifo/gul_S2_summary_P10 fifo/gul_S2_eltcalc_P10 fifo/gul_S2_summarycalc_P10 fifo/gul_S2_pltcalc_P10 work/gul_S2_summaryaalcalc/P10.bin work/gul_S2_summaryleccalc/P10.bin > /dev/null & pid160=$!
+
+( summarycalc -i  -1 fifo/gul_S1_summary_P1 -2 fifo/gul_S2_summary_P1 < fifo/gul_P1 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P2 -2 fifo/gul_S2_summary_P2 < fifo/gul_P2 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P3 -2 fifo/gul_S2_summary_P3 < fifo/gul_P3 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P4 -2 fifo/gul_S2_summary_P4 < fifo/gul_P4 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P5 -2 fifo/gul_S2_summary_P5 < fifo/gul_P5 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P6 -2 fifo/gul_S2_summary_P6 < fifo/gul_P6 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P7 -2 fifo/gul_S2_summary_P7 < fifo/gul_P7 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P8 -2 fifo/gul_S2_summary_P8 < fifo/gul_P8 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P9 -2 fifo/gul_S2_summary_P9 < fifo/gul_P9 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P10 -2 fifo/gul_S2_summary_P10 < fifo/gul_P10 ) 2>> log/stderror.err  &
+
+# --- Do insured loss computes ---
+
+( eltcalc < fifo/full_correlation/il_S1_eltcalc_P1 > work/full_correlation/kat/il_S1_eltcalc_P1 ) 2>> log/stderror.err & pid161=$!
+( summarycalctocsv < fifo/full_correlation/il_S1_summarycalc_P1 > work/full_correlation/kat/il_S1_summarycalc_P1 ) 2>> log/stderror.err & pid162=$!
+( pltcalc < fifo/full_correlation/il_S1_pltcalc_P1 > work/full_correlation/kat/il_S1_pltcalc_P1 ) 2>> log/stderror.err & pid163=$!
+( eltcalc < fifo/full_correlation/il_S2_eltcalc_P1 > work/full_correlation/kat/il_S2_eltcalc_P1 ) 2>> log/stderror.err & pid164=$!
+( summarycalctocsv < fifo/full_correlation/il_S2_summarycalc_P1 > work/full_correlation/kat/il_S2_summarycalc_P1 ) 2>> log/stderror.err & pid165=$!
+( pltcalc < fifo/full_correlation/il_S2_pltcalc_P1 > work/full_correlation/kat/il_S2_pltcalc_P1 ) 2>> log/stderror.err & pid166=$!
+( eltcalc -s < fifo/full_correlation/il_S1_eltcalc_P2 > work/full_correlation/kat/il_S1_eltcalc_P2 ) 2>> log/stderror.err & pid167=$!
+( summarycalctocsv -s < fifo/full_correlation/il_S1_summarycalc_P2 > work/full_correlation/kat/il_S1_summarycalc_P2 ) 2>> log/stderror.err & pid168=$!
+( pltcalc -s < fifo/full_correlation/il_S1_pltcalc_P2 > work/full_correlation/kat/il_S1_pltcalc_P2 ) 2>> log/stderror.err & pid169=$!
+( eltcalc -s < fifo/full_correlation/il_S2_eltcalc_P2 > work/full_correlation/kat/il_S2_eltcalc_P2 ) 2>> log/stderror.err & pid170=$!
+( summarycalctocsv -s < fifo/full_correlation/il_S2_summarycalc_P2 > work/full_correlation/kat/il_S2_summarycalc_P2 ) 2>> log/stderror.err & pid171=$!
+( pltcalc -s < fifo/full_correlation/il_S2_pltcalc_P2 > work/full_correlation/kat/il_S2_pltcalc_P2 ) 2>> log/stderror.err & pid172=$!
+( eltcalc -s < fifo/full_correlation/il_S1_eltcalc_P3 > work/full_correlation/kat/il_S1_eltcalc_P3 ) 2>> log/stderror.err & pid173=$!
+( summarycalctocsv -s < fifo/full_correlation/il_S1_summarycalc_P3 > work/full_correlation/kat/il_S1_summarycalc_P3 ) 2>> log/stderror.err & pid174=$!
+( pltcalc -s < fifo/full_correlation/il_S1_pltcalc_P3 > work/full_correlation/kat/il_S1_pltcalc_P3 ) 2>> log/stderror.err & pid175=$!
+( eltcalc -s < fifo/full_correlation/il_S2_eltcalc_P3 > work/full_correlation/kat/il_S2_eltcalc_P3 ) 2>> log/stderror.err & pid176=$!
+( summarycalctocsv -s < fifo/full_correlation/il_S2_summarycalc_P3 > work/full_correlation/kat/il_S2_summarycalc_P3 ) 2>> log/stderror.err & pid177=$!
+( pltcalc -s < fifo/full_correlation/il_S2_pltcalc_P3 > work/full_correlation/kat/il_S2_pltcalc_P3 ) 2>> log/stderror.err & pid178=$!
+( eltcalc -s < fifo/full_correlation/il_S1_eltcalc_P4 > work/full_correlation/kat/il_S1_eltcalc_P4 ) 2>> log/stderror.err & pid179=$!
+( summarycalctocsv -s < fifo/full_correlation/il_S1_summarycalc_P4 > work/full_correlation/kat/il_S1_summarycalc_P4 ) 2>> log/stderror.err & pid180=$!
+( pltcalc -s < fifo/full_correlation/il_S1_pltcalc_P4 > work/full_correlation/kat/il_S1_pltcalc_P4 ) 2>> log/stderror.err & pid181=$!
+( eltcalc -s < fifo/full_correlation/il_S2_eltcalc_P4 > work/full_correlation/kat/il_S2_eltcalc_P4 ) 2>> log/stderror.err & pid182=$!
+( summarycalctocsv -s < fifo/full_correlation/il_S2_summarycalc_P4 > work/full_correlation/kat/il_S2_summarycalc_P4 ) 2>> log/stderror.err & pid183=$!
+( pltcalc -s < fifo/full_correlation/il_S2_pltcalc_P4 > work/full_correlation/kat/il_S2_pltcalc_P4 ) 2>> log/stderror.err & pid184=$!
+( eltcalc -s < fifo/full_correlation/il_S1_eltcalc_P5 > work/full_correlation/kat/il_S1_eltcalc_P5 ) 2>> log/stderror.err & pid185=$!
+( summarycalctocsv -s < fifo/full_correlation/il_S1_summarycalc_P5 > work/full_correlation/kat/il_S1_summarycalc_P5 ) 2>> log/stderror.err & pid186=$!
+( pltcalc -s < fifo/full_correlation/il_S1_pltcalc_P5 > work/full_correlation/kat/il_S1_pltcalc_P5 ) 2>> log/stderror.err & pid187=$!
+( eltcalc -s < fifo/full_correlation/il_S2_eltcalc_P5 > work/full_correlation/kat/il_S2_eltcalc_P5 ) 2>> log/stderror.err & pid188=$!
+( summarycalctocsv -s < fifo/full_correlation/il_S2_summarycalc_P5 > work/full_correlation/kat/il_S2_summarycalc_P5 ) 2>> log/stderror.err & pid189=$!
+( pltcalc -s < fifo/full_correlation/il_S2_pltcalc_P5 > work/full_correlation/kat/il_S2_pltcalc_P5 ) 2>> log/stderror.err & pid190=$!
+( eltcalc -s < fifo/full_correlation/il_S1_eltcalc_P6 > work/full_correlation/kat/il_S1_eltcalc_P6 ) 2>> log/stderror.err & pid191=$!
+( summarycalctocsv -s < fifo/full_correlation/il_S1_summarycalc_P6 > work/full_correlation/kat/il_S1_summarycalc_P6 ) 2>> log/stderror.err & pid192=$!
+( pltcalc -s < fifo/full_correlation/il_S1_pltcalc_P6 > work/full_correlation/kat/il_S1_pltcalc_P6 ) 2>> log/stderror.err & pid193=$!
+( eltcalc -s < fifo/full_correlation/il_S2_eltcalc_P6 > work/full_correlation/kat/il_S2_eltcalc_P6 ) 2>> log/stderror.err & pid194=$!
+( summarycalctocsv -s < fifo/full_correlation/il_S2_summarycalc_P6 > work/full_correlation/kat/il_S2_summarycalc_P6 ) 2>> log/stderror.err & pid195=$!
+( pltcalc -s < fifo/full_correlation/il_S2_pltcalc_P6 > work/full_correlation/kat/il_S2_pltcalc_P6 ) 2>> log/stderror.err & pid196=$!
+( eltcalc -s < fifo/full_correlation/il_S1_eltcalc_P7 > work/full_correlation/kat/il_S1_eltcalc_P7 ) 2>> log/stderror.err & pid197=$!
+( summarycalctocsv -s < fifo/full_correlation/il_S1_summarycalc_P7 > work/full_correlation/kat/il_S1_summarycalc_P7 ) 2>> log/stderror.err & pid198=$!
+( pltcalc -s < fifo/full_correlation/il_S1_pltcalc_P7 > work/full_correlation/kat/il_S1_pltcalc_P7 ) 2>> log/stderror.err & pid199=$!
+( eltcalc -s < fifo/full_correlation/il_S2_eltcalc_P7 > work/full_correlation/kat/il_S2_eltcalc_P7 ) 2>> log/stderror.err & pid200=$!
+( summarycalctocsv -s < fifo/full_correlation/il_S2_summarycalc_P7 > work/full_correlation/kat/il_S2_summarycalc_P7 ) 2>> log/stderror.err & pid201=$!
+( pltcalc -s < fifo/full_correlation/il_S2_pltcalc_P7 > work/full_correlation/kat/il_S2_pltcalc_P7 ) 2>> log/stderror.err & pid202=$!
+( eltcalc -s < fifo/full_correlation/il_S1_eltcalc_P8 > work/full_correlation/kat/il_S1_eltcalc_P8 ) 2>> log/stderror.err & pid203=$!
+( summarycalctocsv -s < fifo/full_correlation/il_S1_summarycalc_P8 > work/full_correlation/kat/il_S1_summarycalc_P8 ) 2>> log/stderror.err & pid204=$!
+( pltcalc -s < fifo/full_correlation/il_S1_pltcalc_P8 > work/full_correlation/kat/il_S1_pltcalc_P8 ) 2>> log/stderror.err & pid205=$!
+( eltcalc -s < fifo/full_correlation/il_S2_eltcalc_P8 > work/full_correlation/kat/il_S2_eltcalc_P8 ) 2>> log/stderror.err & pid206=$!
+( summarycalctocsv -s < fifo/full_correlation/il_S2_summarycalc_P8 > work/full_correlation/kat/il_S2_summarycalc_P8 ) 2>> log/stderror.err & pid207=$!
+( pltcalc -s < fifo/full_correlation/il_S2_pltcalc_P8 > work/full_correlation/kat/il_S2_pltcalc_P8 ) 2>> log/stderror.err & pid208=$!
+( eltcalc -s < fifo/full_correlation/il_S1_eltcalc_P9 > work/full_correlation/kat/il_S1_eltcalc_P9 ) 2>> log/stderror.err & pid209=$!
+( summarycalctocsv -s < fifo/full_correlation/il_S1_summarycalc_P9 > work/full_correlation/kat/il_S1_summarycalc_P9 ) 2>> log/stderror.err & pid210=$!
+( pltcalc -s < fifo/full_correlation/il_S1_pltcalc_P9 > work/full_correlation/kat/il_S1_pltcalc_P9 ) 2>> log/stderror.err & pid211=$!
+( eltcalc -s < fifo/full_correlation/il_S2_eltcalc_P9 > work/full_correlation/kat/il_S2_eltcalc_P9 ) 2>> log/stderror.err & pid212=$!
+( summarycalctocsv -s < fifo/full_correlation/il_S2_summarycalc_P9 > work/full_correlation/kat/il_S2_summarycalc_P9 ) 2>> log/stderror.err & pid213=$!
+( pltcalc -s < fifo/full_correlation/il_S2_pltcalc_P9 > work/full_correlation/kat/il_S2_pltcalc_P9 ) 2>> log/stderror.err & pid214=$!
+( eltcalc -s < fifo/full_correlation/il_S1_eltcalc_P10 > work/full_correlation/kat/il_S1_eltcalc_P10 ) 2>> log/stderror.err & pid215=$!
+( summarycalctocsv -s < fifo/full_correlation/il_S1_summarycalc_P10 > work/full_correlation/kat/il_S1_summarycalc_P10 ) 2>> log/stderror.err & pid216=$!
+( pltcalc -s < fifo/full_correlation/il_S1_pltcalc_P10 > work/full_correlation/kat/il_S1_pltcalc_P10 ) 2>> log/stderror.err & pid217=$!
+( eltcalc -s < fifo/full_correlation/il_S2_eltcalc_P10 > work/full_correlation/kat/il_S2_eltcalc_P10 ) 2>> log/stderror.err & pid218=$!
+( summarycalctocsv -s < fifo/full_correlation/il_S2_summarycalc_P10 > work/full_correlation/kat/il_S2_summarycalc_P10 ) 2>> log/stderror.err & pid219=$!
+( pltcalc -s < fifo/full_correlation/il_S2_pltcalc_P10 > work/full_correlation/kat/il_S2_pltcalc_P10 ) 2>> log/stderror.err & pid220=$!
+
+tee < fifo/full_correlation/il_S1_summary_P1 fifo/full_correlation/il_S1_eltcalc_P1 fifo/full_correlation/il_S1_summarycalc_P1 fifo/full_correlation/il_S1_pltcalc_P1 work/full_correlation/il_S1_summaryaalcalc/P1.bin work/full_correlation/il_S1_summaryleccalc/P1.bin > /dev/null & pid221=$!
+tee < fifo/full_correlation/il_S2_summary_P1 fifo/full_correlation/il_S2_eltcalc_P1 fifo/full_correlation/il_S2_summarycalc_P1 fifo/full_correlation/il_S2_pltcalc_P1 work/full_correlation/il_S2_summaryaalcalc/P1.bin work/full_correlation/il_S2_summaryleccalc/P1.bin > /dev/null & pid222=$!
+tee < fifo/full_correlation/il_S1_summary_P2 fifo/full_correlation/il_S1_eltcalc_P2 fifo/full_correlation/il_S1_summarycalc_P2 fifo/full_correlation/il_S1_pltcalc_P2 work/full_correlation/il_S1_summaryaalcalc/P2.bin work/full_correlation/il_S1_summaryleccalc/P2.bin > /dev/null & pid223=$!
+tee < fifo/full_correlation/il_S2_summary_P2 fifo/full_correlation/il_S2_eltcalc_P2 fifo/full_correlation/il_S2_summarycalc_P2 fifo/full_correlation/il_S2_pltcalc_P2 work/full_correlation/il_S2_summaryaalcalc/P2.bin work/full_correlation/il_S2_summaryleccalc/P2.bin > /dev/null & pid224=$!
+tee < fifo/full_correlation/il_S1_summary_P3 fifo/full_correlation/il_S1_eltcalc_P3 fifo/full_correlation/il_S1_summarycalc_P3 fifo/full_correlation/il_S1_pltcalc_P3 work/full_correlation/il_S1_summaryaalcalc/P3.bin work/full_correlation/il_S1_summaryleccalc/P3.bin > /dev/null & pid225=$!
+tee < fifo/full_correlation/il_S2_summary_P3 fifo/full_correlation/il_S2_eltcalc_P3 fifo/full_correlation/il_S2_summarycalc_P3 fifo/full_correlation/il_S2_pltcalc_P3 work/full_correlation/il_S2_summaryaalcalc/P3.bin work/full_correlation/il_S2_summaryleccalc/P3.bin > /dev/null & pid226=$!
+tee < fifo/full_correlation/il_S1_summary_P4 fifo/full_correlation/il_S1_eltcalc_P4 fifo/full_correlation/il_S1_summarycalc_P4 fifo/full_correlation/il_S1_pltcalc_P4 work/full_correlation/il_S1_summaryaalcalc/P4.bin work/full_correlation/il_S1_summaryleccalc/P4.bin > /dev/null & pid227=$!
+tee < fifo/full_correlation/il_S2_summary_P4 fifo/full_correlation/il_S2_eltcalc_P4 fifo/full_correlation/il_S2_summarycalc_P4 fifo/full_correlation/il_S2_pltcalc_P4 work/full_correlation/il_S2_summaryaalcalc/P4.bin work/full_correlation/il_S2_summaryleccalc/P4.bin > /dev/null & pid228=$!
+tee < fifo/full_correlation/il_S1_summary_P5 fifo/full_correlation/il_S1_eltcalc_P5 fifo/full_correlation/il_S1_summarycalc_P5 fifo/full_correlation/il_S1_pltcalc_P5 work/full_correlation/il_S1_summaryaalcalc/P5.bin work/full_correlation/il_S1_summaryleccalc/P5.bin > /dev/null & pid229=$!
+tee < fifo/full_correlation/il_S2_summary_P5 fifo/full_correlation/il_S2_eltcalc_P5 fifo/full_correlation/il_S2_summarycalc_P5 fifo/full_correlation/il_S2_pltcalc_P5 work/full_correlation/il_S2_summaryaalcalc/P5.bin work/full_correlation/il_S2_summaryleccalc/P5.bin > /dev/null & pid230=$!
+tee < fifo/full_correlation/il_S1_summary_P6 fifo/full_correlation/il_S1_eltcalc_P6 fifo/full_correlation/il_S1_summarycalc_P6 fifo/full_correlation/il_S1_pltcalc_P6 work/full_correlation/il_S1_summaryaalcalc/P6.bin work/full_correlation/il_S1_summaryleccalc/P6.bin > /dev/null & pid231=$!
+tee < fifo/full_correlation/il_S2_summary_P6 fifo/full_correlation/il_S2_eltcalc_P6 fifo/full_correlation/il_S2_summarycalc_P6 fifo/full_correlation/il_S2_pltcalc_P6 work/full_correlation/il_S2_summaryaalcalc/P6.bin work/full_correlation/il_S2_summaryleccalc/P6.bin > /dev/null & pid232=$!
+tee < fifo/full_correlation/il_S1_summary_P7 fifo/full_correlation/il_S1_eltcalc_P7 fifo/full_correlation/il_S1_summarycalc_P7 fifo/full_correlation/il_S1_pltcalc_P7 work/full_correlation/il_S1_summaryaalcalc/P7.bin work/full_correlation/il_S1_summaryleccalc/P7.bin > /dev/null & pid233=$!
+tee < fifo/full_correlation/il_S2_summary_P7 fifo/full_correlation/il_S2_eltcalc_P7 fifo/full_correlation/il_S2_summarycalc_P7 fifo/full_correlation/il_S2_pltcalc_P7 work/full_correlation/il_S2_summaryaalcalc/P7.bin work/full_correlation/il_S2_summaryleccalc/P7.bin > /dev/null & pid234=$!
+tee < fifo/full_correlation/il_S1_summary_P8 fifo/full_correlation/il_S1_eltcalc_P8 fifo/full_correlation/il_S1_summarycalc_P8 fifo/full_correlation/il_S1_pltcalc_P8 work/full_correlation/il_S1_summaryaalcalc/P8.bin work/full_correlation/il_S1_summaryleccalc/P8.bin > /dev/null & pid235=$!
+tee < fifo/full_correlation/il_S2_summary_P8 fifo/full_correlation/il_S2_eltcalc_P8 fifo/full_correlation/il_S2_summarycalc_P8 fifo/full_correlation/il_S2_pltcalc_P8 work/full_correlation/il_S2_summaryaalcalc/P8.bin work/full_correlation/il_S2_summaryleccalc/P8.bin > /dev/null & pid236=$!
+tee < fifo/full_correlation/il_S1_summary_P9 fifo/full_correlation/il_S1_eltcalc_P9 fifo/full_correlation/il_S1_summarycalc_P9 fifo/full_correlation/il_S1_pltcalc_P9 work/full_correlation/il_S1_summaryaalcalc/P9.bin work/full_correlation/il_S1_summaryleccalc/P9.bin > /dev/null & pid237=$!
+tee < fifo/full_correlation/il_S2_summary_P9 fifo/full_correlation/il_S2_eltcalc_P9 fifo/full_correlation/il_S2_summarycalc_P9 fifo/full_correlation/il_S2_pltcalc_P9 work/full_correlation/il_S2_summaryaalcalc/P9.bin work/full_correlation/il_S2_summaryleccalc/P9.bin > /dev/null & pid238=$!
+tee < fifo/full_correlation/il_S1_summary_P10 fifo/full_correlation/il_S1_eltcalc_P10 fifo/full_correlation/il_S1_summarycalc_P10 fifo/full_correlation/il_S1_pltcalc_P10 work/full_correlation/il_S1_summaryaalcalc/P10.bin work/full_correlation/il_S1_summaryleccalc/P10.bin > /dev/null & pid239=$!
+tee < fifo/full_correlation/il_S2_summary_P10 fifo/full_correlation/il_S2_eltcalc_P10 fifo/full_correlation/il_S2_summarycalc_P10 fifo/full_correlation/il_S2_pltcalc_P10 work/full_correlation/il_S2_summaryaalcalc/P10.bin work/full_correlation/il_S2_summaryleccalc/P10.bin > /dev/null & pid240=$!
+
+( summarycalc -f  -1 fifo/full_correlation/il_S1_summary_P1 -2 fifo/full_correlation/il_S2_summary_P1 < fifo/full_correlation/il_P1 ) 2>> log/stderror.err  &
+( summarycalc -f  -1 fifo/full_correlation/il_S1_summary_P2 -2 fifo/full_correlation/il_S2_summary_P2 < fifo/full_correlation/il_P2 ) 2>> log/stderror.err  &
+( summarycalc -f  -1 fifo/full_correlation/il_S1_summary_P3 -2 fifo/full_correlation/il_S2_summary_P3 < fifo/full_correlation/il_P3 ) 2>> log/stderror.err  &
+( summarycalc -f  -1 fifo/full_correlation/il_S1_summary_P4 -2 fifo/full_correlation/il_S2_summary_P4 < fifo/full_correlation/il_P4 ) 2>> log/stderror.err  &
+( summarycalc -f  -1 fifo/full_correlation/il_S1_summary_P5 -2 fifo/full_correlation/il_S2_summary_P5 < fifo/full_correlation/il_P5 ) 2>> log/stderror.err  &
+( summarycalc -f  -1 fifo/full_correlation/il_S1_summary_P6 -2 fifo/full_correlation/il_S2_summary_P6 < fifo/full_correlation/il_P6 ) 2>> log/stderror.err  &
+( summarycalc -f  -1 fifo/full_correlation/il_S1_summary_P7 -2 fifo/full_correlation/il_S2_summary_P7 < fifo/full_correlation/il_P7 ) 2>> log/stderror.err  &
+( summarycalc -f  -1 fifo/full_correlation/il_S1_summary_P8 -2 fifo/full_correlation/il_S2_summary_P8 < fifo/full_correlation/il_P8 ) 2>> log/stderror.err  &
+( summarycalc -f  -1 fifo/full_correlation/il_S1_summary_P9 -2 fifo/full_correlation/il_S2_summary_P9 < fifo/full_correlation/il_P9 ) 2>> log/stderror.err  &
+( summarycalc -f  -1 fifo/full_correlation/il_S1_summary_P10 -2 fifo/full_correlation/il_S2_summary_P10 < fifo/full_correlation/il_P10 ) 2>> log/stderror.err  &
+
+# --- Do ground up loss computes ---
+
+( eltcalc < fifo/full_correlation/gul_S1_eltcalc_P1 > work/full_correlation/kat/gul_S1_eltcalc_P1 ) 2>> log/stderror.err & pid241=$!
+( summarycalctocsv < fifo/full_correlation/gul_S1_summarycalc_P1 > work/full_correlation/kat/gul_S1_summarycalc_P1 ) 2>> log/stderror.err & pid242=$!
+( pltcalc < fifo/full_correlation/gul_S1_pltcalc_P1 > work/full_correlation/kat/gul_S1_pltcalc_P1 ) 2>> log/stderror.err & pid243=$!
+( eltcalc < fifo/full_correlation/gul_S2_eltcalc_P1 > work/full_correlation/kat/gul_S2_eltcalc_P1 ) 2>> log/stderror.err & pid244=$!
+( summarycalctocsv < fifo/full_correlation/gul_S2_summarycalc_P1 > work/full_correlation/kat/gul_S2_summarycalc_P1 ) 2>> log/stderror.err & pid245=$!
+( pltcalc < fifo/full_correlation/gul_S2_pltcalc_P1 > work/full_correlation/kat/gul_S2_pltcalc_P1 ) 2>> log/stderror.err & pid246=$!
+( eltcalc -s < fifo/full_correlation/gul_S1_eltcalc_P2 > work/full_correlation/kat/gul_S1_eltcalc_P2 ) 2>> log/stderror.err & pid247=$!
+( summarycalctocsv -s < fifo/full_correlation/gul_S1_summarycalc_P2 > work/full_correlation/kat/gul_S1_summarycalc_P2 ) 2>> log/stderror.err & pid248=$!
+( pltcalc -s < fifo/full_correlation/gul_S1_pltcalc_P2 > work/full_correlation/kat/gul_S1_pltcalc_P2 ) 2>> log/stderror.err & pid249=$!
+( eltcalc -s < fifo/full_correlation/gul_S2_eltcalc_P2 > work/full_correlation/kat/gul_S2_eltcalc_P2 ) 2>> log/stderror.err & pid250=$!
+( summarycalctocsv -s < fifo/full_correlation/gul_S2_summarycalc_P2 > work/full_correlation/kat/gul_S2_summarycalc_P2 ) 2>> log/stderror.err & pid251=$!
+( pltcalc -s < fifo/full_correlation/gul_S2_pltcalc_P2 > work/full_correlation/kat/gul_S2_pltcalc_P2 ) 2>> log/stderror.err & pid252=$!
+( eltcalc -s < fifo/full_correlation/gul_S1_eltcalc_P3 > work/full_correlation/kat/gul_S1_eltcalc_P3 ) 2>> log/stderror.err & pid253=$!
+( summarycalctocsv -s < fifo/full_correlation/gul_S1_summarycalc_P3 > work/full_correlation/kat/gul_S1_summarycalc_P3 ) 2>> log/stderror.err & pid254=$!
+( pltcalc -s < fifo/full_correlation/gul_S1_pltcalc_P3 > work/full_correlation/kat/gul_S1_pltcalc_P3 ) 2>> log/stderror.err & pid255=$!
+( eltcalc -s < fifo/full_correlation/gul_S2_eltcalc_P3 > work/full_correlation/kat/gul_S2_eltcalc_P3 ) 2>> log/stderror.err & pid256=$!
+( summarycalctocsv -s < fifo/full_correlation/gul_S2_summarycalc_P3 > work/full_correlation/kat/gul_S2_summarycalc_P3 ) 2>> log/stderror.err & pid257=$!
+( pltcalc -s < fifo/full_correlation/gul_S2_pltcalc_P3 > work/full_correlation/kat/gul_S2_pltcalc_P3 ) 2>> log/stderror.err & pid258=$!
+( eltcalc -s < fifo/full_correlation/gul_S1_eltcalc_P4 > work/full_correlation/kat/gul_S1_eltcalc_P4 ) 2>> log/stderror.err & pid259=$!
+( summarycalctocsv -s < fifo/full_correlation/gul_S1_summarycalc_P4 > work/full_correlation/kat/gul_S1_summarycalc_P4 ) 2>> log/stderror.err & pid260=$!
+( pltcalc -s < fifo/full_correlation/gul_S1_pltcalc_P4 > work/full_correlation/kat/gul_S1_pltcalc_P4 ) 2>> log/stderror.err & pid261=$!
+( eltcalc -s < fifo/full_correlation/gul_S2_eltcalc_P4 > work/full_correlation/kat/gul_S2_eltcalc_P4 ) 2>> log/stderror.err & pid262=$!
+( summarycalctocsv -s < fifo/full_correlation/gul_S2_summarycalc_P4 > work/full_correlation/kat/gul_S2_summarycalc_P4 ) 2>> log/stderror.err & pid263=$!
+( pltcalc -s < fifo/full_correlation/gul_S2_pltcalc_P4 > work/full_correlation/kat/gul_S2_pltcalc_P4 ) 2>> log/stderror.err & pid264=$!
+( eltcalc -s < fifo/full_correlation/gul_S1_eltcalc_P5 > work/full_correlation/kat/gul_S1_eltcalc_P5 ) 2>> log/stderror.err & pid265=$!
+( summarycalctocsv -s < fifo/full_correlation/gul_S1_summarycalc_P5 > work/full_correlation/kat/gul_S1_summarycalc_P5 ) 2>> log/stderror.err & pid266=$!
+( pltcalc -s < fifo/full_correlation/gul_S1_pltcalc_P5 > work/full_correlation/kat/gul_S1_pltcalc_P5 ) 2>> log/stderror.err & pid267=$!
+( eltcalc -s < fifo/full_correlation/gul_S2_eltcalc_P5 > work/full_correlation/kat/gul_S2_eltcalc_P5 ) 2>> log/stderror.err & pid268=$!
+( summarycalctocsv -s < fifo/full_correlation/gul_S2_summarycalc_P5 > work/full_correlation/kat/gul_S2_summarycalc_P5 ) 2>> log/stderror.err & pid269=$!
+( pltcalc -s < fifo/full_correlation/gul_S2_pltcalc_P5 > work/full_correlation/kat/gul_S2_pltcalc_P5 ) 2>> log/stderror.err & pid270=$!
+( eltcalc -s < fifo/full_correlation/gul_S1_eltcalc_P6 > work/full_correlation/kat/gul_S1_eltcalc_P6 ) 2>> log/stderror.err & pid271=$!
+( summarycalctocsv -s < fifo/full_correlation/gul_S1_summarycalc_P6 > work/full_correlation/kat/gul_S1_summarycalc_P6 ) 2>> log/stderror.err & pid272=$!
+( pltcalc -s < fifo/full_correlation/gul_S1_pltcalc_P6 > work/full_correlation/kat/gul_S1_pltcalc_P6 ) 2>> log/stderror.err & pid273=$!
+( eltcalc -s < fifo/full_correlation/gul_S2_eltcalc_P6 > work/full_correlation/kat/gul_S2_eltcalc_P6 ) 2>> log/stderror.err & pid274=$!
+( summarycalctocsv -s < fifo/full_correlation/gul_S2_summarycalc_P6 > work/full_correlation/kat/gul_S2_summarycalc_P6 ) 2>> log/stderror.err & pid275=$!
+( pltcalc -s < fifo/full_correlation/gul_S2_pltcalc_P6 > work/full_correlation/kat/gul_S2_pltcalc_P6 ) 2>> log/stderror.err & pid276=$!
+( eltcalc -s < fifo/full_correlation/gul_S1_eltcalc_P7 > work/full_correlation/kat/gul_S1_eltcalc_P7 ) 2>> log/stderror.err & pid277=$!
+( summarycalctocsv -s < fifo/full_correlation/gul_S1_summarycalc_P7 > work/full_correlation/kat/gul_S1_summarycalc_P7 ) 2>> log/stderror.err & pid278=$!
+( pltcalc -s < fifo/full_correlation/gul_S1_pltcalc_P7 > work/full_correlation/kat/gul_S1_pltcalc_P7 ) 2>> log/stderror.err & pid279=$!
+( eltcalc -s < fifo/full_correlation/gul_S2_eltcalc_P7 > work/full_correlation/kat/gul_S2_eltcalc_P7 ) 2>> log/stderror.err & pid280=$!
+( summarycalctocsv -s < fifo/full_correlation/gul_S2_summarycalc_P7 > work/full_correlation/kat/gul_S2_summarycalc_P7 ) 2>> log/stderror.err & pid281=$!
+( pltcalc -s < fifo/full_correlation/gul_S2_pltcalc_P7 > work/full_correlation/kat/gul_S2_pltcalc_P7 ) 2>> log/stderror.err & pid282=$!
+( eltcalc -s < fifo/full_correlation/gul_S1_eltcalc_P8 > work/full_correlation/kat/gul_S1_eltcalc_P8 ) 2>> log/stderror.err & pid283=$!
+( summarycalctocsv -s < fifo/full_correlation/gul_S1_summarycalc_P8 > work/full_correlation/kat/gul_S1_summarycalc_P8 ) 2>> log/stderror.err & pid284=$!
+( pltcalc -s < fifo/full_correlation/gul_S1_pltcalc_P8 > work/full_correlation/kat/gul_S1_pltcalc_P8 ) 2>> log/stderror.err & pid285=$!
+( eltcalc -s < fifo/full_correlation/gul_S2_eltcalc_P8 > work/full_correlation/kat/gul_S2_eltcalc_P8 ) 2>> log/stderror.err & pid286=$!
+( summarycalctocsv -s < fifo/full_correlation/gul_S2_summarycalc_P8 > work/full_correlation/kat/gul_S2_summarycalc_P8 ) 2>> log/stderror.err & pid287=$!
+( pltcalc -s < fifo/full_correlation/gul_S2_pltcalc_P8 > work/full_correlation/kat/gul_S2_pltcalc_P8 ) 2>> log/stderror.err & pid288=$!
+( eltcalc -s < fifo/full_correlation/gul_S1_eltcalc_P9 > work/full_correlation/kat/gul_S1_eltcalc_P9 ) 2>> log/stderror.err & pid289=$!
+( summarycalctocsv -s < fifo/full_correlation/gul_S1_summarycalc_P9 > work/full_correlation/kat/gul_S1_summarycalc_P9 ) 2>> log/stderror.err & pid290=$!
+( pltcalc -s < fifo/full_correlation/gul_S1_pltcalc_P9 > work/full_correlation/kat/gul_S1_pltcalc_P9 ) 2>> log/stderror.err & pid291=$!
+( eltcalc -s < fifo/full_correlation/gul_S2_eltcalc_P9 > work/full_correlation/kat/gul_S2_eltcalc_P9 ) 2>> log/stderror.err & pid292=$!
+( summarycalctocsv -s < fifo/full_correlation/gul_S2_summarycalc_P9 > work/full_correlation/kat/gul_S2_summarycalc_P9 ) 2>> log/stderror.err & pid293=$!
+( pltcalc -s < fifo/full_correlation/gul_S2_pltcalc_P9 > work/full_correlation/kat/gul_S2_pltcalc_P9 ) 2>> log/stderror.err & pid294=$!
+( eltcalc -s < fifo/full_correlation/gul_S1_eltcalc_P10 > work/full_correlation/kat/gul_S1_eltcalc_P10 ) 2>> log/stderror.err & pid295=$!
+( summarycalctocsv -s < fifo/full_correlation/gul_S1_summarycalc_P10 > work/full_correlation/kat/gul_S1_summarycalc_P10 ) 2>> log/stderror.err & pid296=$!
+( pltcalc -s < fifo/full_correlation/gul_S1_pltcalc_P10 > work/full_correlation/kat/gul_S1_pltcalc_P10 ) 2>> log/stderror.err & pid297=$!
+( eltcalc -s < fifo/full_correlation/gul_S2_eltcalc_P10 > work/full_correlation/kat/gul_S2_eltcalc_P10 ) 2>> log/stderror.err & pid298=$!
+( summarycalctocsv -s < fifo/full_correlation/gul_S2_summarycalc_P10 > work/full_correlation/kat/gul_S2_summarycalc_P10 ) 2>> log/stderror.err & pid299=$!
+( pltcalc -s < fifo/full_correlation/gul_S2_pltcalc_P10 > work/full_correlation/kat/gul_S2_pltcalc_P10 ) 2>> log/stderror.err & pid300=$!
+
+tee < fifo/full_correlation/gul_S1_summary_P1 fifo/full_correlation/gul_S1_eltcalc_P1 fifo/full_correlation/gul_S1_summarycalc_P1 fifo/full_correlation/gul_S1_pltcalc_P1 work/full_correlation/gul_S1_summaryaalcalc/P1.bin work/full_correlation/gul_S1_summaryleccalc/P1.bin > /dev/null & pid301=$!
+tee < fifo/full_correlation/gul_S2_summary_P1 fifo/full_correlation/gul_S2_eltcalc_P1 fifo/full_correlation/gul_S2_summarycalc_P1 fifo/full_correlation/gul_S2_pltcalc_P1 work/full_correlation/gul_S2_summaryaalcalc/P1.bin work/full_correlation/gul_S2_summaryleccalc/P1.bin > /dev/null & pid302=$!
+tee < fifo/full_correlation/gul_S1_summary_P2 fifo/full_correlation/gul_S1_eltcalc_P2 fifo/full_correlation/gul_S1_summarycalc_P2 fifo/full_correlation/gul_S1_pltcalc_P2 work/full_correlation/gul_S1_summaryaalcalc/P2.bin work/full_correlation/gul_S1_summaryleccalc/P2.bin > /dev/null & pid303=$!
+tee < fifo/full_correlation/gul_S2_summary_P2 fifo/full_correlation/gul_S2_eltcalc_P2 fifo/full_correlation/gul_S2_summarycalc_P2 fifo/full_correlation/gul_S2_pltcalc_P2 work/full_correlation/gul_S2_summaryaalcalc/P2.bin work/full_correlation/gul_S2_summaryleccalc/P2.bin > /dev/null & pid304=$!
+tee < fifo/full_correlation/gul_S1_summary_P3 fifo/full_correlation/gul_S1_eltcalc_P3 fifo/full_correlation/gul_S1_summarycalc_P3 fifo/full_correlation/gul_S1_pltcalc_P3 work/full_correlation/gul_S1_summaryaalcalc/P3.bin work/full_correlation/gul_S1_summaryleccalc/P3.bin > /dev/null & pid305=$!
+tee < fifo/full_correlation/gul_S2_summary_P3 fifo/full_correlation/gul_S2_eltcalc_P3 fifo/full_correlation/gul_S2_summarycalc_P3 fifo/full_correlation/gul_S2_pltcalc_P3 work/full_correlation/gul_S2_summaryaalcalc/P3.bin work/full_correlation/gul_S2_summaryleccalc/P3.bin > /dev/null & pid306=$!
+tee < fifo/full_correlation/gul_S1_summary_P4 fifo/full_correlation/gul_S1_eltcalc_P4 fifo/full_correlation/gul_S1_summarycalc_P4 fifo/full_correlation/gul_S1_pltcalc_P4 work/full_correlation/gul_S1_summaryaalcalc/P4.bin work/full_correlation/gul_S1_summaryleccalc/P4.bin > /dev/null & pid307=$!
+tee < fifo/full_correlation/gul_S2_summary_P4 fifo/full_correlation/gul_S2_eltcalc_P4 fifo/full_correlation/gul_S2_summarycalc_P4 fifo/full_correlation/gul_S2_pltcalc_P4 work/full_correlation/gul_S2_summaryaalcalc/P4.bin work/full_correlation/gul_S2_summaryleccalc/P4.bin > /dev/null & pid308=$!
+tee < fifo/full_correlation/gul_S1_summary_P5 fifo/full_correlation/gul_S1_eltcalc_P5 fifo/full_correlation/gul_S1_summarycalc_P5 fifo/full_correlation/gul_S1_pltcalc_P5 work/full_correlation/gul_S1_summaryaalcalc/P5.bin work/full_correlation/gul_S1_summaryleccalc/P5.bin > /dev/null & pid309=$!
+tee < fifo/full_correlation/gul_S2_summary_P5 fifo/full_correlation/gul_S2_eltcalc_P5 fifo/full_correlation/gul_S2_summarycalc_P5 fifo/full_correlation/gul_S2_pltcalc_P5 work/full_correlation/gul_S2_summaryaalcalc/P5.bin work/full_correlation/gul_S2_summaryleccalc/P5.bin > /dev/null & pid310=$!
+tee < fifo/full_correlation/gul_S1_summary_P6 fifo/full_correlation/gul_S1_eltcalc_P6 fifo/full_correlation/gul_S1_summarycalc_P6 fifo/full_correlation/gul_S1_pltcalc_P6 work/full_correlation/gul_S1_summaryaalcalc/P6.bin work/full_correlation/gul_S1_summaryleccalc/P6.bin > /dev/null & pid311=$!
+tee < fifo/full_correlation/gul_S2_summary_P6 fifo/full_correlation/gul_S2_eltcalc_P6 fifo/full_correlation/gul_S2_summarycalc_P6 fifo/full_correlation/gul_S2_pltcalc_P6 work/full_correlation/gul_S2_summaryaalcalc/P6.bin work/full_correlation/gul_S2_summaryleccalc/P6.bin > /dev/null & pid312=$!
+tee < fifo/full_correlation/gul_S1_summary_P7 fifo/full_correlation/gul_S1_eltcalc_P7 fifo/full_correlation/gul_S1_summarycalc_P7 fifo/full_correlation/gul_S1_pltcalc_P7 work/full_correlation/gul_S1_summaryaalcalc/P7.bin work/full_correlation/gul_S1_summaryleccalc/P7.bin > /dev/null & pid313=$!
+tee < fifo/full_correlation/gul_S2_summary_P7 fifo/full_correlation/gul_S2_eltcalc_P7 fifo/full_correlation/gul_S2_summarycalc_P7 fifo/full_correlation/gul_S2_pltcalc_P7 work/full_correlation/gul_S2_summaryaalcalc/P7.bin work/full_correlation/gul_S2_summaryleccalc/P7.bin > /dev/null & pid314=$!
+tee < fifo/full_correlation/gul_S1_summary_P8 fifo/full_correlation/gul_S1_eltcalc_P8 fifo/full_correlation/gul_S1_summarycalc_P8 fifo/full_correlation/gul_S1_pltcalc_P8 work/full_correlation/gul_S1_summaryaalcalc/P8.bin work/full_correlation/gul_S1_summaryleccalc/P8.bin > /dev/null & pid315=$!
+tee < fifo/full_correlation/gul_S2_summary_P8 fifo/full_correlation/gul_S2_eltcalc_P8 fifo/full_correlation/gul_S2_summarycalc_P8 fifo/full_correlation/gul_S2_pltcalc_P8 work/full_correlation/gul_S2_summaryaalcalc/P8.bin work/full_correlation/gul_S2_summaryleccalc/P8.bin > /dev/null & pid316=$!
+tee < fifo/full_correlation/gul_S1_summary_P9 fifo/full_correlation/gul_S1_eltcalc_P9 fifo/full_correlation/gul_S1_summarycalc_P9 fifo/full_correlation/gul_S1_pltcalc_P9 work/full_correlation/gul_S1_summaryaalcalc/P9.bin work/full_correlation/gul_S1_summaryleccalc/P9.bin > /dev/null & pid317=$!
+tee < fifo/full_correlation/gul_S2_summary_P9 fifo/full_correlation/gul_S2_eltcalc_P9 fifo/full_correlation/gul_S2_summarycalc_P9 fifo/full_correlation/gul_S2_pltcalc_P9 work/full_correlation/gul_S2_summaryaalcalc/P9.bin work/full_correlation/gul_S2_summaryleccalc/P9.bin > /dev/null & pid318=$!
+tee < fifo/full_correlation/gul_S1_summary_P10 fifo/full_correlation/gul_S1_eltcalc_P10 fifo/full_correlation/gul_S1_summarycalc_P10 fifo/full_correlation/gul_S1_pltcalc_P10 work/full_correlation/gul_S1_summaryaalcalc/P10.bin work/full_correlation/gul_S1_summaryleccalc/P10.bin > /dev/null & pid319=$!
+tee < fifo/full_correlation/gul_S2_summary_P10 fifo/full_correlation/gul_S2_eltcalc_P10 fifo/full_correlation/gul_S2_summarycalc_P10 fifo/full_correlation/gul_S2_pltcalc_P10 work/full_correlation/gul_S2_summaryaalcalc/P10.bin work/full_correlation/gul_S2_summaryleccalc/P10.bin > /dev/null & pid320=$!
+
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P1 -2 fifo/full_correlation/gul_S2_summary_P1 < fifo/full_correlation/gul_P1 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P2 -2 fifo/full_correlation/gul_S2_summary_P2 < fifo/full_correlation/gul_P2 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P3 -2 fifo/full_correlation/gul_S2_summary_P3 < fifo/full_correlation/gul_P3 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P4 -2 fifo/full_correlation/gul_S2_summary_P4 < fifo/full_correlation/gul_P4 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P5 -2 fifo/full_correlation/gul_S2_summary_P5 < fifo/full_correlation/gul_P5 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P6 -2 fifo/full_correlation/gul_S2_summary_P6 < fifo/full_correlation/gul_P6 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P7 -2 fifo/full_correlation/gul_S2_summary_P7 < fifo/full_correlation/gul_P7 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P8 -2 fifo/full_correlation/gul_S2_summary_P8 < fifo/full_correlation/gul_P8 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P9 -2 fifo/full_correlation/gul_S2_summary_P9 < fifo/full_correlation/gul_P9 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P10 -2 fifo/full_correlation/gul_S2_summary_P10 < fifo/full_correlation/gul_P10 ) 2>> log/stderror.err  &
+
+( tee < fifo/full_correlation/gul_fc_P1 fifo/full_correlation/gul_P1  | fmcalc -a2 > fifo/full_correlation/il_P1  ) 2>> log/stderror.err &
+( tee < fifo/full_correlation/gul_fc_P2 fifo/full_correlation/gul_P2  | fmcalc -a2 > fifo/full_correlation/il_P2  ) 2>> log/stderror.err &
+( tee < fifo/full_correlation/gul_fc_P3 fifo/full_correlation/gul_P3  | fmcalc -a2 > fifo/full_correlation/il_P3  ) 2>> log/stderror.err &
+( tee < fifo/full_correlation/gul_fc_P4 fifo/full_correlation/gul_P4  | fmcalc -a2 > fifo/full_correlation/il_P4  ) 2>> log/stderror.err &
+( tee < fifo/full_correlation/gul_fc_P5 fifo/full_correlation/gul_P5  | fmcalc -a2 > fifo/full_correlation/il_P5  ) 2>> log/stderror.err &
+( tee < fifo/full_correlation/gul_fc_P6 fifo/full_correlation/gul_P6  | fmcalc -a2 > fifo/full_correlation/il_P6  ) 2>> log/stderror.err &
+( tee < fifo/full_correlation/gul_fc_P7 fifo/full_correlation/gul_P7  | fmcalc -a2 > fifo/full_correlation/il_P7  ) 2>> log/stderror.err &
+( tee < fifo/full_correlation/gul_fc_P8 fifo/full_correlation/gul_P8  | fmcalc -a2 > fifo/full_correlation/il_P8  ) 2>> log/stderror.err &
+( tee < fifo/full_correlation/gul_fc_P9 fifo/full_correlation/gul_P9  | fmcalc -a2 > fifo/full_correlation/il_P9  ) 2>> log/stderror.err &
+( tee < fifo/full_correlation/gul_fc_P10 fifo/full_correlation/gul_P10  | fmcalc -a2 > fifo/full_correlation/il_P10  ) 2>> log/stderror.err &
+( eve 1 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_fc_P1 -a1 -i - | tee fifo/gul_P1 | fmcalc -a2 > fifo/il_P1  ) 2>> log/stderror.err &
+( eve 2 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_fc_P2 -a1 -i - | tee fifo/gul_P2 | fmcalc -a2 > fifo/il_P2  ) 2>> log/stderror.err &
+( eve 3 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_fc_P3 -a1 -i - | tee fifo/gul_P3 | fmcalc -a2 > fifo/il_P3  ) 2>> log/stderror.err &
+( eve 4 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_fc_P4 -a1 -i - | tee fifo/gul_P4 | fmcalc -a2 > fifo/il_P4  ) 2>> log/stderror.err &
+( eve 5 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_fc_P5 -a1 -i - | tee fifo/gul_P5 | fmcalc -a2 > fifo/il_P5  ) 2>> log/stderror.err &
+( eve 6 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_fc_P6 -a1 -i - | tee fifo/gul_P6 | fmcalc -a2 > fifo/il_P6  ) 2>> log/stderror.err &
+( eve 7 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_fc_P7 -a1 -i - | tee fifo/gul_P7 | fmcalc -a2 > fifo/il_P7  ) 2>> log/stderror.err &
+( eve 8 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_fc_P8 -a1 -i - | tee fifo/gul_P8 | fmcalc -a2 > fifo/il_P8  ) 2>> log/stderror.err &
+( eve 9 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_fc_P9 -a1 -i - | tee fifo/gul_P9 | fmcalc -a2 > fifo/il_P9  ) 2>> log/stderror.err &
+( eve 10 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_fc_P10 -a1 -i - | tee fifo/gul_P10 | fmcalc -a2 > fifo/il_P10  ) 2>> log/stderror.err &
+
+wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 $pid13 $pid14 $pid15 $pid16 $pid17 $pid18 $pid19 $pid20 $pid21 $pid22 $pid23 $pid24 $pid25 $pid26 $pid27 $pid28 $pid29 $pid30 $pid31 $pid32 $pid33 $pid34 $pid35 $pid36 $pid37 $pid38 $pid39 $pid40 $pid41 $pid42 $pid43 $pid44 $pid45 $pid46 $pid47 $pid48 $pid49 $pid50 $pid51 $pid52 $pid53 $pid54 $pid55 $pid56 $pid57 $pid58 $pid59 $pid60 $pid61 $pid62 $pid63 $pid64 $pid65 $pid66 $pid67 $pid68 $pid69 $pid70 $pid71 $pid72 $pid73 $pid74 $pid75 $pid76 $pid77 $pid78 $pid79 $pid80 $pid81 $pid82 $pid83 $pid84 $pid85 $pid86 $pid87 $pid88 $pid89 $pid90 $pid91 $pid92 $pid93 $pid94 $pid95 $pid96 $pid97 $pid98 $pid99 $pid100 $pid101 $pid102 $pid103 $pid104 $pid105 $pid106 $pid107 $pid108 $pid109 $pid110 $pid111 $pid112 $pid113 $pid114 $pid115 $pid116 $pid117 $pid118 $pid119 $pid120 $pid121 $pid122 $pid123 $pid124 $pid125 $pid126 $pid127 $pid128 $pid129 $pid130 $pid131 $pid132 $pid133 $pid134 $pid135 $pid136 $pid137 $pid138 $pid139 $pid140 $pid141 $pid142 $pid143 $pid144 $pid145 $pid146 $pid147 $pid148 $pid149 $pid150 $pid151 $pid152 $pid153 $pid154 $pid155 $pid156 $pid157 $pid158 $pid159 $pid160 $pid161 $pid162 $pid163 $pid164 $pid165 $pid166 $pid167 $pid168 $pid169 $pid170 $pid171 $pid172 $pid173 $pid174 $pid175 $pid176 $pid177 $pid178 $pid179 $pid180 $pid181 $pid182 $pid183 $pid184 $pid185 $pid186 $pid187 $pid188 $pid189 $pid190 $pid191 $pid192 $pid193 $pid194 $pid195 $pid196 $pid197 $pid198 $pid199 $pid200 $pid201 $pid202 $pid203 $pid204 $pid205 $pid206 $pid207 $pid208 $pid209 $pid210 $pid211 $pid212 $pid213 $pid214 $pid215 $pid216 $pid217 $pid218 $pid219 $pid220 $pid221 $pid222 $pid223 $pid224 $pid225 $pid226 $pid227 $pid228 $pid229 $pid230 $pid231 $pid232 $pid233 $pid234 $pid235 $pid236 $pid237 $pid238 $pid239 $pid240 $pid241 $pid242 $pid243 $pid244 $pid245 $pid246 $pid247 $pid248 $pid249 $pid250 $pid251 $pid252 $pid253 $pid254 $pid255 $pid256 $pid257 $pid258 $pid259 $pid260 $pid261 $pid262 $pid263 $pid264 $pid265 $pid266 $pid267 $pid268 $pid269 $pid270 $pid271 $pid272 $pid273 $pid274 $pid275 $pid276 $pid277 $pid278 $pid279 $pid280 $pid281 $pid282 $pid283 $pid284 $pid285 $pid286 $pid287 $pid288 $pid289 $pid290 $pid291 $pid292 $pid293 $pid294 $pid295 $pid296 $pid297 $pid298 $pid299 $pid300 $pid301 $pid302 $pid303 $pid304 $pid305 $pid306 $pid307 $pid308 $pid309 $pid310 $pid311 $pid312 $pid313 $pid314 $pid315 $pid316 $pid317 $pid318 $pid319 $pid320
+
+
+# --- Do insured loss kats ---
+
+kat -s work/kat/il_S1_eltcalc_P1 work/kat/il_S1_eltcalc_P2 work/kat/il_S1_eltcalc_P3 work/kat/il_S1_eltcalc_P4 work/kat/il_S1_eltcalc_P5 work/kat/il_S1_eltcalc_P6 work/kat/il_S1_eltcalc_P7 work/kat/il_S1_eltcalc_P8 work/kat/il_S1_eltcalc_P9 work/kat/il_S1_eltcalc_P10 > output/il_S1_eltcalc.csv & kpid1=$!
+kat work/kat/il_S1_pltcalc_P1 work/kat/il_S1_pltcalc_P2 work/kat/il_S1_pltcalc_P3 work/kat/il_S1_pltcalc_P4 work/kat/il_S1_pltcalc_P5 work/kat/il_S1_pltcalc_P6 work/kat/il_S1_pltcalc_P7 work/kat/il_S1_pltcalc_P8 work/kat/il_S1_pltcalc_P9 work/kat/il_S1_pltcalc_P10 > output/il_S1_pltcalc.csv & kpid2=$!
+kat work/kat/il_S1_summarycalc_P1 work/kat/il_S1_summarycalc_P2 work/kat/il_S1_summarycalc_P3 work/kat/il_S1_summarycalc_P4 work/kat/il_S1_summarycalc_P5 work/kat/il_S1_summarycalc_P6 work/kat/il_S1_summarycalc_P7 work/kat/il_S1_summarycalc_P8 work/kat/il_S1_summarycalc_P9 work/kat/il_S1_summarycalc_P10 > output/il_S1_summarycalc.csv & kpid3=$!
+kat -s work/kat/il_S2_eltcalc_P1 work/kat/il_S2_eltcalc_P2 work/kat/il_S2_eltcalc_P3 work/kat/il_S2_eltcalc_P4 work/kat/il_S2_eltcalc_P5 work/kat/il_S2_eltcalc_P6 work/kat/il_S2_eltcalc_P7 work/kat/il_S2_eltcalc_P8 work/kat/il_S2_eltcalc_P9 work/kat/il_S2_eltcalc_P10 > output/il_S2_eltcalc.csv & kpid4=$!
+kat work/kat/il_S2_pltcalc_P1 work/kat/il_S2_pltcalc_P2 work/kat/il_S2_pltcalc_P3 work/kat/il_S2_pltcalc_P4 work/kat/il_S2_pltcalc_P5 work/kat/il_S2_pltcalc_P6 work/kat/il_S2_pltcalc_P7 work/kat/il_S2_pltcalc_P8 work/kat/il_S2_pltcalc_P9 work/kat/il_S2_pltcalc_P10 > output/il_S2_pltcalc.csv & kpid5=$!
+kat work/kat/il_S2_summarycalc_P1 work/kat/il_S2_summarycalc_P2 work/kat/il_S2_summarycalc_P3 work/kat/il_S2_summarycalc_P4 work/kat/il_S2_summarycalc_P5 work/kat/il_S2_summarycalc_P6 work/kat/il_S2_summarycalc_P7 work/kat/il_S2_summarycalc_P8 work/kat/il_S2_summarycalc_P9 work/kat/il_S2_summarycalc_P10 > output/il_S2_summarycalc.csv & kpid6=$!
+
+# --- Do insured loss kats for fully correlated output ---
+
+kat -s work/full_correlation/kat/il_S1_eltcalc_P1 work/full_correlation/kat/il_S1_eltcalc_P2 work/full_correlation/kat/il_S1_eltcalc_P3 work/full_correlation/kat/il_S1_eltcalc_P4 work/full_correlation/kat/il_S1_eltcalc_P5 work/full_correlation/kat/il_S1_eltcalc_P6 work/full_correlation/kat/il_S1_eltcalc_P7 work/full_correlation/kat/il_S1_eltcalc_P8 work/full_correlation/kat/il_S1_eltcalc_P9 work/full_correlation/kat/il_S1_eltcalc_P10 > output/full_correlation/il_S1_eltcalc.csv & kpid7=$!
+kat work/full_correlation/kat/il_S1_pltcalc_P1 work/full_correlation/kat/il_S1_pltcalc_P2 work/full_correlation/kat/il_S1_pltcalc_P3 work/full_correlation/kat/il_S1_pltcalc_P4 work/full_correlation/kat/il_S1_pltcalc_P5 work/full_correlation/kat/il_S1_pltcalc_P6 work/full_correlation/kat/il_S1_pltcalc_P7 work/full_correlation/kat/il_S1_pltcalc_P8 work/full_correlation/kat/il_S1_pltcalc_P9 work/full_correlation/kat/il_S1_pltcalc_P10 > output/full_correlation/il_S1_pltcalc.csv & kpid8=$!
+kat work/full_correlation/kat/il_S1_summarycalc_P1 work/full_correlation/kat/il_S1_summarycalc_P2 work/full_correlation/kat/il_S1_summarycalc_P3 work/full_correlation/kat/il_S1_summarycalc_P4 work/full_correlation/kat/il_S1_summarycalc_P5 work/full_correlation/kat/il_S1_summarycalc_P6 work/full_correlation/kat/il_S1_summarycalc_P7 work/full_correlation/kat/il_S1_summarycalc_P8 work/full_correlation/kat/il_S1_summarycalc_P9 work/full_correlation/kat/il_S1_summarycalc_P10 > output/full_correlation/il_S1_summarycalc.csv & kpid9=$!
+kat -s work/full_correlation/kat/il_S2_eltcalc_P1 work/full_correlation/kat/il_S2_eltcalc_P2 work/full_correlation/kat/il_S2_eltcalc_P3 work/full_correlation/kat/il_S2_eltcalc_P4 work/full_correlation/kat/il_S2_eltcalc_P5 work/full_correlation/kat/il_S2_eltcalc_P6 work/full_correlation/kat/il_S2_eltcalc_P7 work/full_correlation/kat/il_S2_eltcalc_P8 work/full_correlation/kat/il_S2_eltcalc_P9 work/full_correlation/kat/il_S2_eltcalc_P10 > output/full_correlation/il_S2_eltcalc.csv & kpid10=$!
+kat work/full_correlation/kat/il_S2_pltcalc_P1 work/full_correlation/kat/il_S2_pltcalc_P2 work/full_correlation/kat/il_S2_pltcalc_P3 work/full_correlation/kat/il_S2_pltcalc_P4 work/full_correlation/kat/il_S2_pltcalc_P5 work/full_correlation/kat/il_S2_pltcalc_P6 work/full_correlation/kat/il_S2_pltcalc_P7 work/full_correlation/kat/il_S2_pltcalc_P8 work/full_correlation/kat/il_S2_pltcalc_P9 work/full_correlation/kat/il_S2_pltcalc_P10 > output/full_correlation/il_S2_pltcalc.csv & kpid11=$!
+kat work/full_correlation/kat/il_S2_summarycalc_P1 work/full_correlation/kat/il_S2_summarycalc_P2 work/full_correlation/kat/il_S2_summarycalc_P3 work/full_correlation/kat/il_S2_summarycalc_P4 work/full_correlation/kat/il_S2_summarycalc_P5 work/full_correlation/kat/il_S2_summarycalc_P6 work/full_correlation/kat/il_S2_summarycalc_P7 work/full_correlation/kat/il_S2_summarycalc_P8 work/full_correlation/kat/il_S2_summarycalc_P9 work/full_correlation/kat/il_S2_summarycalc_P10 > output/full_correlation/il_S2_summarycalc.csv & kpid12=$!
+
+# --- Do ground up loss kats ---
+
+kat -s work/kat/gul_S1_eltcalc_P1 work/kat/gul_S1_eltcalc_P2 work/kat/gul_S1_eltcalc_P3 work/kat/gul_S1_eltcalc_P4 work/kat/gul_S1_eltcalc_P5 work/kat/gul_S1_eltcalc_P6 work/kat/gul_S1_eltcalc_P7 work/kat/gul_S1_eltcalc_P8 work/kat/gul_S1_eltcalc_P9 work/kat/gul_S1_eltcalc_P10 > output/gul_S1_eltcalc.csv & kpid13=$!
+kat work/kat/gul_S1_pltcalc_P1 work/kat/gul_S1_pltcalc_P2 work/kat/gul_S1_pltcalc_P3 work/kat/gul_S1_pltcalc_P4 work/kat/gul_S1_pltcalc_P5 work/kat/gul_S1_pltcalc_P6 work/kat/gul_S1_pltcalc_P7 work/kat/gul_S1_pltcalc_P8 work/kat/gul_S1_pltcalc_P9 work/kat/gul_S1_pltcalc_P10 > output/gul_S1_pltcalc.csv & kpid14=$!
+kat work/kat/gul_S1_summarycalc_P1 work/kat/gul_S1_summarycalc_P2 work/kat/gul_S1_summarycalc_P3 work/kat/gul_S1_summarycalc_P4 work/kat/gul_S1_summarycalc_P5 work/kat/gul_S1_summarycalc_P6 work/kat/gul_S1_summarycalc_P7 work/kat/gul_S1_summarycalc_P8 work/kat/gul_S1_summarycalc_P9 work/kat/gul_S1_summarycalc_P10 > output/gul_S1_summarycalc.csv & kpid15=$!
+kat -s work/kat/gul_S2_eltcalc_P1 work/kat/gul_S2_eltcalc_P2 work/kat/gul_S2_eltcalc_P3 work/kat/gul_S2_eltcalc_P4 work/kat/gul_S2_eltcalc_P5 work/kat/gul_S2_eltcalc_P6 work/kat/gul_S2_eltcalc_P7 work/kat/gul_S2_eltcalc_P8 work/kat/gul_S2_eltcalc_P9 work/kat/gul_S2_eltcalc_P10 > output/gul_S2_eltcalc.csv & kpid16=$!
+kat work/kat/gul_S2_pltcalc_P1 work/kat/gul_S2_pltcalc_P2 work/kat/gul_S2_pltcalc_P3 work/kat/gul_S2_pltcalc_P4 work/kat/gul_S2_pltcalc_P5 work/kat/gul_S2_pltcalc_P6 work/kat/gul_S2_pltcalc_P7 work/kat/gul_S2_pltcalc_P8 work/kat/gul_S2_pltcalc_P9 work/kat/gul_S2_pltcalc_P10 > output/gul_S2_pltcalc.csv & kpid17=$!
+kat work/kat/gul_S2_summarycalc_P1 work/kat/gul_S2_summarycalc_P2 work/kat/gul_S2_summarycalc_P3 work/kat/gul_S2_summarycalc_P4 work/kat/gul_S2_summarycalc_P5 work/kat/gul_S2_summarycalc_P6 work/kat/gul_S2_summarycalc_P7 work/kat/gul_S2_summarycalc_P8 work/kat/gul_S2_summarycalc_P9 work/kat/gul_S2_summarycalc_P10 > output/gul_S2_summarycalc.csv & kpid18=$!
+
+# --- Do ground up loss kats for fully correlated output ---
+
+kat -s work/full_correlation/kat/gul_S1_eltcalc_P1 work/full_correlation/kat/gul_S1_eltcalc_P2 work/full_correlation/kat/gul_S1_eltcalc_P3 work/full_correlation/kat/gul_S1_eltcalc_P4 work/full_correlation/kat/gul_S1_eltcalc_P5 work/full_correlation/kat/gul_S1_eltcalc_P6 work/full_correlation/kat/gul_S1_eltcalc_P7 work/full_correlation/kat/gul_S1_eltcalc_P8 work/full_correlation/kat/gul_S1_eltcalc_P9 work/full_correlation/kat/gul_S1_eltcalc_P10 > output/full_correlation/gul_S1_eltcalc.csv & kpid19=$!
+kat work/full_correlation/kat/gul_S1_pltcalc_P1 work/full_correlation/kat/gul_S1_pltcalc_P2 work/full_correlation/kat/gul_S1_pltcalc_P3 work/full_correlation/kat/gul_S1_pltcalc_P4 work/full_correlation/kat/gul_S1_pltcalc_P5 work/full_correlation/kat/gul_S1_pltcalc_P6 work/full_correlation/kat/gul_S1_pltcalc_P7 work/full_correlation/kat/gul_S1_pltcalc_P8 work/full_correlation/kat/gul_S1_pltcalc_P9 work/full_correlation/kat/gul_S1_pltcalc_P10 > output/full_correlation/gul_S1_pltcalc.csv & kpid20=$!
+kat work/full_correlation/kat/gul_S1_summarycalc_P1 work/full_correlation/kat/gul_S1_summarycalc_P2 work/full_correlation/kat/gul_S1_summarycalc_P3 work/full_correlation/kat/gul_S1_summarycalc_P4 work/full_correlation/kat/gul_S1_summarycalc_P5 work/full_correlation/kat/gul_S1_summarycalc_P6 work/full_correlation/kat/gul_S1_summarycalc_P7 work/full_correlation/kat/gul_S1_summarycalc_P8 work/full_correlation/kat/gul_S1_summarycalc_P9 work/full_correlation/kat/gul_S1_summarycalc_P10 > output/full_correlation/gul_S1_summarycalc.csv & kpid21=$!
+kat -s work/full_correlation/kat/gul_S2_eltcalc_P1 work/full_correlation/kat/gul_S2_eltcalc_P2 work/full_correlation/kat/gul_S2_eltcalc_P3 work/full_correlation/kat/gul_S2_eltcalc_P4 work/full_correlation/kat/gul_S2_eltcalc_P5 work/full_correlation/kat/gul_S2_eltcalc_P6 work/full_correlation/kat/gul_S2_eltcalc_P7 work/full_correlation/kat/gul_S2_eltcalc_P8 work/full_correlation/kat/gul_S2_eltcalc_P9 work/full_correlation/kat/gul_S2_eltcalc_P10 > output/full_correlation/gul_S2_eltcalc.csv & kpid22=$!
+kat work/full_correlation/kat/gul_S2_pltcalc_P1 work/full_correlation/kat/gul_S2_pltcalc_P2 work/full_correlation/kat/gul_S2_pltcalc_P3 work/full_correlation/kat/gul_S2_pltcalc_P4 work/full_correlation/kat/gul_S2_pltcalc_P5 work/full_correlation/kat/gul_S2_pltcalc_P6 work/full_correlation/kat/gul_S2_pltcalc_P7 work/full_correlation/kat/gul_S2_pltcalc_P8 work/full_correlation/kat/gul_S2_pltcalc_P9 work/full_correlation/kat/gul_S2_pltcalc_P10 > output/full_correlation/gul_S2_pltcalc.csv & kpid23=$!
+kat work/full_correlation/kat/gul_S2_summarycalc_P1 work/full_correlation/kat/gul_S2_summarycalc_P2 work/full_correlation/kat/gul_S2_summarycalc_P3 work/full_correlation/kat/gul_S2_summarycalc_P4 work/full_correlation/kat/gul_S2_summarycalc_P5 work/full_correlation/kat/gul_S2_summarycalc_P6 work/full_correlation/kat/gul_S2_summarycalc_P7 work/full_correlation/kat/gul_S2_summarycalc_P8 work/full_correlation/kat/gul_S2_summarycalc_P9 work/full_correlation/kat/gul_S2_summarycalc_P10 > output/full_correlation/gul_S2_summarycalc.csv & kpid24=$!
+wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpid11 $kpid12 $kpid13 $kpid14 $kpid15 $kpid16 $kpid17 $kpid18 $kpid19 $kpid20 $kpid21 $kpid22 $kpid23 $kpid24
+
+
+( aalcalc -Kil_S1_summaryaalcalc > output/il_S1_aalcalc.csv ) 2>> log/stderror.err & lpid1=$!
+( ordleccalc -r -Kil_S1_summaryleccalc -F -S -s -M -m -W -w -O output/il_S1_ept.csv -o output/il_S1_psept.csv ) 2>> log/stderror.err & lpid2=$!
+( aalcalc -Kil_S2_summaryaalcalc > output/il_S2_aalcalc.csv ) 2>> log/stderror.err & lpid3=$!
+( ordleccalc -r -Kil_S2_summaryleccalc -F -S -s -M -m -W -w -O output/il_S2_ept.csv -o output/il_S2_psept.csv ) 2>> log/stderror.err & lpid4=$!
+( aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv ) 2>> log/stderror.err & lpid5=$!
+( ordleccalc -r -Kgul_S1_summaryleccalc -F -S -s -M -m -W -w -O output/gul_S1_ept.csv -o output/gul_S1_psept.csv ) 2>> log/stderror.err & lpid6=$!
+( aalcalc -Kgul_S2_summaryaalcalc > output/gul_S2_aalcalc.csv ) 2>> log/stderror.err & lpid7=$!
+( ordleccalc -r -Kgul_S2_summaryleccalc -F -S -s -M -m -W -w -O output/gul_S2_ept.csv -o output/gul_S2_psept.csv ) 2>> log/stderror.err & lpid8=$!
+( aalcalc -Kfull_correlation/il_S1_summaryaalcalc > output/full_correlation/il_S1_aalcalc.csv ) 2>> log/stderror.err & lpid9=$!
+( ordleccalc -r -Kfull_correlation/il_S1_summaryleccalc -F -S -s -M -m -W -w -O output/full_correlation/il_S1_ept.csv -o output/full_correlation/il_S1_psept.csv ) 2>> log/stderror.err & lpid10=$!
+( aalcalc -Kfull_correlation/il_S2_summaryaalcalc > output/full_correlation/il_S2_aalcalc.csv ) 2>> log/stderror.err & lpid11=$!
+( ordleccalc -r -Kfull_correlation/il_S2_summaryleccalc -F -S -s -M -m -W -w -O output/full_correlation/il_S2_ept.csv -o output/full_correlation/il_S2_psept.csv ) 2>> log/stderror.err & lpid12=$!
+( aalcalc -Kfull_correlation/gul_S1_summaryaalcalc > output/full_correlation/gul_S1_aalcalc.csv ) 2>> log/stderror.err & lpid13=$!
+( ordleccalc -r -Kfull_correlation/gul_S1_summaryleccalc -F -S -s -M -m -W -w -O output/full_correlation/gul_S1_ept.csv -o output/full_correlation/gul_S1_psept.csv ) 2>> log/stderror.err & lpid14=$!
+( aalcalc -Kfull_correlation/gul_S2_summaryaalcalc > output/full_correlation/gul_S2_aalcalc.csv ) 2>> log/stderror.err & lpid15=$!
+( ordleccalc -r -Kfull_correlation/gul_S2_summaryleccalc -F -S -s -M -m -W -w -O output/full_correlation/gul_S2_ept.csv -o output/full_correlation/gul_S2_psept.csv ) 2>> log/stderror.err & lpid16=$!
+wait $lpid1 $lpid2 $lpid3 $lpid4 $lpid5 $lpid6 $lpid7 $lpid8 $lpid9 $lpid10 $lpid11 $lpid12 $lpid13 $lpid14 $lpid15 $lpid16
+
+rm -R -f work/*
+rm -R -f fifo/*
+
+check_complete
+exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_ord_ept_psept_2_output_10_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_ord_ept_psept_2_output_10_partition.sh
@@ -29,7 +29,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
    ps f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk -F: '$1>$script_pid' | grep -v celery | grep -v python | grep -v $group_pid | grep -v run_ktools)
+   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | grep -v *.sh)
    echo "$PIDS_KILL" >> log/killout.txt
    kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
    exit $exit_code

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_ord_psept_lec_1_output_10_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_ord_psept_lec_1_output_10_partition.sh
@@ -29,7 +29,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
    ps f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk -F: '$1>$script_pid' | grep -v celery | grep -v python | grep -v $group_pid | grep -v run_ktools)
+   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | grep -v *.sh)
    echo "$PIDS_KILL" >> log/killout.txt
    kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
    exit $exit_code

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_ord_psept_lec_1_output_10_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_ord_psept_lec_1_output_10_partition.sh
@@ -1,0 +1,623 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+
+touch log/stderror.err
+ktools_monitor.sh $$ & pid0=$!
+
+exit_handler(){
+   exit_code=$?
+   kill -9 $pid0 2> /dev/null
+   if [ "$exit_code" -gt 0 ]; then
+       echo 'Ktools Run Error - exitcode='$exit_code
+   else
+       echo 'Run Completed'
+   fi
+
+   set +x
+   group_pid=$(ps -p $$ -o pgid --no-headers)
+   sess_pid=$(ps -p $$ -o sess --no-headers)
+   script_pid=$$
+   printf "Script PID:%d, GPID:%s, SPID:%d
+" $script_pid $group_pid $sess_pid >> log/killout.txt
+
+   ps f -g $sess_pid > log/subprocess_list
+   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk -F: '$1>$script_pid' | grep -v celery | grep -v python | grep -v $group_pid | grep -v run_ktools)
+   echo "$PIDS_KILL" >> log/killout.txt
+   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+   exit $exit_code
+}
+trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
+
+check_complete(){
+    set +e
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
+    has_error=0
+    for p in $proc_list; do
+        started=$(find log -name "$p*.log" | wc -l)
+        finished=$(find log -name "$p*.log" -exec grep -l "finish" {} + | wc -l)
+        if [ "$finished" -lt "$started" ]; then
+            echo "[ERROR] $p - $((started-finished)) processes lost"
+            has_error=1
+        elif [ "$started" -gt 0 ]; then
+            echo "[OK] $p"
+        fi
+    done
+    if [ "$has_error" -ne 0 ]; then
+        false # raise non-zero exit code
+    fi
+}
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+mkdir output/full_correlation/
+
+rm -R -f fifo/*
+mkdir fifo/full_correlation/
+rm -R -f work/*
+mkdir work/kat/
+mkdir work/full_correlation/
+mkdir work/full_correlation/kat/
+
+mkdir work/gul_S1_summaryleccalc
+mkdir work/gul_S1_summaryaalcalc
+mkdir work/full_correlation/gul_S1_summaryleccalc
+mkdir work/full_correlation/gul_S1_summaryaalcalc
+mkdir work/il_S1_summaryleccalc
+mkdir work/il_S1_summaryaalcalc
+mkdir work/full_correlation/il_S1_summaryleccalc
+mkdir work/full_correlation/il_S1_summaryaalcalc
+
+mkfifo fifo/full_correlation/gul_fc_P1
+mkfifo fifo/full_correlation/gul_fc_P2
+mkfifo fifo/full_correlation/gul_fc_P3
+mkfifo fifo/full_correlation/gul_fc_P4
+mkfifo fifo/full_correlation/gul_fc_P5
+mkfifo fifo/full_correlation/gul_fc_P6
+mkfifo fifo/full_correlation/gul_fc_P7
+mkfifo fifo/full_correlation/gul_fc_P8
+mkfifo fifo/full_correlation/gul_fc_P9
+mkfifo fifo/full_correlation/gul_fc_P10
+
+mkfifo fifo/gul_P1
+mkfifo fifo/gul_P2
+mkfifo fifo/gul_P3
+mkfifo fifo/gul_P4
+mkfifo fifo/gul_P5
+mkfifo fifo/gul_P6
+mkfifo fifo/gul_P7
+mkfifo fifo/gul_P8
+mkfifo fifo/gul_P9
+mkfifo fifo/gul_P10
+
+mkfifo fifo/gul_S1_summary_P1
+mkfifo fifo/gul_S1_eltcalc_P1
+mkfifo fifo/gul_S1_summarycalc_P1
+mkfifo fifo/gul_S1_pltcalc_P1
+
+mkfifo fifo/gul_S1_summary_P2
+mkfifo fifo/gul_S1_eltcalc_P2
+mkfifo fifo/gul_S1_summarycalc_P2
+mkfifo fifo/gul_S1_pltcalc_P2
+
+mkfifo fifo/gul_S1_summary_P3
+mkfifo fifo/gul_S1_eltcalc_P3
+mkfifo fifo/gul_S1_summarycalc_P3
+mkfifo fifo/gul_S1_pltcalc_P3
+
+mkfifo fifo/gul_S1_summary_P4
+mkfifo fifo/gul_S1_eltcalc_P4
+mkfifo fifo/gul_S1_summarycalc_P4
+mkfifo fifo/gul_S1_pltcalc_P4
+
+mkfifo fifo/gul_S1_summary_P5
+mkfifo fifo/gul_S1_eltcalc_P5
+mkfifo fifo/gul_S1_summarycalc_P5
+mkfifo fifo/gul_S1_pltcalc_P5
+
+mkfifo fifo/gul_S1_summary_P6
+mkfifo fifo/gul_S1_eltcalc_P6
+mkfifo fifo/gul_S1_summarycalc_P6
+mkfifo fifo/gul_S1_pltcalc_P6
+
+mkfifo fifo/gul_S1_summary_P7
+mkfifo fifo/gul_S1_eltcalc_P7
+mkfifo fifo/gul_S1_summarycalc_P7
+mkfifo fifo/gul_S1_pltcalc_P7
+
+mkfifo fifo/gul_S1_summary_P8
+mkfifo fifo/gul_S1_eltcalc_P8
+mkfifo fifo/gul_S1_summarycalc_P8
+mkfifo fifo/gul_S1_pltcalc_P8
+
+mkfifo fifo/gul_S1_summary_P9
+mkfifo fifo/gul_S1_eltcalc_P9
+mkfifo fifo/gul_S1_summarycalc_P9
+mkfifo fifo/gul_S1_pltcalc_P9
+
+mkfifo fifo/gul_S1_summary_P10
+mkfifo fifo/gul_S1_eltcalc_P10
+mkfifo fifo/gul_S1_summarycalc_P10
+mkfifo fifo/gul_S1_pltcalc_P10
+
+mkfifo fifo/il_P1
+mkfifo fifo/il_P2
+mkfifo fifo/il_P3
+mkfifo fifo/il_P4
+mkfifo fifo/il_P5
+mkfifo fifo/il_P6
+mkfifo fifo/il_P7
+mkfifo fifo/il_P8
+mkfifo fifo/il_P9
+mkfifo fifo/il_P10
+
+mkfifo fifo/il_S1_summary_P1
+mkfifo fifo/il_S1_eltcalc_P1
+mkfifo fifo/il_S1_summarycalc_P1
+mkfifo fifo/il_S1_pltcalc_P1
+
+mkfifo fifo/il_S1_summary_P2
+mkfifo fifo/il_S1_eltcalc_P2
+mkfifo fifo/il_S1_summarycalc_P2
+mkfifo fifo/il_S1_pltcalc_P2
+
+mkfifo fifo/il_S1_summary_P3
+mkfifo fifo/il_S1_eltcalc_P3
+mkfifo fifo/il_S1_summarycalc_P3
+mkfifo fifo/il_S1_pltcalc_P3
+
+mkfifo fifo/il_S1_summary_P4
+mkfifo fifo/il_S1_eltcalc_P4
+mkfifo fifo/il_S1_summarycalc_P4
+mkfifo fifo/il_S1_pltcalc_P4
+
+mkfifo fifo/il_S1_summary_P5
+mkfifo fifo/il_S1_eltcalc_P5
+mkfifo fifo/il_S1_summarycalc_P5
+mkfifo fifo/il_S1_pltcalc_P5
+
+mkfifo fifo/il_S1_summary_P6
+mkfifo fifo/il_S1_eltcalc_P6
+mkfifo fifo/il_S1_summarycalc_P6
+mkfifo fifo/il_S1_pltcalc_P6
+
+mkfifo fifo/il_S1_summary_P7
+mkfifo fifo/il_S1_eltcalc_P7
+mkfifo fifo/il_S1_summarycalc_P7
+mkfifo fifo/il_S1_pltcalc_P7
+
+mkfifo fifo/il_S1_summary_P8
+mkfifo fifo/il_S1_eltcalc_P8
+mkfifo fifo/il_S1_summarycalc_P8
+mkfifo fifo/il_S1_pltcalc_P8
+
+mkfifo fifo/il_S1_summary_P9
+mkfifo fifo/il_S1_eltcalc_P9
+mkfifo fifo/il_S1_summarycalc_P9
+mkfifo fifo/il_S1_pltcalc_P9
+
+mkfifo fifo/il_S1_summary_P10
+mkfifo fifo/il_S1_eltcalc_P10
+mkfifo fifo/il_S1_summarycalc_P10
+mkfifo fifo/il_S1_pltcalc_P10
+
+mkfifo fifo/full_correlation/gul_P1
+mkfifo fifo/full_correlation/gul_P2
+mkfifo fifo/full_correlation/gul_P3
+mkfifo fifo/full_correlation/gul_P4
+mkfifo fifo/full_correlation/gul_P5
+mkfifo fifo/full_correlation/gul_P6
+mkfifo fifo/full_correlation/gul_P7
+mkfifo fifo/full_correlation/gul_P8
+mkfifo fifo/full_correlation/gul_P9
+mkfifo fifo/full_correlation/gul_P10
+
+mkfifo fifo/full_correlation/gul_S1_summary_P1
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P1
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P1
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P1
+
+mkfifo fifo/full_correlation/gul_S1_summary_P2
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P2
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P2
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P2
+
+mkfifo fifo/full_correlation/gul_S1_summary_P3
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P3
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P3
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P3
+
+mkfifo fifo/full_correlation/gul_S1_summary_P4
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P4
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P4
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P4
+
+mkfifo fifo/full_correlation/gul_S1_summary_P5
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P5
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P5
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P5
+
+mkfifo fifo/full_correlation/gul_S1_summary_P6
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P6
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P6
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P6
+
+mkfifo fifo/full_correlation/gul_S1_summary_P7
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P7
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P7
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P7
+
+mkfifo fifo/full_correlation/gul_S1_summary_P8
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P8
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P8
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P8
+
+mkfifo fifo/full_correlation/gul_S1_summary_P9
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P9
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P9
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P9
+
+mkfifo fifo/full_correlation/gul_S1_summary_P10
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P10
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P10
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P10
+
+mkfifo fifo/full_correlation/il_P1
+mkfifo fifo/full_correlation/il_P2
+mkfifo fifo/full_correlation/il_P3
+mkfifo fifo/full_correlation/il_P4
+mkfifo fifo/full_correlation/il_P5
+mkfifo fifo/full_correlation/il_P6
+mkfifo fifo/full_correlation/il_P7
+mkfifo fifo/full_correlation/il_P8
+mkfifo fifo/full_correlation/il_P9
+mkfifo fifo/full_correlation/il_P10
+
+mkfifo fifo/full_correlation/il_S1_summary_P1
+mkfifo fifo/full_correlation/il_S1_eltcalc_P1
+mkfifo fifo/full_correlation/il_S1_summarycalc_P1
+mkfifo fifo/full_correlation/il_S1_pltcalc_P1
+
+mkfifo fifo/full_correlation/il_S1_summary_P2
+mkfifo fifo/full_correlation/il_S1_eltcalc_P2
+mkfifo fifo/full_correlation/il_S1_summarycalc_P2
+mkfifo fifo/full_correlation/il_S1_pltcalc_P2
+
+mkfifo fifo/full_correlation/il_S1_summary_P3
+mkfifo fifo/full_correlation/il_S1_eltcalc_P3
+mkfifo fifo/full_correlation/il_S1_summarycalc_P3
+mkfifo fifo/full_correlation/il_S1_pltcalc_P3
+
+mkfifo fifo/full_correlation/il_S1_summary_P4
+mkfifo fifo/full_correlation/il_S1_eltcalc_P4
+mkfifo fifo/full_correlation/il_S1_summarycalc_P4
+mkfifo fifo/full_correlation/il_S1_pltcalc_P4
+
+mkfifo fifo/full_correlation/il_S1_summary_P5
+mkfifo fifo/full_correlation/il_S1_eltcalc_P5
+mkfifo fifo/full_correlation/il_S1_summarycalc_P5
+mkfifo fifo/full_correlation/il_S1_pltcalc_P5
+
+mkfifo fifo/full_correlation/il_S1_summary_P6
+mkfifo fifo/full_correlation/il_S1_eltcalc_P6
+mkfifo fifo/full_correlation/il_S1_summarycalc_P6
+mkfifo fifo/full_correlation/il_S1_pltcalc_P6
+
+mkfifo fifo/full_correlation/il_S1_summary_P7
+mkfifo fifo/full_correlation/il_S1_eltcalc_P7
+mkfifo fifo/full_correlation/il_S1_summarycalc_P7
+mkfifo fifo/full_correlation/il_S1_pltcalc_P7
+
+mkfifo fifo/full_correlation/il_S1_summary_P8
+mkfifo fifo/full_correlation/il_S1_eltcalc_P8
+mkfifo fifo/full_correlation/il_S1_summarycalc_P8
+mkfifo fifo/full_correlation/il_S1_pltcalc_P8
+
+mkfifo fifo/full_correlation/il_S1_summary_P9
+mkfifo fifo/full_correlation/il_S1_eltcalc_P9
+mkfifo fifo/full_correlation/il_S1_summarycalc_P9
+mkfifo fifo/full_correlation/il_S1_pltcalc_P9
+
+mkfifo fifo/full_correlation/il_S1_summary_P10
+mkfifo fifo/full_correlation/il_S1_eltcalc_P10
+mkfifo fifo/full_correlation/il_S1_summarycalc_P10
+mkfifo fifo/full_correlation/il_S1_pltcalc_P10
+
+
+
+# --- Do insured loss computes ---
+
+( eltcalc < fifo/il_S1_eltcalc_P1 > work/kat/il_S1_eltcalc_P1 ) 2>> log/stderror.err & pid1=$!
+( summarycalctocsv < fifo/il_S1_summarycalc_P1 > work/kat/il_S1_summarycalc_P1 ) 2>> log/stderror.err & pid2=$!
+( pltcalc < fifo/il_S1_pltcalc_P1 > work/kat/il_S1_pltcalc_P1 ) 2>> log/stderror.err & pid3=$!
+( eltcalc -s < fifo/il_S1_eltcalc_P2 > work/kat/il_S1_eltcalc_P2 ) 2>> log/stderror.err & pid4=$!
+( summarycalctocsv -s < fifo/il_S1_summarycalc_P2 > work/kat/il_S1_summarycalc_P2 ) 2>> log/stderror.err & pid5=$!
+( pltcalc -s < fifo/il_S1_pltcalc_P2 > work/kat/il_S1_pltcalc_P2 ) 2>> log/stderror.err & pid6=$!
+( eltcalc -s < fifo/il_S1_eltcalc_P3 > work/kat/il_S1_eltcalc_P3 ) 2>> log/stderror.err & pid7=$!
+( summarycalctocsv -s < fifo/il_S1_summarycalc_P3 > work/kat/il_S1_summarycalc_P3 ) 2>> log/stderror.err & pid8=$!
+( pltcalc -s < fifo/il_S1_pltcalc_P3 > work/kat/il_S1_pltcalc_P3 ) 2>> log/stderror.err & pid9=$!
+( eltcalc -s < fifo/il_S1_eltcalc_P4 > work/kat/il_S1_eltcalc_P4 ) 2>> log/stderror.err & pid10=$!
+( summarycalctocsv -s < fifo/il_S1_summarycalc_P4 > work/kat/il_S1_summarycalc_P4 ) 2>> log/stderror.err & pid11=$!
+( pltcalc -s < fifo/il_S1_pltcalc_P4 > work/kat/il_S1_pltcalc_P4 ) 2>> log/stderror.err & pid12=$!
+( eltcalc -s < fifo/il_S1_eltcalc_P5 > work/kat/il_S1_eltcalc_P5 ) 2>> log/stderror.err & pid13=$!
+( summarycalctocsv -s < fifo/il_S1_summarycalc_P5 > work/kat/il_S1_summarycalc_P5 ) 2>> log/stderror.err & pid14=$!
+( pltcalc -s < fifo/il_S1_pltcalc_P5 > work/kat/il_S1_pltcalc_P5 ) 2>> log/stderror.err & pid15=$!
+( eltcalc -s < fifo/il_S1_eltcalc_P6 > work/kat/il_S1_eltcalc_P6 ) 2>> log/stderror.err & pid16=$!
+( summarycalctocsv -s < fifo/il_S1_summarycalc_P6 > work/kat/il_S1_summarycalc_P6 ) 2>> log/stderror.err & pid17=$!
+( pltcalc -s < fifo/il_S1_pltcalc_P6 > work/kat/il_S1_pltcalc_P6 ) 2>> log/stderror.err & pid18=$!
+( eltcalc -s < fifo/il_S1_eltcalc_P7 > work/kat/il_S1_eltcalc_P7 ) 2>> log/stderror.err & pid19=$!
+( summarycalctocsv -s < fifo/il_S1_summarycalc_P7 > work/kat/il_S1_summarycalc_P7 ) 2>> log/stderror.err & pid20=$!
+( pltcalc -s < fifo/il_S1_pltcalc_P7 > work/kat/il_S1_pltcalc_P7 ) 2>> log/stderror.err & pid21=$!
+( eltcalc -s < fifo/il_S1_eltcalc_P8 > work/kat/il_S1_eltcalc_P8 ) 2>> log/stderror.err & pid22=$!
+( summarycalctocsv -s < fifo/il_S1_summarycalc_P8 > work/kat/il_S1_summarycalc_P8 ) 2>> log/stderror.err & pid23=$!
+( pltcalc -s < fifo/il_S1_pltcalc_P8 > work/kat/il_S1_pltcalc_P8 ) 2>> log/stderror.err & pid24=$!
+( eltcalc -s < fifo/il_S1_eltcalc_P9 > work/kat/il_S1_eltcalc_P9 ) 2>> log/stderror.err & pid25=$!
+( summarycalctocsv -s < fifo/il_S1_summarycalc_P9 > work/kat/il_S1_summarycalc_P9 ) 2>> log/stderror.err & pid26=$!
+( pltcalc -s < fifo/il_S1_pltcalc_P9 > work/kat/il_S1_pltcalc_P9 ) 2>> log/stderror.err & pid27=$!
+( eltcalc -s < fifo/il_S1_eltcalc_P10 > work/kat/il_S1_eltcalc_P10 ) 2>> log/stderror.err & pid28=$!
+( summarycalctocsv -s < fifo/il_S1_summarycalc_P10 > work/kat/il_S1_summarycalc_P10 ) 2>> log/stderror.err & pid29=$!
+( pltcalc -s < fifo/il_S1_pltcalc_P10 > work/kat/il_S1_pltcalc_P10 ) 2>> log/stderror.err & pid30=$!
+
+tee < fifo/il_S1_summary_P1 fifo/il_S1_eltcalc_P1 fifo/il_S1_summarycalc_P1 fifo/il_S1_pltcalc_P1 work/il_S1_summaryaalcalc/P1.bin work/il_S1_summaryleccalc/P1.bin > /dev/null & pid31=$!
+tee < fifo/il_S1_summary_P2 fifo/il_S1_eltcalc_P2 fifo/il_S1_summarycalc_P2 fifo/il_S1_pltcalc_P2 work/il_S1_summaryaalcalc/P2.bin work/il_S1_summaryleccalc/P2.bin > /dev/null & pid32=$!
+tee < fifo/il_S1_summary_P3 fifo/il_S1_eltcalc_P3 fifo/il_S1_summarycalc_P3 fifo/il_S1_pltcalc_P3 work/il_S1_summaryaalcalc/P3.bin work/il_S1_summaryleccalc/P3.bin > /dev/null & pid33=$!
+tee < fifo/il_S1_summary_P4 fifo/il_S1_eltcalc_P4 fifo/il_S1_summarycalc_P4 fifo/il_S1_pltcalc_P4 work/il_S1_summaryaalcalc/P4.bin work/il_S1_summaryleccalc/P4.bin > /dev/null & pid34=$!
+tee < fifo/il_S1_summary_P5 fifo/il_S1_eltcalc_P5 fifo/il_S1_summarycalc_P5 fifo/il_S1_pltcalc_P5 work/il_S1_summaryaalcalc/P5.bin work/il_S1_summaryleccalc/P5.bin > /dev/null & pid35=$!
+tee < fifo/il_S1_summary_P6 fifo/il_S1_eltcalc_P6 fifo/il_S1_summarycalc_P6 fifo/il_S1_pltcalc_P6 work/il_S1_summaryaalcalc/P6.bin work/il_S1_summaryleccalc/P6.bin > /dev/null & pid36=$!
+tee < fifo/il_S1_summary_P7 fifo/il_S1_eltcalc_P7 fifo/il_S1_summarycalc_P7 fifo/il_S1_pltcalc_P7 work/il_S1_summaryaalcalc/P7.bin work/il_S1_summaryleccalc/P7.bin > /dev/null & pid37=$!
+tee < fifo/il_S1_summary_P8 fifo/il_S1_eltcalc_P8 fifo/il_S1_summarycalc_P8 fifo/il_S1_pltcalc_P8 work/il_S1_summaryaalcalc/P8.bin work/il_S1_summaryleccalc/P8.bin > /dev/null & pid38=$!
+tee < fifo/il_S1_summary_P9 fifo/il_S1_eltcalc_P9 fifo/il_S1_summarycalc_P9 fifo/il_S1_pltcalc_P9 work/il_S1_summaryaalcalc/P9.bin work/il_S1_summaryleccalc/P9.bin > /dev/null & pid39=$!
+tee < fifo/il_S1_summary_P10 fifo/il_S1_eltcalc_P10 fifo/il_S1_summarycalc_P10 fifo/il_S1_pltcalc_P10 work/il_S1_summaryaalcalc/P10.bin work/il_S1_summaryleccalc/P10.bin > /dev/null & pid40=$!
+
+( summarycalc -f  -1 fifo/il_S1_summary_P1 < fifo/il_P1 ) 2>> log/stderror.err  &
+( summarycalc -f  -1 fifo/il_S1_summary_P2 < fifo/il_P2 ) 2>> log/stderror.err  &
+( summarycalc -f  -1 fifo/il_S1_summary_P3 < fifo/il_P3 ) 2>> log/stderror.err  &
+( summarycalc -f  -1 fifo/il_S1_summary_P4 < fifo/il_P4 ) 2>> log/stderror.err  &
+( summarycalc -f  -1 fifo/il_S1_summary_P5 < fifo/il_P5 ) 2>> log/stderror.err  &
+( summarycalc -f  -1 fifo/il_S1_summary_P6 < fifo/il_P6 ) 2>> log/stderror.err  &
+( summarycalc -f  -1 fifo/il_S1_summary_P7 < fifo/il_P7 ) 2>> log/stderror.err  &
+( summarycalc -f  -1 fifo/il_S1_summary_P8 < fifo/il_P8 ) 2>> log/stderror.err  &
+( summarycalc -f  -1 fifo/il_S1_summary_P9 < fifo/il_P9 ) 2>> log/stderror.err  &
+( summarycalc -f  -1 fifo/il_S1_summary_P10 < fifo/il_P10 ) 2>> log/stderror.err  &
+
+# --- Do ground up loss computes ---
+
+( eltcalc < fifo/gul_S1_eltcalc_P1 > work/kat/gul_S1_eltcalc_P1 ) 2>> log/stderror.err & pid41=$!
+( summarycalctocsv < fifo/gul_S1_summarycalc_P1 > work/kat/gul_S1_summarycalc_P1 ) 2>> log/stderror.err & pid42=$!
+( pltcalc < fifo/gul_S1_pltcalc_P1 > work/kat/gul_S1_pltcalc_P1 ) 2>> log/stderror.err & pid43=$!
+( eltcalc -s < fifo/gul_S1_eltcalc_P2 > work/kat/gul_S1_eltcalc_P2 ) 2>> log/stderror.err & pid44=$!
+( summarycalctocsv -s < fifo/gul_S1_summarycalc_P2 > work/kat/gul_S1_summarycalc_P2 ) 2>> log/stderror.err & pid45=$!
+( pltcalc -s < fifo/gul_S1_pltcalc_P2 > work/kat/gul_S1_pltcalc_P2 ) 2>> log/stderror.err & pid46=$!
+( eltcalc -s < fifo/gul_S1_eltcalc_P3 > work/kat/gul_S1_eltcalc_P3 ) 2>> log/stderror.err & pid47=$!
+( summarycalctocsv -s < fifo/gul_S1_summarycalc_P3 > work/kat/gul_S1_summarycalc_P3 ) 2>> log/stderror.err & pid48=$!
+( pltcalc -s < fifo/gul_S1_pltcalc_P3 > work/kat/gul_S1_pltcalc_P3 ) 2>> log/stderror.err & pid49=$!
+( eltcalc -s < fifo/gul_S1_eltcalc_P4 > work/kat/gul_S1_eltcalc_P4 ) 2>> log/stderror.err & pid50=$!
+( summarycalctocsv -s < fifo/gul_S1_summarycalc_P4 > work/kat/gul_S1_summarycalc_P4 ) 2>> log/stderror.err & pid51=$!
+( pltcalc -s < fifo/gul_S1_pltcalc_P4 > work/kat/gul_S1_pltcalc_P4 ) 2>> log/stderror.err & pid52=$!
+( eltcalc -s < fifo/gul_S1_eltcalc_P5 > work/kat/gul_S1_eltcalc_P5 ) 2>> log/stderror.err & pid53=$!
+( summarycalctocsv -s < fifo/gul_S1_summarycalc_P5 > work/kat/gul_S1_summarycalc_P5 ) 2>> log/stderror.err & pid54=$!
+( pltcalc -s < fifo/gul_S1_pltcalc_P5 > work/kat/gul_S1_pltcalc_P5 ) 2>> log/stderror.err & pid55=$!
+( eltcalc -s < fifo/gul_S1_eltcalc_P6 > work/kat/gul_S1_eltcalc_P6 ) 2>> log/stderror.err & pid56=$!
+( summarycalctocsv -s < fifo/gul_S1_summarycalc_P6 > work/kat/gul_S1_summarycalc_P6 ) 2>> log/stderror.err & pid57=$!
+( pltcalc -s < fifo/gul_S1_pltcalc_P6 > work/kat/gul_S1_pltcalc_P6 ) 2>> log/stderror.err & pid58=$!
+( eltcalc -s < fifo/gul_S1_eltcalc_P7 > work/kat/gul_S1_eltcalc_P7 ) 2>> log/stderror.err & pid59=$!
+( summarycalctocsv -s < fifo/gul_S1_summarycalc_P7 > work/kat/gul_S1_summarycalc_P7 ) 2>> log/stderror.err & pid60=$!
+( pltcalc -s < fifo/gul_S1_pltcalc_P7 > work/kat/gul_S1_pltcalc_P7 ) 2>> log/stderror.err & pid61=$!
+( eltcalc -s < fifo/gul_S1_eltcalc_P8 > work/kat/gul_S1_eltcalc_P8 ) 2>> log/stderror.err & pid62=$!
+( summarycalctocsv -s < fifo/gul_S1_summarycalc_P8 > work/kat/gul_S1_summarycalc_P8 ) 2>> log/stderror.err & pid63=$!
+( pltcalc -s < fifo/gul_S1_pltcalc_P8 > work/kat/gul_S1_pltcalc_P8 ) 2>> log/stderror.err & pid64=$!
+( eltcalc -s < fifo/gul_S1_eltcalc_P9 > work/kat/gul_S1_eltcalc_P9 ) 2>> log/stderror.err & pid65=$!
+( summarycalctocsv -s < fifo/gul_S1_summarycalc_P9 > work/kat/gul_S1_summarycalc_P9 ) 2>> log/stderror.err & pid66=$!
+( pltcalc -s < fifo/gul_S1_pltcalc_P9 > work/kat/gul_S1_pltcalc_P9 ) 2>> log/stderror.err & pid67=$!
+( eltcalc -s < fifo/gul_S1_eltcalc_P10 > work/kat/gul_S1_eltcalc_P10 ) 2>> log/stderror.err & pid68=$!
+( summarycalctocsv -s < fifo/gul_S1_summarycalc_P10 > work/kat/gul_S1_summarycalc_P10 ) 2>> log/stderror.err & pid69=$!
+( pltcalc -s < fifo/gul_S1_pltcalc_P10 > work/kat/gul_S1_pltcalc_P10 ) 2>> log/stderror.err & pid70=$!
+
+tee < fifo/gul_S1_summary_P1 fifo/gul_S1_eltcalc_P1 fifo/gul_S1_summarycalc_P1 fifo/gul_S1_pltcalc_P1 work/gul_S1_summaryaalcalc/P1.bin work/gul_S1_summaryleccalc/P1.bin > /dev/null & pid71=$!
+tee < fifo/gul_S1_summary_P2 fifo/gul_S1_eltcalc_P2 fifo/gul_S1_summarycalc_P2 fifo/gul_S1_pltcalc_P2 work/gul_S1_summaryaalcalc/P2.bin work/gul_S1_summaryleccalc/P2.bin > /dev/null & pid72=$!
+tee < fifo/gul_S1_summary_P3 fifo/gul_S1_eltcalc_P3 fifo/gul_S1_summarycalc_P3 fifo/gul_S1_pltcalc_P3 work/gul_S1_summaryaalcalc/P3.bin work/gul_S1_summaryleccalc/P3.bin > /dev/null & pid73=$!
+tee < fifo/gul_S1_summary_P4 fifo/gul_S1_eltcalc_P4 fifo/gul_S1_summarycalc_P4 fifo/gul_S1_pltcalc_P4 work/gul_S1_summaryaalcalc/P4.bin work/gul_S1_summaryleccalc/P4.bin > /dev/null & pid74=$!
+tee < fifo/gul_S1_summary_P5 fifo/gul_S1_eltcalc_P5 fifo/gul_S1_summarycalc_P5 fifo/gul_S1_pltcalc_P5 work/gul_S1_summaryaalcalc/P5.bin work/gul_S1_summaryleccalc/P5.bin > /dev/null & pid75=$!
+tee < fifo/gul_S1_summary_P6 fifo/gul_S1_eltcalc_P6 fifo/gul_S1_summarycalc_P6 fifo/gul_S1_pltcalc_P6 work/gul_S1_summaryaalcalc/P6.bin work/gul_S1_summaryleccalc/P6.bin > /dev/null & pid76=$!
+tee < fifo/gul_S1_summary_P7 fifo/gul_S1_eltcalc_P7 fifo/gul_S1_summarycalc_P7 fifo/gul_S1_pltcalc_P7 work/gul_S1_summaryaalcalc/P7.bin work/gul_S1_summaryleccalc/P7.bin > /dev/null & pid77=$!
+tee < fifo/gul_S1_summary_P8 fifo/gul_S1_eltcalc_P8 fifo/gul_S1_summarycalc_P8 fifo/gul_S1_pltcalc_P8 work/gul_S1_summaryaalcalc/P8.bin work/gul_S1_summaryleccalc/P8.bin > /dev/null & pid78=$!
+tee < fifo/gul_S1_summary_P9 fifo/gul_S1_eltcalc_P9 fifo/gul_S1_summarycalc_P9 fifo/gul_S1_pltcalc_P9 work/gul_S1_summaryaalcalc/P9.bin work/gul_S1_summaryleccalc/P9.bin > /dev/null & pid79=$!
+tee < fifo/gul_S1_summary_P10 fifo/gul_S1_eltcalc_P10 fifo/gul_S1_summarycalc_P10 fifo/gul_S1_pltcalc_P10 work/gul_S1_summaryaalcalc/P10.bin work/gul_S1_summaryleccalc/P10.bin > /dev/null & pid80=$!
+
+( summarycalc -i  -1 fifo/gul_S1_summary_P1 < fifo/gul_P1 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P2 < fifo/gul_P2 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P3 < fifo/gul_P3 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P4 < fifo/gul_P4 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P5 < fifo/gul_P5 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P6 < fifo/gul_P6 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P7 < fifo/gul_P7 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P8 < fifo/gul_P8 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P9 < fifo/gul_P9 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P10 < fifo/gul_P10 ) 2>> log/stderror.err  &
+
+# --- Do insured loss computes ---
+
+( eltcalc < fifo/full_correlation/il_S1_eltcalc_P1 > work/full_correlation/kat/il_S1_eltcalc_P1 ) 2>> log/stderror.err & pid81=$!
+( summarycalctocsv < fifo/full_correlation/il_S1_summarycalc_P1 > work/full_correlation/kat/il_S1_summarycalc_P1 ) 2>> log/stderror.err & pid82=$!
+( pltcalc < fifo/full_correlation/il_S1_pltcalc_P1 > work/full_correlation/kat/il_S1_pltcalc_P1 ) 2>> log/stderror.err & pid83=$!
+( eltcalc -s < fifo/full_correlation/il_S1_eltcalc_P2 > work/full_correlation/kat/il_S1_eltcalc_P2 ) 2>> log/stderror.err & pid84=$!
+( summarycalctocsv -s < fifo/full_correlation/il_S1_summarycalc_P2 > work/full_correlation/kat/il_S1_summarycalc_P2 ) 2>> log/stderror.err & pid85=$!
+( pltcalc -s < fifo/full_correlation/il_S1_pltcalc_P2 > work/full_correlation/kat/il_S1_pltcalc_P2 ) 2>> log/stderror.err & pid86=$!
+( eltcalc -s < fifo/full_correlation/il_S1_eltcalc_P3 > work/full_correlation/kat/il_S1_eltcalc_P3 ) 2>> log/stderror.err & pid87=$!
+( summarycalctocsv -s < fifo/full_correlation/il_S1_summarycalc_P3 > work/full_correlation/kat/il_S1_summarycalc_P3 ) 2>> log/stderror.err & pid88=$!
+( pltcalc -s < fifo/full_correlation/il_S1_pltcalc_P3 > work/full_correlation/kat/il_S1_pltcalc_P3 ) 2>> log/stderror.err & pid89=$!
+( eltcalc -s < fifo/full_correlation/il_S1_eltcalc_P4 > work/full_correlation/kat/il_S1_eltcalc_P4 ) 2>> log/stderror.err & pid90=$!
+( summarycalctocsv -s < fifo/full_correlation/il_S1_summarycalc_P4 > work/full_correlation/kat/il_S1_summarycalc_P4 ) 2>> log/stderror.err & pid91=$!
+( pltcalc -s < fifo/full_correlation/il_S1_pltcalc_P4 > work/full_correlation/kat/il_S1_pltcalc_P4 ) 2>> log/stderror.err & pid92=$!
+( eltcalc -s < fifo/full_correlation/il_S1_eltcalc_P5 > work/full_correlation/kat/il_S1_eltcalc_P5 ) 2>> log/stderror.err & pid93=$!
+( summarycalctocsv -s < fifo/full_correlation/il_S1_summarycalc_P5 > work/full_correlation/kat/il_S1_summarycalc_P5 ) 2>> log/stderror.err & pid94=$!
+( pltcalc -s < fifo/full_correlation/il_S1_pltcalc_P5 > work/full_correlation/kat/il_S1_pltcalc_P5 ) 2>> log/stderror.err & pid95=$!
+( eltcalc -s < fifo/full_correlation/il_S1_eltcalc_P6 > work/full_correlation/kat/il_S1_eltcalc_P6 ) 2>> log/stderror.err & pid96=$!
+( summarycalctocsv -s < fifo/full_correlation/il_S1_summarycalc_P6 > work/full_correlation/kat/il_S1_summarycalc_P6 ) 2>> log/stderror.err & pid97=$!
+( pltcalc -s < fifo/full_correlation/il_S1_pltcalc_P6 > work/full_correlation/kat/il_S1_pltcalc_P6 ) 2>> log/stderror.err & pid98=$!
+( eltcalc -s < fifo/full_correlation/il_S1_eltcalc_P7 > work/full_correlation/kat/il_S1_eltcalc_P7 ) 2>> log/stderror.err & pid99=$!
+( summarycalctocsv -s < fifo/full_correlation/il_S1_summarycalc_P7 > work/full_correlation/kat/il_S1_summarycalc_P7 ) 2>> log/stderror.err & pid100=$!
+( pltcalc -s < fifo/full_correlation/il_S1_pltcalc_P7 > work/full_correlation/kat/il_S1_pltcalc_P7 ) 2>> log/stderror.err & pid101=$!
+( eltcalc -s < fifo/full_correlation/il_S1_eltcalc_P8 > work/full_correlation/kat/il_S1_eltcalc_P8 ) 2>> log/stderror.err & pid102=$!
+( summarycalctocsv -s < fifo/full_correlation/il_S1_summarycalc_P8 > work/full_correlation/kat/il_S1_summarycalc_P8 ) 2>> log/stderror.err & pid103=$!
+( pltcalc -s < fifo/full_correlation/il_S1_pltcalc_P8 > work/full_correlation/kat/il_S1_pltcalc_P8 ) 2>> log/stderror.err & pid104=$!
+( eltcalc -s < fifo/full_correlation/il_S1_eltcalc_P9 > work/full_correlation/kat/il_S1_eltcalc_P9 ) 2>> log/stderror.err & pid105=$!
+( summarycalctocsv -s < fifo/full_correlation/il_S1_summarycalc_P9 > work/full_correlation/kat/il_S1_summarycalc_P9 ) 2>> log/stderror.err & pid106=$!
+( pltcalc -s < fifo/full_correlation/il_S1_pltcalc_P9 > work/full_correlation/kat/il_S1_pltcalc_P9 ) 2>> log/stderror.err & pid107=$!
+( eltcalc -s < fifo/full_correlation/il_S1_eltcalc_P10 > work/full_correlation/kat/il_S1_eltcalc_P10 ) 2>> log/stderror.err & pid108=$!
+( summarycalctocsv -s < fifo/full_correlation/il_S1_summarycalc_P10 > work/full_correlation/kat/il_S1_summarycalc_P10 ) 2>> log/stderror.err & pid109=$!
+( pltcalc -s < fifo/full_correlation/il_S1_pltcalc_P10 > work/full_correlation/kat/il_S1_pltcalc_P10 ) 2>> log/stderror.err & pid110=$!
+
+tee < fifo/full_correlation/il_S1_summary_P1 fifo/full_correlation/il_S1_eltcalc_P1 fifo/full_correlation/il_S1_summarycalc_P1 fifo/full_correlation/il_S1_pltcalc_P1 work/full_correlation/il_S1_summaryaalcalc/P1.bin work/full_correlation/il_S1_summaryleccalc/P1.bin > /dev/null & pid111=$!
+tee < fifo/full_correlation/il_S1_summary_P2 fifo/full_correlation/il_S1_eltcalc_P2 fifo/full_correlation/il_S1_summarycalc_P2 fifo/full_correlation/il_S1_pltcalc_P2 work/full_correlation/il_S1_summaryaalcalc/P2.bin work/full_correlation/il_S1_summaryleccalc/P2.bin > /dev/null & pid112=$!
+tee < fifo/full_correlation/il_S1_summary_P3 fifo/full_correlation/il_S1_eltcalc_P3 fifo/full_correlation/il_S1_summarycalc_P3 fifo/full_correlation/il_S1_pltcalc_P3 work/full_correlation/il_S1_summaryaalcalc/P3.bin work/full_correlation/il_S1_summaryleccalc/P3.bin > /dev/null & pid113=$!
+tee < fifo/full_correlation/il_S1_summary_P4 fifo/full_correlation/il_S1_eltcalc_P4 fifo/full_correlation/il_S1_summarycalc_P4 fifo/full_correlation/il_S1_pltcalc_P4 work/full_correlation/il_S1_summaryaalcalc/P4.bin work/full_correlation/il_S1_summaryleccalc/P4.bin > /dev/null & pid114=$!
+tee < fifo/full_correlation/il_S1_summary_P5 fifo/full_correlation/il_S1_eltcalc_P5 fifo/full_correlation/il_S1_summarycalc_P5 fifo/full_correlation/il_S1_pltcalc_P5 work/full_correlation/il_S1_summaryaalcalc/P5.bin work/full_correlation/il_S1_summaryleccalc/P5.bin > /dev/null & pid115=$!
+tee < fifo/full_correlation/il_S1_summary_P6 fifo/full_correlation/il_S1_eltcalc_P6 fifo/full_correlation/il_S1_summarycalc_P6 fifo/full_correlation/il_S1_pltcalc_P6 work/full_correlation/il_S1_summaryaalcalc/P6.bin work/full_correlation/il_S1_summaryleccalc/P6.bin > /dev/null & pid116=$!
+tee < fifo/full_correlation/il_S1_summary_P7 fifo/full_correlation/il_S1_eltcalc_P7 fifo/full_correlation/il_S1_summarycalc_P7 fifo/full_correlation/il_S1_pltcalc_P7 work/full_correlation/il_S1_summaryaalcalc/P7.bin work/full_correlation/il_S1_summaryleccalc/P7.bin > /dev/null & pid117=$!
+tee < fifo/full_correlation/il_S1_summary_P8 fifo/full_correlation/il_S1_eltcalc_P8 fifo/full_correlation/il_S1_summarycalc_P8 fifo/full_correlation/il_S1_pltcalc_P8 work/full_correlation/il_S1_summaryaalcalc/P8.bin work/full_correlation/il_S1_summaryleccalc/P8.bin > /dev/null & pid118=$!
+tee < fifo/full_correlation/il_S1_summary_P9 fifo/full_correlation/il_S1_eltcalc_P9 fifo/full_correlation/il_S1_summarycalc_P9 fifo/full_correlation/il_S1_pltcalc_P9 work/full_correlation/il_S1_summaryaalcalc/P9.bin work/full_correlation/il_S1_summaryleccalc/P9.bin > /dev/null & pid119=$!
+tee < fifo/full_correlation/il_S1_summary_P10 fifo/full_correlation/il_S1_eltcalc_P10 fifo/full_correlation/il_S1_summarycalc_P10 fifo/full_correlation/il_S1_pltcalc_P10 work/full_correlation/il_S1_summaryaalcalc/P10.bin work/full_correlation/il_S1_summaryleccalc/P10.bin > /dev/null & pid120=$!
+
+( summarycalc -f  -1 fifo/full_correlation/il_S1_summary_P1 < fifo/full_correlation/il_P1 ) 2>> log/stderror.err  &
+( summarycalc -f  -1 fifo/full_correlation/il_S1_summary_P2 < fifo/full_correlation/il_P2 ) 2>> log/stderror.err  &
+( summarycalc -f  -1 fifo/full_correlation/il_S1_summary_P3 < fifo/full_correlation/il_P3 ) 2>> log/stderror.err  &
+( summarycalc -f  -1 fifo/full_correlation/il_S1_summary_P4 < fifo/full_correlation/il_P4 ) 2>> log/stderror.err  &
+( summarycalc -f  -1 fifo/full_correlation/il_S1_summary_P5 < fifo/full_correlation/il_P5 ) 2>> log/stderror.err  &
+( summarycalc -f  -1 fifo/full_correlation/il_S1_summary_P6 < fifo/full_correlation/il_P6 ) 2>> log/stderror.err  &
+( summarycalc -f  -1 fifo/full_correlation/il_S1_summary_P7 < fifo/full_correlation/il_P7 ) 2>> log/stderror.err  &
+( summarycalc -f  -1 fifo/full_correlation/il_S1_summary_P8 < fifo/full_correlation/il_P8 ) 2>> log/stderror.err  &
+( summarycalc -f  -1 fifo/full_correlation/il_S1_summary_P9 < fifo/full_correlation/il_P9 ) 2>> log/stderror.err  &
+( summarycalc -f  -1 fifo/full_correlation/il_S1_summary_P10 < fifo/full_correlation/il_P10 ) 2>> log/stderror.err  &
+
+# --- Do ground up loss computes ---
+
+( eltcalc < fifo/full_correlation/gul_S1_eltcalc_P1 > work/full_correlation/kat/gul_S1_eltcalc_P1 ) 2>> log/stderror.err & pid121=$!
+( summarycalctocsv < fifo/full_correlation/gul_S1_summarycalc_P1 > work/full_correlation/kat/gul_S1_summarycalc_P1 ) 2>> log/stderror.err & pid122=$!
+( pltcalc < fifo/full_correlation/gul_S1_pltcalc_P1 > work/full_correlation/kat/gul_S1_pltcalc_P1 ) 2>> log/stderror.err & pid123=$!
+( eltcalc -s < fifo/full_correlation/gul_S1_eltcalc_P2 > work/full_correlation/kat/gul_S1_eltcalc_P2 ) 2>> log/stderror.err & pid124=$!
+( summarycalctocsv -s < fifo/full_correlation/gul_S1_summarycalc_P2 > work/full_correlation/kat/gul_S1_summarycalc_P2 ) 2>> log/stderror.err & pid125=$!
+( pltcalc -s < fifo/full_correlation/gul_S1_pltcalc_P2 > work/full_correlation/kat/gul_S1_pltcalc_P2 ) 2>> log/stderror.err & pid126=$!
+( eltcalc -s < fifo/full_correlation/gul_S1_eltcalc_P3 > work/full_correlation/kat/gul_S1_eltcalc_P3 ) 2>> log/stderror.err & pid127=$!
+( summarycalctocsv -s < fifo/full_correlation/gul_S1_summarycalc_P3 > work/full_correlation/kat/gul_S1_summarycalc_P3 ) 2>> log/stderror.err & pid128=$!
+( pltcalc -s < fifo/full_correlation/gul_S1_pltcalc_P3 > work/full_correlation/kat/gul_S1_pltcalc_P3 ) 2>> log/stderror.err & pid129=$!
+( eltcalc -s < fifo/full_correlation/gul_S1_eltcalc_P4 > work/full_correlation/kat/gul_S1_eltcalc_P4 ) 2>> log/stderror.err & pid130=$!
+( summarycalctocsv -s < fifo/full_correlation/gul_S1_summarycalc_P4 > work/full_correlation/kat/gul_S1_summarycalc_P4 ) 2>> log/stderror.err & pid131=$!
+( pltcalc -s < fifo/full_correlation/gul_S1_pltcalc_P4 > work/full_correlation/kat/gul_S1_pltcalc_P4 ) 2>> log/stderror.err & pid132=$!
+( eltcalc -s < fifo/full_correlation/gul_S1_eltcalc_P5 > work/full_correlation/kat/gul_S1_eltcalc_P5 ) 2>> log/stderror.err & pid133=$!
+( summarycalctocsv -s < fifo/full_correlation/gul_S1_summarycalc_P5 > work/full_correlation/kat/gul_S1_summarycalc_P5 ) 2>> log/stderror.err & pid134=$!
+( pltcalc -s < fifo/full_correlation/gul_S1_pltcalc_P5 > work/full_correlation/kat/gul_S1_pltcalc_P5 ) 2>> log/stderror.err & pid135=$!
+( eltcalc -s < fifo/full_correlation/gul_S1_eltcalc_P6 > work/full_correlation/kat/gul_S1_eltcalc_P6 ) 2>> log/stderror.err & pid136=$!
+( summarycalctocsv -s < fifo/full_correlation/gul_S1_summarycalc_P6 > work/full_correlation/kat/gul_S1_summarycalc_P6 ) 2>> log/stderror.err & pid137=$!
+( pltcalc -s < fifo/full_correlation/gul_S1_pltcalc_P6 > work/full_correlation/kat/gul_S1_pltcalc_P6 ) 2>> log/stderror.err & pid138=$!
+( eltcalc -s < fifo/full_correlation/gul_S1_eltcalc_P7 > work/full_correlation/kat/gul_S1_eltcalc_P7 ) 2>> log/stderror.err & pid139=$!
+( summarycalctocsv -s < fifo/full_correlation/gul_S1_summarycalc_P7 > work/full_correlation/kat/gul_S1_summarycalc_P7 ) 2>> log/stderror.err & pid140=$!
+( pltcalc -s < fifo/full_correlation/gul_S1_pltcalc_P7 > work/full_correlation/kat/gul_S1_pltcalc_P7 ) 2>> log/stderror.err & pid141=$!
+( eltcalc -s < fifo/full_correlation/gul_S1_eltcalc_P8 > work/full_correlation/kat/gul_S1_eltcalc_P8 ) 2>> log/stderror.err & pid142=$!
+( summarycalctocsv -s < fifo/full_correlation/gul_S1_summarycalc_P8 > work/full_correlation/kat/gul_S1_summarycalc_P8 ) 2>> log/stderror.err & pid143=$!
+( pltcalc -s < fifo/full_correlation/gul_S1_pltcalc_P8 > work/full_correlation/kat/gul_S1_pltcalc_P8 ) 2>> log/stderror.err & pid144=$!
+( eltcalc -s < fifo/full_correlation/gul_S1_eltcalc_P9 > work/full_correlation/kat/gul_S1_eltcalc_P9 ) 2>> log/stderror.err & pid145=$!
+( summarycalctocsv -s < fifo/full_correlation/gul_S1_summarycalc_P9 > work/full_correlation/kat/gul_S1_summarycalc_P9 ) 2>> log/stderror.err & pid146=$!
+( pltcalc -s < fifo/full_correlation/gul_S1_pltcalc_P9 > work/full_correlation/kat/gul_S1_pltcalc_P9 ) 2>> log/stderror.err & pid147=$!
+( eltcalc -s < fifo/full_correlation/gul_S1_eltcalc_P10 > work/full_correlation/kat/gul_S1_eltcalc_P10 ) 2>> log/stderror.err & pid148=$!
+( summarycalctocsv -s < fifo/full_correlation/gul_S1_summarycalc_P10 > work/full_correlation/kat/gul_S1_summarycalc_P10 ) 2>> log/stderror.err & pid149=$!
+( pltcalc -s < fifo/full_correlation/gul_S1_pltcalc_P10 > work/full_correlation/kat/gul_S1_pltcalc_P10 ) 2>> log/stderror.err & pid150=$!
+
+tee < fifo/full_correlation/gul_S1_summary_P1 fifo/full_correlation/gul_S1_eltcalc_P1 fifo/full_correlation/gul_S1_summarycalc_P1 fifo/full_correlation/gul_S1_pltcalc_P1 work/full_correlation/gul_S1_summaryaalcalc/P1.bin work/full_correlation/gul_S1_summaryleccalc/P1.bin > /dev/null & pid151=$!
+tee < fifo/full_correlation/gul_S1_summary_P2 fifo/full_correlation/gul_S1_eltcalc_P2 fifo/full_correlation/gul_S1_summarycalc_P2 fifo/full_correlation/gul_S1_pltcalc_P2 work/full_correlation/gul_S1_summaryaalcalc/P2.bin work/full_correlation/gul_S1_summaryleccalc/P2.bin > /dev/null & pid152=$!
+tee < fifo/full_correlation/gul_S1_summary_P3 fifo/full_correlation/gul_S1_eltcalc_P3 fifo/full_correlation/gul_S1_summarycalc_P3 fifo/full_correlation/gul_S1_pltcalc_P3 work/full_correlation/gul_S1_summaryaalcalc/P3.bin work/full_correlation/gul_S1_summaryleccalc/P3.bin > /dev/null & pid153=$!
+tee < fifo/full_correlation/gul_S1_summary_P4 fifo/full_correlation/gul_S1_eltcalc_P4 fifo/full_correlation/gul_S1_summarycalc_P4 fifo/full_correlation/gul_S1_pltcalc_P4 work/full_correlation/gul_S1_summaryaalcalc/P4.bin work/full_correlation/gul_S1_summaryleccalc/P4.bin > /dev/null & pid154=$!
+tee < fifo/full_correlation/gul_S1_summary_P5 fifo/full_correlation/gul_S1_eltcalc_P5 fifo/full_correlation/gul_S1_summarycalc_P5 fifo/full_correlation/gul_S1_pltcalc_P5 work/full_correlation/gul_S1_summaryaalcalc/P5.bin work/full_correlation/gul_S1_summaryleccalc/P5.bin > /dev/null & pid155=$!
+tee < fifo/full_correlation/gul_S1_summary_P6 fifo/full_correlation/gul_S1_eltcalc_P6 fifo/full_correlation/gul_S1_summarycalc_P6 fifo/full_correlation/gul_S1_pltcalc_P6 work/full_correlation/gul_S1_summaryaalcalc/P6.bin work/full_correlation/gul_S1_summaryleccalc/P6.bin > /dev/null & pid156=$!
+tee < fifo/full_correlation/gul_S1_summary_P7 fifo/full_correlation/gul_S1_eltcalc_P7 fifo/full_correlation/gul_S1_summarycalc_P7 fifo/full_correlation/gul_S1_pltcalc_P7 work/full_correlation/gul_S1_summaryaalcalc/P7.bin work/full_correlation/gul_S1_summaryleccalc/P7.bin > /dev/null & pid157=$!
+tee < fifo/full_correlation/gul_S1_summary_P8 fifo/full_correlation/gul_S1_eltcalc_P8 fifo/full_correlation/gul_S1_summarycalc_P8 fifo/full_correlation/gul_S1_pltcalc_P8 work/full_correlation/gul_S1_summaryaalcalc/P8.bin work/full_correlation/gul_S1_summaryleccalc/P8.bin > /dev/null & pid158=$!
+tee < fifo/full_correlation/gul_S1_summary_P9 fifo/full_correlation/gul_S1_eltcalc_P9 fifo/full_correlation/gul_S1_summarycalc_P9 fifo/full_correlation/gul_S1_pltcalc_P9 work/full_correlation/gul_S1_summaryaalcalc/P9.bin work/full_correlation/gul_S1_summaryleccalc/P9.bin > /dev/null & pid159=$!
+tee < fifo/full_correlation/gul_S1_summary_P10 fifo/full_correlation/gul_S1_eltcalc_P10 fifo/full_correlation/gul_S1_summarycalc_P10 fifo/full_correlation/gul_S1_pltcalc_P10 work/full_correlation/gul_S1_summaryaalcalc/P10.bin work/full_correlation/gul_S1_summaryleccalc/P10.bin > /dev/null & pid160=$!
+
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P1 < fifo/full_correlation/gul_P1 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P2 < fifo/full_correlation/gul_P2 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P3 < fifo/full_correlation/gul_P3 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P4 < fifo/full_correlation/gul_P4 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P5 < fifo/full_correlation/gul_P5 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P6 < fifo/full_correlation/gul_P6 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P7 < fifo/full_correlation/gul_P7 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P8 < fifo/full_correlation/gul_P8 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P9 < fifo/full_correlation/gul_P9 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P10 < fifo/full_correlation/gul_P10 ) 2>> log/stderror.err  &
+
+( tee < fifo/full_correlation/gul_fc_P1 fifo/full_correlation/gul_P1  | fmcalc -a2 > fifo/full_correlation/il_P1  ) 2>> log/stderror.err &
+( tee < fifo/full_correlation/gul_fc_P2 fifo/full_correlation/gul_P2  | fmcalc -a2 > fifo/full_correlation/il_P2  ) 2>> log/stderror.err &
+( tee < fifo/full_correlation/gul_fc_P3 fifo/full_correlation/gul_P3  | fmcalc -a2 > fifo/full_correlation/il_P3  ) 2>> log/stderror.err &
+( tee < fifo/full_correlation/gul_fc_P4 fifo/full_correlation/gul_P4  | fmcalc -a2 > fifo/full_correlation/il_P4  ) 2>> log/stderror.err &
+( tee < fifo/full_correlation/gul_fc_P5 fifo/full_correlation/gul_P5  | fmcalc -a2 > fifo/full_correlation/il_P5  ) 2>> log/stderror.err &
+( tee < fifo/full_correlation/gul_fc_P6 fifo/full_correlation/gul_P6  | fmcalc -a2 > fifo/full_correlation/il_P6  ) 2>> log/stderror.err &
+( tee < fifo/full_correlation/gul_fc_P7 fifo/full_correlation/gul_P7  | fmcalc -a2 > fifo/full_correlation/il_P7  ) 2>> log/stderror.err &
+( tee < fifo/full_correlation/gul_fc_P8 fifo/full_correlation/gul_P8  | fmcalc -a2 > fifo/full_correlation/il_P8  ) 2>> log/stderror.err &
+( tee < fifo/full_correlation/gul_fc_P9 fifo/full_correlation/gul_P9  | fmcalc -a2 > fifo/full_correlation/il_P9  ) 2>> log/stderror.err &
+( tee < fifo/full_correlation/gul_fc_P10 fifo/full_correlation/gul_P10  | fmcalc -a2 > fifo/full_correlation/il_P10  ) 2>> log/stderror.err &
+( eve 1 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_fc_P1 -a1 -i - | tee fifo/gul_P1 | fmcalc -a2 > fifo/il_P1  ) 2>> log/stderror.err &
+( eve 2 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_fc_P2 -a1 -i - | tee fifo/gul_P2 | fmcalc -a2 > fifo/il_P2  ) 2>> log/stderror.err &
+( eve 3 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_fc_P3 -a1 -i - | tee fifo/gul_P3 | fmcalc -a2 > fifo/il_P3  ) 2>> log/stderror.err &
+( eve 4 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_fc_P4 -a1 -i - | tee fifo/gul_P4 | fmcalc -a2 > fifo/il_P4  ) 2>> log/stderror.err &
+( eve 5 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_fc_P5 -a1 -i - | tee fifo/gul_P5 | fmcalc -a2 > fifo/il_P5  ) 2>> log/stderror.err &
+( eve 6 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_fc_P6 -a1 -i - | tee fifo/gul_P6 | fmcalc -a2 > fifo/il_P6  ) 2>> log/stderror.err &
+( eve 7 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_fc_P7 -a1 -i - | tee fifo/gul_P7 | fmcalc -a2 > fifo/il_P7  ) 2>> log/stderror.err &
+( eve 8 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_fc_P8 -a1 -i - | tee fifo/gul_P8 | fmcalc -a2 > fifo/il_P8  ) 2>> log/stderror.err &
+( eve 9 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_fc_P9 -a1 -i - | tee fifo/gul_P9 | fmcalc -a2 > fifo/il_P9  ) 2>> log/stderror.err &
+( eve 10 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_fc_P10 -a1 -i - | tee fifo/gul_P10 | fmcalc -a2 > fifo/il_P10  ) 2>> log/stderror.err &
+
+wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 $pid13 $pid14 $pid15 $pid16 $pid17 $pid18 $pid19 $pid20 $pid21 $pid22 $pid23 $pid24 $pid25 $pid26 $pid27 $pid28 $pid29 $pid30 $pid31 $pid32 $pid33 $pid34 $pid35 $pid36 $pid37 $pid38 $pid39 $pid40 $pid41 $pid42 $pid43 $pid44 $pid45 $pid46 $pid47 $pid48 $pid49 $pid50 $pid51 $pid52 $pid53 $pid54 $pid55 $pid56 $pid57 $pid58 $pid59 $pid60 $pid61 $pid62 $pid63 $pid64 $pid65 $pid66 $pid67 $pid68 $pid69 $pid70 $pid71 $pid72 $pid73 $pid74 $pid75 $pid76 $pid77 $pid78 $pid79 $pid80 $pid81 $pid82 $pid83 $pid84 $pid85 $pid86 $pid87 $pid88 $pid89 $pid90 $pid91 $pid92 $pid93 $pid94 $pid95 $pid96 $pid97 $pid98 $pid99 $pid100 $pid101 $pid102 $pid103 $pid104 $pid105 $pid106 $pid107 $pid108 $pid109 $pid110 $pid111 $pid112 $pid113 $pid114 $pid115 $pid116 $pid117 $pid118 $pid119 $pid120 $pid121 $pid122 $pid123 $pid124 $pid125 $pid126 $pid127 $pid128 $pid129 $pid130 $pid131 $pid132 $pid133 $pid134 $pid135 $pid136 $pid137 $pid138 $pid139 $pid140 $pid141 $pid142 $pid143 $pid144 $pid145 $pid146 $pid147 $pid148 $pid149 $pid150 $pid151 $pid152 $pid153 $pid154 $pid155 $pid156 $pid157 $pid158 $pid159 $pid160
+
+
+# --- Do insured loss kats ---
+
+kat -s work/kat/il_S1_eltcalc_P1 work/kat/il_S1_eltcalc_P2 work/kat/il_S1_eltcalc_P3 work/kat/il_S1_eltcalc_P4 work/kat/il_S1_eltcalc_P5 work/kat/il_S1_eltcalc_P6 work/kat/il_S1_eltcalc_P7 work/kat/il_S1_eltcalc_P8 work/kat/il_S1_eltcalc_P9 work/kat/il_S1_eltcalc_P10 > output/il_S1_eltcalc.csv & kpid1=$!
+kat work/kat/il_S1_pltcalc_P1 work/kat/il_S1_pltcalc_P2 work/kat/il_S1_pltcalc_P3 work/kat/il_S1_pltcalc_P4 work/kat/il_S1_pltcalc_P5 work/kat/il_S1_pltcalc_P6 work/kat/il_S1_pltcalc_P7 work/kat/il_S1_pltcalc_P8 work/kat/il_S1_pltcalc_P9 work/kat/il_S1_pltcalc_P10 > output/il_S1_pltcalc.csv & kpid2=$!
+kat work/kat/il_S1_summarycalc_P1 work/kat/il_S1_summarycalc_P2 work/kat/il_S1_summarycalc_P3 work/kat/il_S1_summarycalc_P4 work/kat/il_S1_summarycalc_P5 work/kat/il_S1_summarycalc_P6 work/kat/il_S1_summarycalc_P7 work/kat/il_S1_summarycalc_P8 work/kat/il_S1_summarycalc_P9 work/kat/il_S1_summarycalc_P10 > output/il_S1_summarycalc.csv & kpid3=$!
+
+# --- Do insured loss kats for fully correlated output ---
+
+kat -s work/full_correlation/kat/il_S1_eltcalc_P1 work/full_correlation/kat/il_S1_eltcalc_P2 work/full_correlation/kat/il_S1_eltcalc_P3 work/full_correlation/kat/il_S1_eltcalc_P4 work/full_correlation/kat/il_S1_eltcalc_P5 work/full_correlation/kat/il_S1_eltcalc_P6 work/full_correlation/kat/il_S1_eltcalc_P7 work/full_correlation/kat/il_S1_eltcalc_P8 work/full_correlation/kat/il_S1_eltcalc_P9 work/full_correlation/kat/il_S1_eltcalc_P10 > output/full_correlation/il_S1_eltcalc.csv & kpid4=$!
+kat work/full_correlation/kat/il_S1_pltcalc_P1 work/full_correlation/kat/il_S1_pltcalc_P2 work/full_correlation/kat/il_S1_pltcalc_P3 work/full_correlation/kat/il_S1_pltcalc_P4 work/full_correlation/kat/il_S1_pltcalc_P5 work/full_correlation/kat/il_S1_pltcalc_P6 work/full_correlation/kat/il_S1_pltcalc_P7 work/full_correlation/kat/il_S1_pltcalc_P8 work/full_correlation/kat/il_S1_pltcalc_P9 work/full_correlation/kat/il_S1_pltcalc_P10 > output/full_correlation/il_S1_pltcalc.csv & kpid5=$!
+kat work/full_correlation/kat/il_S1_summarycalc_P1 work/full_correlation/kat/il_S1_summarycalc_P2 work/full_correlation/kat/il_S1_summarycalc_P3 work/full_correlation/kat/il_S1_summarycalc_P4 work/full_correlation/kat/il_S1_summarycalc_P5 work/full_correlation/kat/il_S1_summarycalc_P6 work/full_correlation/kat/il_S1_summarycalc_P7 work/full_correlation/kat/il_S1_summarycalc_P8 work/full_correlation/kat/il_S1_summarycalc_P9 work/full_correlation/kat/il_S1_summarycalc_P10 > output/full_correlation/il_S1_summarycalc.csv & kpid6=$!
+
+# --- Do ground up loss kats ---
+
+kat -s work/kat/gul_S1_eltcalc_P1 work/kat/gul_S1_eltcalc_P2 work/kat/gul_S1_eltcalc_P3 work/kat/gul_S1_eltcalc_P4 work/kat/gul_S1_eltcalc_P5 work/kat/gul_S1_eltcalc_P6 work/kat/gul_S1_eltcalc_P7 work/kat/gul_S1_eltcalc_P8 work/kat/gul_S1_eltcalc_P9 work/kat/gul_S1_eltcalc_P10 > output/gul_S1_eltcalc.csv & kpid7=$!
+kat work/kat/gul_S1_pltcalc_P1 work/kat/gul_S1_pltcalc_P2 work/kat/gul_S1_pltcalc_P3 work/kat/gul_S1_pltcalc_P4 work/kat/gul_S1_pltcalc_P5 work/kat/gul_S1_pltcalc_P6 work/kat/gul_S1_pltcalc_P7 work/kat/gul_S1_pltcalc_P8 work/kat/gul_S1_pltcalc_P9 work/kat/gul_S1_pltcalc_P10 > output/gul_S1_pltcalc.csv & kpid8=$!
+kat work/kat/gul_S1_summarycalc_P1 work/kat/gul_S1_summarycalc_P2 work/kat/gul_S1_summarycalc_P3 work/kat/gul_S1_summarycalc_P4 work/kat/gul_S1_summarycalc_P5 work/kat/gul_S1_summarycalc_P6 work/kat/gul_S1_summarycalc_P7 work/kat/gul_S1_summarycalc_P8 work/kat/gul_S1_summarycalc_P9 work/kat/gul_S1_summarycalc_P10 > output/gul_S1_summarycalc.csv & kpid9=$!
+
+# --- Do ground up loss kats for fully correlated output ---
+
+kat -s work/full_correlation/kat/gul_S1_eltcalc_P1 work/full_correlation/kat/gul_S1_eltcalc_P2 work/full_correlation/kat/gul_S1_eltcalc_P3 work/full_correlation/kat/gul_S1_eltcalc_P4 work/full_correlation/kat/gul_S1_eltcalc_P5 work/full_correlation/kat/gul_S1_eltcalc_P6 work/full_correlation/kat/gul_S1_eltcalc_P7 work/full_correlation/kat/gul_S1_eltcalc_P8 work/full_correlation/kat/gul_S1_eltcalc_P9 work/full_correlation/kat/gul_S1_eltcalc_P10 > output/full_correlation/gul_S1_eltcalc.csv & kpid10=$!
+kat work/full_correlation/kat/gul_S1_pltcalc_P1 work/full_correlation/kat/gul_S1_pltcalc_P2 work/full_correlation/kat/gul_S1_pltcalc_P3 work/full_correlation/kat/gul_S1_pltcalc_P4 work/full_correlation/kat/gul_S1_pltcalc_P5 work/full_correlation/kat/gul_S1_pltcalc_P6 work/full_correlation/kat/gul_S1_pltcalc_P7 work/full_correlation/kat/gul_S1_pltcalc_P8 work/full_correlation/kat/gul_S1_pltcalc_P9 work/full_correlation/kat/gul_S1_pltcalc_P10 > output/full_correlation/gul_S1_pltcalc.csv & kpid11=$!
+kat work/full_correlation/kat/gul_S1_summarycalc_P1 work/full_correlation/kat/gul_S1_summarycalc_P2 work/full_correlation/kat/gul_S1_summarycalc_P3 work/full_correlation/kat/gul_S1_summarycalc_P4 work/full_correlation/kat/gul_S1_summarycalc_P5 work/full_correlation/kat/gul_S1_summarycalc_P6 work/full_correlation/kat/gul_S1_summarycalc_P7 work/full_correlation/kat/gul_S1_summarycalc_P8 work/full_correlation/kat/gul_S1_summarycalc_P9 work/full_correlation/kat/gul_S1_summarycalc_P10 > output/full_correlation/gul_S1_summarycalc.csv & kpid12=$!
+wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpid11 $kpid12
+
+
+( aalcalc -Kil_S1_summaryaalcalc > output/il_S1_aalcalc.csv ) 2>> log/stderror.err & lpid1=$!
+( ordleccalc -r -Kil_S1_summaryleccalc -W -w -o output/il_S1_psept.csv ) 2>> log/stderror.err & lpid2=$!
+( leccalc -r -Kil_S1_summaryleccalc -F output/il_S1_leccalc_full_uncertainty_aep.csv -f output/il_S1_leccalc_full_uncertainty_oep.csv -S output/il_S1_leccalc_sample_mean_aep.csv -s output/il_S1_leccalc_sample_mean_oep.csv -W output/il_S1_leccalc_wheatsheaf_aep.csv -M output/il_S1_leccalc_wheatsheaf_mean_aep.csv -m output/il_S1_leccalc_wheatsheaf_mean_oep.csv -w output/il_S1_leccalc_wheatsheaf_oep.csv ) 2>> log/stderror.err & lpid3=$!
+( aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv ) 2>> log/stderror.err & lpid4=$!
+( ordleccalc  -Kgul_S1_summaryleccalc -W -w -o output/gul_S1_psept.csv ) 2>> log/stderror.err & lpid5=$!
+( leccalc -r -Kgul_S1_summaryleccalc -F output/gul_S1_leccalc_full_uncertainty_aep.csv -f output/gul_S1_leccalc_full_uncertainty_oep.csv -S output/gul_S1_leccalc_sample_mean_aep.csv -s output/gul_S1_leccalc_sample_mean_oep.csv -W output/gul_S1_leccalc_wheatsheaf_aep.csv -M output/gul_S1_leccalc_wheatsheaf_mean_aep.csv -m output/gul_S1_leccalc_wheatsheaf_mean_oep.csv -w output/gul_S1_leccalc_wheatsheaf_oep.csv ) 2>> log/stderror.err & lpid6=$!
+( aalcalc -Kfull_correlation/il_S1_summaryaalcalc > output/full_correlation/il_S1_aalcalc.csv ) 2>> log/stderror.err & lpid7=$!
+( ordleccalc -r -Kfull_correlation/il_S1_summaryleccalc -W -w -o output/full_correlation/il_S1_psept.csv ) 2>> log/stderror.err & lpid8=$!
+( leccalc -r -Kfull_correlation/il_S1_summaryleccalc -F output/full_correlation/il_S1_leccalc_full_uncertainty_aep.csv -f output/full_correlation/il_S1_leccalc_full_uncertainty_oep.csv -S output/full_correlation/il_S1_leccalc_sample_mean_aep.csv -s output/full_correlation/il_S1_leccalc_sample_mean_oep.csv -W output/full_correlation/il_S1_leccalc_wheatsheaf_aep.csv -M output/full_correlation/il_S1_leccalc_wheatsheaf_mean_aep.csv -m output/full_correlation/il_S1_leccalc_wheatsheaf_mean_oep.csv -w output/full_correlation/il_S1_leccalc_wheatsheaf_oep.csv ) 2>> log/stderror.err & lpid9=$!
+( aalcalc -Kfull_correlation/gul_S1_summaryaalcalc > output/full_correlation/gul_S1_aalcalc.csv ) 2>> log/stderror.err & lpid10=$!
+( ordleccalc  -Kfull_correlation/gul_S1_summaryleccalc -W -w -o output/full_correlation/gul_S1_psept.csv ) 2>> log/stderror.err & lpid11=$!
+( leccalc -r -Kfull_correlation/gul_S1_summaryleccalc -F output/full_correlation/gul_S1_leccalc_full_uncertainty_aep.csv -f output/full_correlation/gul_S1_leccalc_full_uncertainty_oep.csv -S output/full_correlation/gul_S1_leccalc_sample_mean_aep.csv -s output/full_correlation/gul_S1_leccalc_sample_mean_oep.csv -W output/full_correlation/gul_S1_leccalc_wheatsheaf_aep.csv -M output/full_correlation/gul_S1_leccalc_wheatsheaf_mean_aep.csv -m output/full_correlation/gul_S1_leccalc_wheatsheaf_mean_oep.csv -w output/full_correlation/gul_S1_leccalc_wheatsheaf_oep.csv ) 2>> log/stderror.err & lpid12=$!
+wait $lpid1 $lpid2 $lpid3 $lpid4 $lpid5 $lpid6 $lpid7 $lpid8 $lpid9 $lpid10 $lpid11 $lpid12
+
+rm -R -f work/*
+rm -R -f fifo/*
+
+check_complete
+exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_lec_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/gul_lec_1_output_2_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_lec_1_output_2_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/gul_lec_2_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_lec_2_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/gul_lec_2_output_2_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_lec_2_output_2_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/gul_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_no_lec_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/gul_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_no_lec_1_output_2_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/gul_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_no_lec_2_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/gul_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_no_lec_2_output_2_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/gul_ord_ept_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_ord_ept_1_output_1_partition.sh
@@ -29,7 +29,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
    ps f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk -F: '$1>$script_pid' | grep -v celery | grep -v python | grep -v $group_pid | grep -v run_ktools)
+   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | grep -v *.sh)
    echo "$PIDS_KILL" >> log/killout.txt
    kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
    exit $exit_code

--- a/tests/model_execution/err_fc_kparse_reference/gul_ord_ept_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_ord_ept_1_output_1_partition.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+
+touch log/stderror.err
+ktools_monitor.sh $$ & pid0=$!
+
+exit_handler(){
+   exit_code=$?
+   kill -9 $pid0 2> /dev/null
+   if [ "$exit_code" -gt 0 ]; then
+       echo 'Ktools Run Error - exitcode='$exit_code
+   else
+       echo 'Run Completed'
+   fi
+
+   set +x
+   group_pid=$(ps -p $$ -o pgid --no-headers)
+   sess_pid=$(ps -p $$ -o sess --no-headers)
+   script_pid=$$
+   printf "Script PID:%d, GPID:%s, SPID:%d
+" $script_pid $group_pid $sess_pid >> log/killout.txt
+
+   ps f -g $sess_pid > log/subprocess_list
+   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk -F: '$1>$script_pid' | grep -v celery | grep -v python | grep -v $group_pid | grep -v run_ktools)
+   echo "$PIDS_KILL" >> log/killout.txt
+   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+   exit $exit_code
+}
+trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
+
+check_complete(){
+    set +e
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
+    has_error=0
+    for p in $proc_list; do
+        started=$(find log -name "$p*.log" | wc -l)
+        finished=$(find log -name "$p*.log" -exec grep -l "finish" {} + | wc -l)
+        if [ "$finished" -lt "$started" ]; then
+            echo "[ERROR] $p - $((started-finished)) processes lost"
+            has_error=1
+        elif [ "$started" -gt 0 ]; then
+            echo "[OK] $p"
+        fi
+    done
+    if [ "$has_error" -ne 0 ]; then
+        false # raise non-zero exit code
+    fi
+}
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+mkdir output/full_correlation/
+
+rm -R -f fifo/*
+mkdir fifo/full_correlation/
+rm -R -f work/*
+mkdir work/kat/
+mkdir work/full_correlation/
+mkdir work/full_correlation/kat/
+
+mkdir work/gul_S1_summaryleccalc
+mkdir work/full_correlation/gul_S1_summaryleccalc
+
+mkfifo fifo/gul_P1
+
+mkfifo fifo/gul_S1_summary_P1
+
+mkfifo fifo/full_correlation/gul_P1
+
+mkfifo fifo/full_correlation/gul_S1_summary_P1
+
+
+
+# --- Do ground up loss computes ---
+
+
+tee < fifo/gul_S1_summary_P1 work/gul_S1_summaryleccalc/P1.bin > /dev/null & pid1=$!
+
+( summarycalc -i  -1 fifo/gul_S1_summary_P1 < fifo/gul_P1 ) 2>> log/stderror.err  &
+
+# --- Do ground up loss computes ---
+
+
+tee < fifo/full_correlation/gul_S1_summary_P1 work/full_correlation/gul_S1_summaryleccalc/P1.bin > /dev/null & pid2=$!
+
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P1 < fifo/full_correlation/gul_P1 ) 2>> log/stderror.err  &
+
+( eve 1 1 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P1 -a1 -i - > fifo/gul_P1  ) 2>> log/stderror.err &
+
+wait $pid1 $pid2
+
+
+# --- Do ground up loss kats ---
+
+
+# --- Do ground up loss kats for fully correlated output ---
+
+
+( ordleccalc -r -Kgul_S1_summaryleccalc -F -f -S -s -M -m -O output/gul_S1_ept.csv ) 2>> log/stderror.err & lpid1=$!
+( ordleccalc -r -Kfull_correlation/gul_S1_summaryleccalc -F -f -S -s -M -m -O output/full_correlation/gul_S1_ept.csv ) 2>> log/stderror.err & lpid2=$!
+wait $lpid1 $lpid2
+
+rm -R -f work/*
+rm -R -f fifo/*
+
+check_complete
+exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_ord_ept_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_ord_ept_1_output_20_partition.sh
@@ -1,0 +1,324 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+
+touch log/stderror.err
+ktools_monitor.sh $$ & pid0=$!
+
+exit_handler(){
+   exit_code=$?
+   kill -9 $pid0 2> /dev/null
+   if [ "$exit_code" -gt 0 ]; then
+       echo 'Ktools Run Error - exitcode='$exit_code
+   else
+       echo 'Run Completed'
+   fi
+
+   set +x
+   group_pid=$(ps -p $$ -o pgid --no-headers)
+   sess_pid=$(ps -p $$ -o sess --no-headers)
+   script_pid=$$
+   printf "Script PID:%d, GPID:%s, SPID:%d
+" $script_pid $group_pid $sess_pid >> log/killout.txt
+
+   ps f -g $sess_pid > log/subprocess_list
+   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk -F: '$1>$script_pid' | grep -v celery | grep -v python | grep -v $group_pid | grep -v run_ktools)
+   echo "$PIDS_KILL" >> log/killout.txt
+   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+   exit $exit_code
+}
+trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
+
+check_complete(){
+    set +e
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
+    has_error=0
+    for p in $proc_list; do
+        started=$(find log -name "$p*.log" | wc -l)
+        finished=$(find log -name "$p*.log" -exec grep -l "finish" {} + | wc -l)
+        if [ "$finished" -lt "$started" ]; then
+            echo "[ERROR] $p - $((started-finished)) processes lost"
+            has_error=1
+        elif [ "$started" -gt 0 ]; then
+            echo "[OK] $p"
+        fi
+    done
+    if [ "$has_error" -ne 0 ]; then
+        false # raise non-zero exit code
+    fi
+}
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+mkdir output/full_correlation/
+
+rm -R -f fifo/*
+mkdir fifo/full_correlation/
+rm -R -f work/*
+mkdir work/kat/
+mkdir work/full_correlation/
+mkdir work/full_correlation/kat/
+
+mkdir work/gul_S1_summaryleccalc
+mkdir work/full_correlation/gul_S1_summaryleccalc
+
+mkfifo fifo/gul_P1
+mkfifo fifo/gul_P2
+mkfifo fifo/gul_P3
+mkfifo fifo/gul_P4
+mkfifo fifo/gul_P5
+mkfifo fifo/gul_P6
+mkfifo fifo/gul_P7
+mkfifo fifo/gul_P8
+mkfifo fifo/gul_P9
+mkfifo fifo/gul_P10
+mkfifo fifo/gul_P11
+mkfifo fifo/gul_P12
+mkfifo fifo/gul_P13
+mkfifo fifo/gul_P14
+mkfifo fifo/gul_P15
+mkfifo fifo/gul_P16
+mkfifo fifo/gul_P17
+mkfifo fifo/gul_P18
+mkfifo fifo/gul_P19
+mkfifo fifo/gul_P20
+
+mkfifo fifo/gul_S1_summary_P1
+
+mkfifo fifo/gul_S1_summary_P2
+
+mkfifo fifo/gul_S1_summary_P3
+
+mkfifo fifo/gul_S1_summary_P4
+
+mkfifo fifo/gul_S1_summary_P5
+
+mkfifo fifo/gul_S1_summary_P6
+
+mkfifo fifo/gul_S1_summary_P7
+
+mkfifo fifo/gul_S1_summary_P8
+
+mkfifo fifo/gul_S1_summary_P9
+
+mkfifo fifo/gul_S1_summary_P10
+
+mkfifo fifo/gul_S1_summary_P11
+
+mkfifo fifo/gul_S1_summary_P12
+
+mkfifo fifo/gul_S1_summary_P13
+
+mkfifo fifo/gul_S1_summary_P14
+
+mkfifo fifo/gul_S1_summary_P15
+
+mkfifo fifo/gul_S1_summary_P16
+
+mkfifo fifo/gul_S1_summary_P17
+
+mkfifo fifo/gul_S1_summary_P18
+
+mkfifo fifo/gul_S1_summary_P19
+
+mkfifo fifo/gul_S1_summary_P20
+
+mkfifo fifo/full_correlation/gul_P1
+mkfifo fifo/full_correlation/gul_P2
+mkfifo fifo/full_correlation/gul_P3
+mkfifo fifo/full_correlation/gul_P4
+mkfifo fifo/full_correlation/gul_P5
+mkfifo fifo/full_correlation/gul_P6
+mkfifo fifo/full_correlation/gul_P7
+mkfifo fifo/full_correlation/gul_P8
+mkfifo fifo/full_correlation/gul_P9
+mkfifo fifo/full_correlation/gul_P10
+mkfifo fifo/full_correlation/gul_P11
+mkfifo fifo/full_correlation/gul_P12
+mkfifo fifo/full_correlation/gul_P13
+mkfifo fifo/full_correlation/gul_P14
+mkfifo fifo/full_correlation/gul_P15
+mkfifo fifo/full_correlation/gul_P16
+mkfifo fifo/full_correlation/gul_P17
+mkfifo fifo/full_correlation/gul_P18
+mkfifo fifo/full_correlation/gul_P19
+mkfifo fifo/full_correlation/gul_P20
+
+mkfifo fifo/full_correlation/gul_S1_summary_P1
+
+mkfifo fifo/full_correlation/gul_S1_summary_P2
+
+mkfifo fifo/full_correlation/gul_S1_summary_P3
+
+mkfifo fifo/full_correlation/gul_S1_summary_P4
+
+mkfifo fifo/full_correlation/gul_S1_summary_P5
+
+mkfifo fifo/full_correlation/gul_S1_summary_P6
+
+mkfifo fifo/full_correlation/gul_S1_summary_P7
+
+mkfifo fifo/full_correlation/gul_S1_summary_P8
+
+mkfifo fifo/full_correlation/gul_S1_summary_P9
+
+mkfifo fifo/full_correlation/gul_S1_summary_P10
+
+mkfifo fifo/full_correlation/gul_S1_summary_P11
+
+mkfifo fifo/full_correlation/gul_S1_summary_P12
+
+mkfifo fifo/full_correlation/gul_S1_summary_P13
+
+mkfifo fifo/full_correlation/gul_S1_summary_P14
+
+mkfifo fifo/full_correlation/gul_S1_summary_P15
+
+mkfifo fifo/full_correlation/gul_S1_summary_P16
+
+mkfifo fifo/full_correlation/gul_S1_summary_P17
+
+mkfifo fifo/full_correlation/gul_S1_summary_P18
+
+mkfifo fifo/full_correlation/gul_S1_summary_P19
+
+mkfifo fifo/full_correlation/gul_S1_summary_P20
+
+
+
+# --- Do ground up loss computes ---
+
+
+tee < fifo/gul_S1_summary_P1 work/gul_S1_summaryleccalc/P1.bin > /dev/null & pid1=$!
+tee < fifo/gul_S1_summary_P2 work/gul_S1_summaryleccalc/P2.bin > /dev/null & pid2=$!
+tee < fifo/gul_S1_summary_P3 work/gul_S1_summaryleccalc/P3.bin > /dev/null & pid3=$!
+tee < fifo/gul_S1_summary_P4 work/gul_S1_summaryleccalc/P4.bin > /dev/null & pid4=$!
+tee < fifo/gul_S1_summary_P5 work/gul_S1_summaryleccalc/P5.bin > /dev/null & pid5=$!
+tee < fifo/gul_S1_summary_P6 work/gul_S1_summaryleccalc/P6.bin > /dev/null & pid6=$!
+tee < fifo/gul_S1_summary_P7 work/gul_S1_summaryleccalc/P7.bin > /dev/null & pid7=$!
+tee < fifo/gul_S1_summary_P8 work/gul_S1_summaryleccalc/P8.bin > /dev/null & pid8=$!
+tee < fifo/gul_S1_summary_P9 work/gul_S1_summaryleccalc/P9.bin > /dev/null & pid9=$!
+tee < fifo/gul_S1_summary_P10 work/gul_S1_summaryleccalc/P10.bin > /dev/null & pid10=$!
+tee < fifo/gul_S1_summary_P11 work/gul_S1_summaryleccalc/P11.bin > /dev/null & pid11=$!
+tee < fifo/gul_S1_summary_P12 work/gul_S1_summaryleccalc/P12.bin > /dev/null & pid12=$!
+tee < fifo/gul_S1_summary_P13 work/gul_S1_summaryleccalc/P13.bin > /dev/null & pid13=$!
+tee < fifo/gul_S1_summary_P14 work/gul_S1_summaryleccalc/P14.bin > /dev/null & pid14=$!
+tee < fifo/gul_S1_summary_P15 work/gul_S1_summaryleccalc/P15.bin > /dev/null & pid15=$!
+tee < fifo/gul_S1_summary_P16 work/gul_S1_summaryleccalc/P16.bin > /dev/null & pid16=$!
+tee < fifo/gul_S1_summary_P17 work/gul_S1_summaryleccalc/P17.bin > /dev/null & pid17=$!
+tee < fifo/gul_S1_summary_P18 work/gul_S1_summaryleccalc/P18.bin > /dev/null & pid18=$!
+tee < fifo/gul_S1_summary_P19 work/gul_S1_summaryleccalc/P19.bin > /dev/null & pid19=$!
+tee < fifo/gul_S1_summary_P20 work/gul_S1_summaryleccalc/P20.bin > /dev/null & pid20=$!
+
+( summarycalc -i  -1 fifo/gul_S1_summary_P1 < fifo/gul_P1 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P2 < fifo/gul_P2 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P3 < fifo/gul_P3 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P4 < fifo/gul_P4 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P5 < fifo/gul_P5 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P6 < fifo/gul_P6 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P7 < fifo/gul_P7 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P8 < fifo/gul_P8 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P9 < fifo/gul_P9 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P10 < fifo/gul_P10 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P11 < fifo/gul_P11 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P12 < fifo/gul_P12 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P13 < fifo/gul_P13 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P14 < fifo/gul_P14 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P15 < fifo/gul_P15 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P16 < fifo/gul_P16 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P17 < fifo/gul_P17 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P18 < fifo/gul_P18 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P19 < fifo/gul_P19 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P20 < fifo/gul_P20 ) 2>> log/stderror.err  &
+
+# --- Do ground up loss computes ---
+
+
+tee < fifo/full_correlation/gul_S1_summary_P1 work/full_correlation/gul_S1_summaryleccalc/P1.bin > /dev/null & pid21=$!
+tee < fifo/full_correlation/gul_S1_summary_P2 work/full_correlation/gul_S1_summaryleccalc/P2.bin > /dev/null & pid22=$!
+tee < fifo/full_correlation/gul_S1_summary_P3 work/full_correlation/gul_S1_summaryleccalc/P3.bin > /dev/null & pid23=$!
+tee < fifo/full_correlation/gul_S1_summary_P4 work/full_correlation/gul_S1_summaryleccalc/P4.bin > /dev/null & pid24=$!
+tee < fifo/full_correlation/gul_S1_summary_P5 work/full_correlation/gul_S1_summaryleccalc/P5.bin > /dev/null & pid25=$!
+tee < fifo/full_correlation/gul_S1_summary_P6 work/full_correlation/gul_S1_summaryleccalc/P6.bin > /dev/null & pid26=$!
+tee < fifo/full_correlation/gul_S1_summary_P7 work/full_correlation/gul_S1_summaryleccalc/P7.bin > /dev/null & pid27=$!
+tee < fifo/full_correlation/gul_S1_summary_P8 work/full_correlation/gul_S1_summaryleccalc/P8.bin > /dev/null & pid28=$!
+tee < fifo/full_correlation/gul_S1_summary_P9 work/full_correlation/gul_S1_summaryleccalc/P9.bin > /dev/null & pid29=$!
+tee < fifo/full_correlation/gul_S1_summary_P10 work/full_correlation/gul_S1_summaryleccalc/P10.bin > /dev/null & pid30=$!
+tee < fifo/full_correlation/gul_S1_summary_P11 work/full_correlation/gul_S1_summaryleccalc/P11.bin > /dev/null & pid31=$!
+tee < fifo/full_correlation/gul_S1_summary_P12 work/full_correlation/gul_S1_summaryleccalc/P12.bin > /dev/null & pid32=$!
+tee < fifo/full_correlation/gul_S1_summary_P13 work/full_correlation/gul_S1_summaryleccalc/P13.bin > /dev/null & pid33=$!
+tee < fifo/full_correlation/gul_S1_summary_P14 work/full_correlation/gul_S1_summaryleccalc/P14.bin > /dev/null & pid34=$!
+tee < fifo/full_correlation/gul_S1_summary_P15 work/full_correlation/gul_S1_summaryleccalc/P15.bin > /dev/null & pid35=$!
+tee < fifo/full_correlation/gul_S1_summary_P16 work/full_correlation/gul_S1_summaryleccalc/P16.bin > /dev/null & pid36=$!
+tee < fifo/full_correlation/gul_S1_summary_P17 work/full_correlation/gul_S1_summaryleccalc/P17.bin > /dev/null & pid37=$!
+tee < fifo/full_correlation/gul_S1_summary_P18 work/full_correlation/gul_S1_summaryleccalc/P18.bin > /dev/null & pid38=$!
+tee < fifo/full_correlation/gul_S1_summary_P19 work/full_correlation/gul_S1_summaryleccalc/P19.bin > /dev/null & pid39=$!
+tee < fifo/full_correlation/gul_S1_summary_P20 work/full_correlation/gul_S1_summaryleccalc/P20.bin > /dev/null & pid40=$!
+
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P1 < fifo/full_correlation/gul_P1 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P2 < fifo/full_correlation/gul_P2 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P3 < fifo/full_correlation/gul_P3 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P4 < fifo/full_correlation/gul_P4 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P5 < fifo/full_correlation/gul_P5 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P6 < fifo/full_correlation/gul_P6 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P7 < fifo/full_correlation/gul_P7 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P8 < fifo/full_correlation/gul_P8 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P9 < fifo/full_correlation/gul_P9 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P10 < fifo/full_correlation/gul_P10 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P11 < fifo/full_correlation/gul_P11 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P12 < fifo/full_correlation/gul_P12 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P13 < fifo/full_correlation/gul_P13 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P14 < fifo/full_correlation/gul_P14 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P15 < fifo/full_correlation/gul_P15 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P16 < fifo/full_correlation/gul_P16 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P17 < fifo/full_correlation/gul_P17 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P18 < fifo/full_correlation/gul_P18 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P19 < fifo/full_correlation/gul_P19 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P20 < fifo/full_correlation/gul_P20 ) 2>> log/stderror.err  &
+
+( eve 1 20 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P1 -a1 -i - > fifo/gul_P1  ) 2>> log/stderror.err &
+( eve 2 20 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P2 -a1 -i - > fifo/gul_P2  ) 2>> log/stderror.err &
+( eve 3 20 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P3 -a1 -i - > fifo/gul_P3  ) 2>> log/stderror.err &
+( eve 4 20 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P4 -a1 -i - > fifo/gul_P4  ) 2>> log/stderror.err &
+( eve 5 20 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P5 -a1 -i - > fifo/gul_P5  ) 2>> log/stderror.err &
+( eve 6 20 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P6 -a1 -i - > fifo/gul_P6  ) 2>> log/stderror.err &
+( eve 7 20 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P7 -a1 -i - > fifo/gul_P7  ) 2>> log/stderror.err &
+( eve 8 20 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P8 -a1 -i - > fifo/gul_P8  ) 2>> log/stderror.err &
+( eve 9 20 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P9 -a1 -i - > fifo/gul_P9  ) 2>> log/stderror.err &
+( eve 10 20 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P10 -a1 -i - > fifo/gul_P10  ) 2>> log/stderror.err &
+( eve 11 20 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P11 -a1 -i - > fifo/gul_P11  ) 2>> log/stderror.err &
+( eve 12 20 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P12 -a1 -i - > fifo/gul_P12  ) 2>> log/stderror.err &
+( eve 13 20 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P13 -a1 -i - > fifo/gul_P13  ) 2>> log/stderror.err &
+( eve 14 20 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P14 -a1 -i - > fifo/gul_P14  ) 2>> log/stderror.err &
+( eve 15 20 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P15 -a1 -i - > fifo/gul_P15  ) 2>> log/stderror.err &
+( eve 16 20 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P16 -a1 -i - > fifo/gul_P16  ) 2>> log/stderror.err &
+( eve 17 20 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P17 -a1 -i - > fifo/gul_P17  ) 2>> log/stderror.err &
+( eve 18 20 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P18 -a1 -i - > fifo/gul_P18  ) 2>> log/stderror.err &
+( eve 19 20 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P19 -a1 -i - > fifo/gul_P19  ) 2>> log/stderror.err &
+( eve 20 20 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P20 -a1 -i - > fifo/gul_P20  ) 2>> log/stderror.err &
+
+wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 $pid13 $pid14 $pid15 $pid16 $pid17 $pid18 $pid19 $pid20 $pid21 $pid22 $pid23 $pid24 $pid25 $pid26 $pid27 $pid28 $pid29 $pid30 $pid31 $pid32 $pid33 $pid34 $pid35 $pid36 $pid37 $pid38 $pid39 $pid40
+
+
+# --- Do ground up loss kats ---
+
+
+# --- Do ground up loss kats for fully correlated output ---
+
+
+( ordleccalc -r -Kgul_S1_summaryleccalc -F -f -S -s -M -m -O output/gul_S1_ept.csv ) 2>> log/stderror.err & lpid1=$!
+( ordleccalc -r -Kfull_correlation/gul_S1_summaryleccalc -F -f -S -s -M -m -O output/full_correlation/gul_S1_ept.csv ) 2>> log/stderror.err & lpid2=$!
+wait $lpid1 $lpid2
+
+rm -R -f work/*
+rm -R -f fifo/*
+
+check_complete
+exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_ord_ept_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_ord_ept_1_output_20_partition.sh
@@ -29,7 +29,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
    ps f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk -F: '$1>$script_pid' | grep -v celery | grep -v python | grep -v $group_pid | grep -v run_ktools)
+   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | grep -v *.sh)
    echo "$PIDS_KILL" >> log/killout.txt
    kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
    exit $exit_code

--- a/tests/model_execution/err_fc_kparse_reference/gul_ord_ept_psept_lec_2_output_10_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_ord_ept_psept_lec_2_output_10_partition.sh
@@ -1,0 +1,524 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+
+touch log/stderror.err
+ktools_monitor.sh $$ & pid0=$!
+
+exit_handler(){
+   exit_code=$?
+   kill -9 $pid0 2> /dev/null
+   if [ "$exit_code" -gt 0 ]; then
+       echo 'Ktools Run Error - exitcode='$exit_code
+   else
+       echo 'Run Completed'
+   fi
+
+   set +x
+   group_pid=$(ps -p $$ -o pgid --no-headers)
+   sess_pid=$(ps -p $$ -o sess --no-headers)
+   script_pid=$$
+   printf "Script PID:%d, GPID:%s, SPID:%d
+" $script_pid $group_pid $sess_pid >> log/killout.txt
+
+   ps f -g $sess_pid > log/subprocess_list
+   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk -F: '$1>$script_pid' | grep -v celery | grep -v python | grep -v $group_pid | grep -v run_ktools)
+   echo "$PIDS_KILL" >> log/killout.txt
+   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+   exit $exit_code
+}
+trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
+
+check_complete(){
+    set +e
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
+    has_error=0
+    for p in $proc_list; do
+        started=$(find log -name "$p*.log" | wc -l)
+        finished=$(find log -name "$p*.log" -exec grep -l "finish" {} + | wc -l)
+        if [ "$finished" -lt "$started" ]; then
+            echo "[ERROR] $p - $((started-finished)) processes lost"
+            has_error=1
+        elif [ "$started" -gt 0 ]; then
+            echo "[OK] $p"
+        fi
+    done
+    if [ "$has_error" -ne 0 ]; then
+        false # raise non-zero exit code
+    fi
+}
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+mkdir output/full_correlation/
+
+rm -R -f fifo/*
+mkdir fifo/full_correlation/
+rm -R -f work/*
+mkdir work/kat/
+mkdir work/full_correlation/
+mkdir work/full_correlation/kat/
+
+mkdir work/gul_S1_summaryleccalc
+mkdir work/gul_S1_summaryaalcalc
+mkdir work/gul_S2_summaryleccalc
+mkdir work/gul_S2_summaryaalcalc
+mkdir work/full_correlation/gul_S1_summaryleccalc
+mkdir work/full_correlation/gul_S1_summaryaalcalc
+mkdir work/full_correlation/gul_S2_summaryleccalc
+mkdir work/full_correlation/gul_S2_summaryaalcalc
+
+mkfifo fifo/gul_P1
+mkfifo fifo/gul_P2
+mkfifo fifo/gul_P3
+mkfifo fifo/gul_P4
+mkfifo fifo/gul_P5
+mkfifo fifo/gul_P6
+mkfifo fifo/gul_P7
+mkfifo fifo/gul_P8
+mkfifo fifo/gul_P9
+mkfifo fifo/gul_P10
+
+mkfifo fifo/gul_S1_summary_P1
+mkfifo fifo/gul_S1_eltcalc_P1
+mkfifo fifo/gul_S1_summarycalc_P1
+mkfifo fifo/gul_S1_pltcalc_P1
+mkfifo fifo/gul_S2_summary_P1
+mkfifo fifo/gul_S2_eltcalc_P1
+mkfifo fifo/gul_S2_summarycalc_P1
+mkfifo fifo/gul_S2_pltcalc_P1
+
+mkfifo fifo/gul_S1_summary_P2
+mkfifo fifo/gul_S1_eltcalc_P2
+mkfifo fifo/gul_S1_summarycalc_P2
+mkfifo fifo/gul_S1_pltcalc_P2
+mkfifo fifo/gul_S2_summary_P2
+mkfifo fifo/gul_S2_eltcalc_P2
+mkfifo fifo/gul_S2_summarycalc_P2
+mkfifo fifo/gul_S2_pltcalc_P2
+
+mkfifo fifo/gul_S1_summary_P3
+mkfifo fifo/gul_S1_eltcalc_P3
+mkfifo fifo/gul_S1_summarycalc_P3
+mkfifo fifo/gul_S1_pltcalc_P3
+mkfifo fifo/gul_S2_summary_P3
+mkfifo fifo/gul_S2_eltcalc_P3
+mkfifo fifo/gul_S2_summarycalc_P3
+mkfifo fifo/gul_S2_pltcalc_P3
+
+mkfifo fifo/gul_S1_summary_P4
+mkfifo fifo/gul_S1_eltcalc_P4
+mkfifo fifo/gul_S1_summarycalc_P4
+mkfifo fifo/gul_S1_pltcalc_P4
+mkfifo fifo/gul_S2_summary_P4
+mkfifo fifo/gul_S2_eltcalc_P4
+mkfifo fifo/gul_S2_summarycalc_P4
+mkfifo fifo/gul_S2_pltcalc_P4
+
+mkfifo fifo/gul_S1_summary_P5
+mkfifo fifo/gul_S1_eltcalc_P5
+mkfifo fifo/gul_S1_summarycalc_P5
+mkfifo fifo/gul_S1_pltcalc_P5
+mkfifo fifo/gul_S2_summary_P5
+mkfifo fifo/gul_S2_eltcalc_P5
+mkfifo fifo/gul_S2_summarycalc_P5
+mkfifo fifo/gul_S2_pltcalc_P5
+
+mkfifo fifo/gul_S1_summary_P6
+mkfifo fifo/gul_S1_eltcalc_P6
+mkfifo fifo/gul_S1_summarycalc_P6
+mkfifo fifo/gul_S1_pltcalc_P6
+mkfifo fifo/gul_S2_summary_P6
+mkfifo fifo/gul_S2_eltcalc_P6
+mkfifo fifo/gul_S2_summarycalc_P6
+mkfifo fifo/gul_S2_pltcalc_P6
+
+mkfifo fifo/gul_S1_summary_P7
+mkfifo fifo/gul_S1_eltcalc_P7
+mkfifo fifo/gul_S1_summarycalc_P7
+mkfifo fifo/gul_S1_pltcalc_P7
+mkfifo fifo/gul_S2_summary_P7
+mkfifo fifo/gul_S2_eltcalc_P7
+mkfifo fifo/gul_S2_summarycalc_P7
+mkfifo fifo/gul_S2_pltcalc_P7
+
+mkfifo fifo/gul_S1_summary_P8
+mkfifo fifo/gul_S1_eltcalc_P8
+mkfifo fifo/gul_S1_summarycalc_P8
+mkfifo fifo/gul_S1_pltcalc_P8
+mkfifo fifo/gul_S2_summary_P8
+mkfifo fifo/gul_S2_eltcalc_P8
+mkfifo fifo/gul_S2_summarycalc_P8
+mkfifo fifo/gul_S2_pltcalc_P8
+
+mkfifo fifo/gul_S1_summary_P9
+mkfifo fifo/gul_S1_eltcalc_P9
+mkfifo fifo/gul_S1_summarycalc_P9
+mkfifo fifo/gul_S1_pltcalc_P9
+mkfifo fifo/gul_S2_summary_P9
+mkfifo fifo/gul_S2_eltcalc_P9
+mkfifo fifo/gul_S2_summarycalc_P9
+mkfifo fifo/gul_S2_pltcalc_P9
+
+mkfifo fifo/gul_S1_summary_P10
+mkfifo fifo/gul_S1_eltcalc_P10
+mkfifo fifo/gul_S1_summarycalc_P10
+mkfifo fifo/gul_S1_pltcalc_P10
+mkfifo fifo/gul_S2_summary_P10
+mkfifo fifo/gul_S2_eltcalc_P10
+mkfifo fifo/gul_S2_summarycalc_P10
+mkfifo fifo/gul_S2_pltcalc_P10
+
+mkfifo fifo/full_correlation/gul_P1
+mkfifo fifo/full_correlation/gul_P2
+mkfifo fifo/full_correlation/gul_P3
+mkfifo fifo/full_correlation/gul_P4
+mkfifo fifo/full_correlation/gul_P5
+mkfifo fifo/full_correlation/gul_P6
+mkfifo fifo/full_correlation/gul_P7
+mkfifo fifo/full_correlation/gul_P8
+mkfifo fifo/full_correlation/gul_P9
+mkfifo fifo/full_correlation/gul_P10
+
+mkfifo fifo/full_correlation/gul_S1_summary_P1
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P1
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P1
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P1
+mkfifo fifo/full_correlation/gul_S2_summary_P1
+mkfifo fifo/full_correlation/gul_S2_eltcalc_P1
+mkfifo fifo/full_correlation/gul_S2_summarycalc_P1
+mkfifo fifo/full_correlation/gul_S2_pltcalc_P1
+
+mkfifo fifo/full_correlation/gul_S1_summary_P2
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P2
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P2
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P2
+mkfifo fifo/full_correlation/gul_S2_summary_P2
+mkfifo fifo/full_correlation/gul_S2_eltcalc_P2
+mkfifo fifo/full_correlation/gul_S2_summarycalc_P2
+mkfifo fifo/full_correlation/gul_S2_pltcalc_P2
+
+mkfifo fifo/full_correlation/gul_S1_summary_P3
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P3
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P3
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P3
+mkfifo fifo/full_correlation/gul_S2_summary_P3
+mkfifo fifo/full_correlation/gul_S2_eltcalc_P3
+mkfifo fifo/full_correlation/gul_S2_summarycalc_P3
+mkfifo fifo/full_correlation/gul_S2_pltcalc_P3
+
+mkfifo fifo/full_correlation/gul_S1_summary_P4
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P4
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P4
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P4
+mkfifo fifo/full_correlation/gul_S2_summary_P4
+mkfifo fifo/full_correlation/gul_S2_eltcalc_P4
+mkfifo fifo/full_correlation/gul_S2_summarycalc_P4
+mkfifo fifo/full_correlation/gul_S2_pltcalc_P4
+
+mkfifo fifo/full_correlation/gul_S1_summary_P5
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P5
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P5
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P5
+mkfifo fifo/full_correlation/gul_S2_summary_P5
+mkfifo fifo/full_correlation/gul_S2_eltcalc_P5
+mkfifo fifo/full_correlation/gul_S2_summarycalc_P5
+mkfifo fifo/full_correlation/gul_S2_pltcalc_P5
+
+mkfifo fifo/full_correlation/gul_S1_summary_P6
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P6
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P6
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P6
+mkfifo fifo/full_correlation/gul_S2_summary_P6
+mkfifo fifo/full_correlation/gul_S2_eltcalc_P6
+mkfifo fifo/full_correlation/gul_S2_summarycalc_P6
+mkfifo fifo/full_correlation/gul_S2_pltcalc_P6
+
+mkfifo fifo/full_correlation/gul_S1_summary_P7
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P7
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P7
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P7
+mkfifo fifo/full_correlation/gul_S2_summary_P7
+mkfifo fifo/full_correlation/gul_S2_eltcalc_P7
+mkfifo fifo/full_correlation/gul_S2_summarycalc_P7
+mkfifo fifo/full_correlation/gul_S2_pltcalc_P7
+
+mkfifo fifo/full_correlation/gul_S1_summary_P8
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P8
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P8
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P8
+mkfifo fifo/full_correlation/gul_S2_summary_P8
+mkfifo fifo/full_correlation/gul_S2_eltcalc_P8
+mkfifo fifo/full_correlation/gul_S2_summarycalc_P8
+mkfifo fifo/full_correlation/gul_S2_pltcalc_P8
+
+mkfifo fifo/full_correlation/gul_S1_summary_P9
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P9
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P9
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P9
+mkfifo fifo/full_correlation/gul_S2_summary_P9
+mkfifo fifo/full_correlation/gul_S2_eltcalc_P9
+mkfifo fifo/full_correlation/gul_S2_summarycalc_P9
+mkfifo fifo/full_correlation/gul_S2_pltcalc_P9
+
+mkfifo fifo/full_correlation/gul_S1_summary_P10
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P10
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P10
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P10
+mkfifo fifo/full_correlation/gul_S2_summary_P10
+mkfifo fifo/full_correlation/gul_S2_eltcalc_P10
+mkfifo fifo/full_correlation/gul_S2_summarycalc_P10
+mkfifo fifo/full_correlation/gul_S2_pltcalc_P10
+
+
+
+# --- Do ground up loss computes ---
+
+( eltcalc < fifo/gul_S1_eltcalc_P1 > work/kat/gul_S1_eltcalc_P1 ) 2>> log/stderror.err & pid1=$!
+( summarycalctocsv < fifo/gul_S1_summarycalc_P1 > work/kat/gul_S1_summarycalc_P1 ) 2>> log/stderror.err & pid2=$!
+( pltcalc < fifo/gul_S1_pltcalc_P1 > work/kat/gul_S1_pltcalc_P1 ) 2>> log/stderror.err & pid3=$!
+( eltcalc < fifo/gul_S2_eltcalc_P1 > work/kat/gul_S2_eltcalc_P1 ) 2>> log/stderror.err & pid4=$!
+( summarycalctocsv < fifo/gul_S2_summarycalc_P1 > work/kat/gul_S2_summarycalc_P1 ) 2>> log/stderror.err & pid5=$!
+( pltcalc < fifo/gul_S2_pltcalc_P1 > work/kat/gul_S2_pltcalc_P1 ) 2>> log/stderror.err & pid6=$!
+( eltcalc -s < fifo/gul_S1_eltcalc_P2 > work/kat/gul_S1_eltcalc_P2 ) 2>> log/stderror.err & pid7=$!
+( summarycalctocsv -s < fifo/gul_S1_summarycalc_P2 > work/kat/gul_S1_summarycalc_P2 ) 2>> log/stderror.err & pid8=$!
+( pltcalc -s < fifo/gul_S1_pltcalc_P2 > work/kat/gul_S1_pltcalc_P2 ) 2>> log/stderror.err & pid9=$!
+( eltcalc -s < fifo/gul_S2_eltcalc_P2 > work/kat/gul_S2_eltcalc_P2 ) 2>> log/stderror.err & pid10=$!
+( summarycalctocsv -s < fifo/gul_S2_summarycalc_P2 > work/kat/gul_S2_summarycalc_P2 ) 2>> log/stderror.err & pid11=$!
+( pltcalc -s < fifo/gul_S2_pltcalc_P2 > work/kat/gul_S2_pltcalc_P2 ) 2>> log/stderror.err & pid12=$!
+( eltcalc -s < fifo/gul_S1_eltcalc_P3 > work/kat/gul_S1_eltcalc_P3 ) 2>> log/stderror.err & pid13=$!
+( summarycalctocsv -s < fifo/gul_S1_summarycalc_P3 > work/kat/gul_S1_summarycalc_P3 ) 2>> log/stderror.err & pid14=$!
+( pltcalc -s < fifo/gul_S1_pltcalc_P3 > work/kat/gul_S1_pltcalc_P3 ) 2>> log/stderror.err & pid15=$!
+( eltcalc -s < fifo/gul_S2_eltcalc_P3 > work/kat/gul_S2_eltcalc_P3 ) 2>> log/stderror.err & pid16=$!
+( summarycalctocsv -s < fifo/gul_S2_summarycalc_P3 > work/kat/gul_S2_summarycalc_P3 ) 2>> log/stderror.err & pid17=$!
+( pltcalc -s < fifo/gul_S2_pltcalc_P3 > work/kat/gul_S2_pltcalc_P3 ) 2>> log/stderror.err & pid18=$!
+( eltcalc -s < fifo/gul_S1_eltcalc_P4 > work/kat/gul_S1_eltcalc_P4 ) 2>> log/stderror.err & pid19=$!
+( summarycalctocsv -s < fifo/gul_S1_summarycalc_P4 > work/kat/gul_S1_summarycalc_P4 ) 2>> log/stderror.err & pid20=$!
+( pltcalc -s < fifo/gul_S1_pltcalc_P4 > work/kat/gul_S1_pltcalc_P4 ) 2>> log/stderror.err & pid21=$!
+( eltcalc -s < fifo/gul_S2_eltcalc_P4 > work/kat/gul_S2_eltcalc_P4 ) 2>> log/stderror.err & pid22=$!
+( summarycalctocsv -s < fifo/gul_S2_summarycalc_P4 > work/kat/gul_S2_summarycalc_P4 ) 2>> log/stderror.err & pid23=$!
+( pltcalc -s < fifo/gul_S2_pltcalc_P4 > work/kat/gul_S2_pltcalc_P4 ) 2>> log/stderror.err & pid24=$!
+( eltcalc -s < fifo/gul_S1_eltcalc_P5 > work/kat/gul_S1_eltcalc_P5 ) 2>> log/stderror.err & pid25=$!
+( summarycalctocsv -s < fifo/gul_S1_summarycalc_P5 > work/kat/gul_S1_summarycalc_P5 ) 2>> log/stderror.err & pid26=$!
+( pltcalc -s < fifo/gul_S1_pltcalc_P5 > work/kat/gul_S1_pltcalc_P5 ) 2>> log/stderror.err & pid27=$!
+( eltcalc -s < fifo/gul_S2_eltcalc_P5 > work/kat/gul_S2_eltcalc_P5 ) 2>> log/stderror.err & pid28=$!
+( summarycalctocsv -s < fifo/gul_S2_summarycalc_P5 > work/kat/gul_S2_summarycalc_P5 ) 2>> log/stderror.err & pid29=$!
+( pltcalc -s < fifo/gul_S2_pltcalc_P5 > work/kat/gul_S2_pltcalc_P5 ) 2>> log/stderror.err & pid30=$!
+( eltcalc -s < fifo/gul_S1_eltcalc_P6 > work/kat/gul_S1_eltcalc_P6 ) 2>> log/stderror.err & pid31=$!
+( summarycalctocsv -s < fifo/gul_S1_summarycalc_P6 > work/kat/gul_S1_summarycalc_P6 ) 2>> log/stderror.err & pid32=$!
+( pltcalc -s < fifo/gul_S1_pltcalc_P6 > work/kat/gul_S1_pltcalc_P6 ) 2>> log/stderror.err & pid33=$!
+( eltcalc -s < fifo/gul_S2_eltcalc_P6 > work/kat/gul_S2_eltcalc_P6 ) 2>> log/stderror.err & pid34=$!
+( summarycalctocsv -s < fifo/gul_S2_summarycalc_P6 > work/kat/gul_S2_summarycalc_P6 ) 2>> log/stderror.err & pid35=$!
+( pltcalc -s < fifo/gul_S2_pltcalc_P6 > work/kat/gul_S2_pltcalc_P6 ) 2>> log/stderror.err & pid36=$!
+( eltcalc -s < fifo/gul_S1_eltcalc_P7 > work/kat/gul_S1_eltcalc_P7 ) 2>> log/stderror.err & pid37=$!
+( summarycalctocsv -s < fifo/gul_S1_summarycalc_P7 > work/kat/gul_S1_summarycalc_P7 ) 2>> log/stderror.err & pid38=$!
+( pltcalc -s < fifo/gul_S1_pltcalc_P7 > work/kat/gul_S1_pltcalc_P7 ) 2>> log/stderror.err & pid39=$!
+( eltcalc -s < fifo/gul_S2_eltcalc_P7 > work/kat/gul_S2_eltcalc_P7 ) 2>> log/stderror.err & pid40=$!
+( summarycalctocsv -s < fifo/gul_S2_summarycalc_P7 > work/kat/gul_S2_summarycalc_P7 ) 2>> log/stderror.err & pid41=$!
+( pltcalc -s < fifo/gul_S2_pltcalc_P7 > work/kat/gul_S2_pltcalc_P7 ) 2>> log/stderror.err & pid42=$!
+( eltcalc -s < fifo/gul_S1_eltcalc_P8 > work/kat/gul_S1_eltcalc_P8 ) 2>> log/stderror.err & pid43=$!
+( summarycalctocsv -s < fifo/gul_S1_summarycalc_P8 > work/kat/gul_S1_summarycalc_P8 ) 2>> log/stderror.err & pid44=$!
+( pltcalc -s < fifo/gul_S1_pltcalc_P8 > work/kat/gul_S1_pltcalc_P8 ) 2>> log/stderror.err & pid45=$!
+( eltcalc -s < fifo/gul_S2_eltcalc_P8 > work/kat/gul_S2_eltcalc_P8 ) 2>> log/stderror.err & pid46=$!
+( summarycalctocsv -s < fifo/gul_S2_summarycalc_P8 > work/kat/gul_S2_summarycalc_P8 ) 2>> log/stderror.err & pid47=$!
+( pltcalc -s < fifo/gul_S2_pltcalc_P8 > work/kat/gul_S2_pltcalc_P8 ) 2>> log/stderror.err & pid48=$!
+( eltcalc -s < fifo/gul_S1_eltcalc_P9 > work/kat/gul_S1_eltcalc_P9 ) 2>> log/stderror.err & pid49=$!
+( summarycalctocsv -s < fifo/gul_S1_summarycalc_P9 > work/kat/gul_S1_summarycalc_P9 ) 2>> log/stderror.err & pid50=$!
+( pltcalc -s < fifo/gul_S1_pltcalc_P9 > work/kat/gul_S1_pltcalc_P9 ) 2>> log/stderror.err & pid51=$!
+( eltcalc -s < fifo/gul_S2_eltcalc_P9 > work/kat/gul_S2_eltcalc_P9 ) 2>> log/stderror.err & pid52=$!
+( summarycalctocsv -s < fifo/gul_S2_summarycalc_P9 > work/kat/gul_S2_summarycalc_P9 ) 2>> log/stderror.err & pid53=$!
+( pltcalc -s < fifo/gul_S2_pltcalc_P9 > work/kat/gul_S2_pltcalc_P9 ) 2>> log/stderror.err & pid54=$!
+( eltcalc -s < fifo/gul_S1_eltcalc_P10 > work/kat/gul_S1_eltcalc_P10 ) 2>> log/stderror.err & pid55=$!
+( summarycalctocsv -s < fifo/gul_S1_summarycalc_P10 > work/kat/gul_S1_summarycalc_P10 ) 2>> log/stderror.err & pid56=$!
+( pltcalc -s < fifo/gul_S1_pltcalc_P10 > work/kat/gul_S1_pltcalc_P10 ) 2>> log/stderror.err & pid57=$!
+( eltcalc -s < fifo/gul_S2_eltcalc_P10 > work/kat/gul_S2_eltcalc_P10 ) 2>> log/stderror.err & pid58=$!
+( summarycalctocsv -s < fifo/gul_S2_summarycalc_P10 > work/kat/gul_S2_summarycalc_P10 ) 2>> log/stderror.err & pid59=$!
+( pltcalc -s < fifo/gul_S2_pltcalc_P10 > work/kat/gul_S2_pltcalc_P10 ) 2>> log/stderror.err & pid60=$!
+
+tee < fifo/gul_S1_summary_P1 fifo/gul_S1_eltcalc_P1 fifo/gul_S1_summarycalc_P1 fifo/gul_S1_pltcalc_P1 work/gul_S1_summaryaalcalc/P1.bin work/gul_S1_summaryleccalc/P1.bin > /dev/null & pid61=$!
+tee < fifo/gul_S2_summary_P1 fifo/gul_S2_eltcalc_P1 fifo/gul_S2_summarycalc_P1 fifo/gul_S2_pltcalc_P1 work/gul_S2_summaryaalcalc/P1.bin work/gul_S2_summaryleccalc/P1.bin > /dev/null & pid62=$!
+tee < fifo/gul_S1_summary_P2 fifo/gul_S1_eltcalc_P2 fifo/gul_S1_summarycalc_P2 fifo/gul_S1_pltcalc_P2 work/gul_S1_summaryaalcalc/P2.bin work/gul_S1_summaryleccalc/P2.bin > /dev/null & pid63=$!
+tee < fifo/gul_S2_summary_P2 fifo/gul_S2_eltcalc_P2 fifo/gul_S2_summarycalc_P2 fifo/gul_S2_pltcalc_P2 work/gul_S2_summaryaalcalc/P2.bin work/gul_S2_summaryleccalc/P2.bin > /dev/null & pid64=$!
+tee < fifo/gul_S1_summary_P3 fifo/gul_S1_eltcalc_P3 fifo/gul_S1_summarycalc_P3 fifo/gul_S1_pltcalc_P3 work/gul_S1_summaryaalcalc/P3.bin work/gul_S1_summaryleccalc/P3.bin > /dev/null & pid65=$!
+tee < fifo/gul_S2_summary_P3 fifo/gul_S2_eltcalc_P3 fifo/gul_S2_summarycalc_P3 fifo/gul_S2_pltcalc_P3 work/gul_S2_summaryaalcalc/P3.bin work/gul_S2_summaryleccalc/P3.bin > /dev/null & pid66=$!
+tee < fifo/gul_S1_summary_P4 fifo/gul_S1_eltcalc_P4 fifo/gul_S1_summarycalc_P4 fifo/gul_S1_pltcalc_P4 work/gul_S1_summaryaalcalc/P4.bin work/gul_S1_summaryleccalc/P4.bin > /dev/null & pid67=$!
+tee < fifo/gul_S2_summary_P4 fifo/gul_S2_eltcalc_P4 fifo/gul_S2_summarycalc_P4 fifo/gul_S2_pltcalc_P4 work/gul_S2_summaryaalcalc/P4.bin work/gul_S2_summaryleccalc/P4.bin > /dev/null & pid68=$!
+tee < fifo/gul_S1_summary_P5 fifo/gul_S1_eltcalc_P5 fifo/gul_S1_summarycalc_P5 fifo/gul_S1_pltcalc_P5 work/gul_S1_summaryaalcalc/P5.bin work/gul_S1_summaryleccalc/P5.bin > /dev/null & pid69=$!
+tee < fifo/gul_S2_summary_P5 fifo/gul_S2_eltcalc_P5 fifo/gul_S2_summarycalc_P5 fifo/gul_S2_pltcalc_P5 work/gul_S2_summaryaalcalc/P5.bin work/gul_S2_summaryleccalc/P5.bin > /dev/null & pid70=$!
+tee < fifo/gul_S1_summary_P6 fifo/gul_S1_eltcalc_P6 fifo/gul_S1_summarycalc_P6 fifo/gul_S1_pltcalc_P6 work/gul_S1_summaryaalcalc/P6.bin work/gul_S1_summaryleccalc/P6.bin > /dev/null & pid71=$!
+tee < fifo/gul_S2_summary_P6 fifo/gul_S2_eltcalc_P6 fifo/gul_S2_summarycalc_P6 fifo/gul_S2_pltcalc_P6 work/gul_S2_summaryaalcalc/P6.bin work/gul_S2_summaryleccalc/P6.bin > /dev/null & pid72=$!
+tee < fifo/gul_S1_summary_P7 fifo/gul_S1_eltcalc_P7 fifo/gul_S1_summarycalc_P7 fifo/gul_S1_pltcalc_P7 work/gul_S1_summaryaalcalc/P7.bin work/gul_S1_summaryleccalc/P7.bin > /dev/null & pid73=$!
+tee < fifo/gul_S2_summary_P7 fifo/gul_S2_eltcalc_P7 fifo/gul_S2_summarycalc_P7 fifo/gul_S2_pltcalc_P7 work/gul_S2_summaryaalcalc/P7.bin work/gul_S2_summaryleccalc/P7.bin > /dev/null & pid74=$!
+tee < fifo/gul_S1_summary_P8 fifo/gul_S1_eltcalc_P8 fifo/gul_S1_summarycalc_P8 fifo/gul_S1_pltcalc_P8 work/gul_S1_summaryaalcalc/P8.bin work/gul_S1_summaryleccalc/P8.bin > /dev/null & pid75=$!
+tee < fifo/gul_S2_summary_P8 fifo/gul_S2_eltcalc_P8 fifo/gul_S2_summarycalc_P8 fifo/gul_S2_pltcalc_P8 work/gul_S2_summaryaalcalc/P8.bin work/gul_S2_summaryleccalc/P8.bin > /dev/null & pid76=$!
+tee < fifo/gul_S1_summary_P9 fifo/gul_S1_eltcalc_P9 fifo/gul_S1_summarycalc_P9 fifo/gul_S1_pltcalc_P9 work/gul_S1_summaryaalcalc/P9.bin work/gul_S1_summaryleccalc/P9.bin > /dev/null & pid77=$!
+tee < fifo/gul_S2_summary_P9 fifo/gul_S2_eltcalc_P9 fifo/gul_S2_summarycalc_P9 fifo/gul_S2_pltcalc_P9 work/gul_S2_summaryaalcalc/P9.bin work/gul_S2_summaryleccalc/P9.bin > /dev/null & pid78=$!
+tee < fifo/gul_S1_summary_P10 fifo/gul_S1_eltcalc_P10 fifo/gul_S1_summarycalc_P10 fifo/gul_S1_pltcalc_P10 work/gul_S1_summaryaalcalc/P10.bin work/gul_S1_summaryleccalc/P10.bin > /dev/null & pid79=$!
+tee < fifo/gul_S2_summary_P10 fifo/gul_S2_eltcalc_P10 fifo/gul_S2_summarycalc_P10 fifo/gul_S2_pltcalc_P10 work/gul_S2_summaryaalcalc/P10.bin work/gul_S2_summaryleccalc/P10.bin > /dev/null & pid80=$!
+
+( summarycalc -i  -1 fifo/gul_S1_summary_P1 -2 fifo/gul_S2_summary_P1 < fifo/gul_P1 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P2 -2 fifo/gul_S2_summary_P2 < fifo/gul_P2 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P3 -2 fifo/gul_S2_summary_P3 < fifo/gul_P3 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P4 -2 fifo/gul_S2_summary_P4 < fifo/gul_P4 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P5 -2 fifo/gul_S2_summary_P5 < fifo/gul_P5 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P6 -2 fifo/gul_S2_summary_P6 < fifo/gul_P6 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P7 -2 fifo/gul_S2_summary_P7 < fifo/gul_P7 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P8 -2 fifo/gul_S2_summary_P8 < fifo/gul_P8 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P9 -2 fifo/gul_S2_summary_P9 < fifo/gul_P9 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P10 -2 fifo/gul_S2_summary_P10 < fifo/gul_P10 ) 2>> log/stderror.err  &
+
+# --- Do ground up loss computes ---
+
+( eltcalc < fifo/full_correlation/gul_S1_eltcalc_P1 > work/full_correlation/kat/gul_S1_eltcalc_P1 ) 2>> log/stderror.err & pid81=$!
+( summarycalctocsv < fifo/full_correlation/gul_S1_summarycalc_P1 > work/full_correlation/kat/gul_S1_summarycalc_P1 ) 2>> log/stderror.err & pid82=$!
+( pltcalc < fifo/full_correlation/gul_S1_pltcalc_P1 > work/full_correlation/kat/gul_S1_pltcalc_P1 ) 2>> log/stderror.err & pid83=$!
+( eltcalc < fifo/full_correlation/gul_S2_eltcalc_P1 > work/full_correlation/kat/gul_S2_eltcalc_P1 ) 2>> log/stderror.err & pid84=$!
+( summarycalctocsv < fifo/full_correlation/gul_S2_summarycalc_P1 > work/full_correlation/kat/gul_S2_summarycalc_P1 ) 2>> log/stderror.err & pid85=$!
+( pltcalc < fifo/full_correlation/gul_S2_pltcalc_P1 > work/full_correlation/kat/gul_S2_pltcalc_P1 ) 2>> log/stderror.err & pid86=$!
+( eltcalc -s < fifo/full_correlation/gul_S1_eltcalc_P2 > work/full_correlation/kat/gul_S1_eltcalc_P2 ) 2>> log/stderror.err & pid87=$!
+( summarycalctocsv -s < fifo/full_correlation/gul_S1_summarycalc_P2 > work/full_correlation/kat/gul_S1_summarycalc_P2 ) 2>> log/stderror.err & pid88=$!
+( pltcalc -s < fifo/full_correlation/gul_S1_pltcalc_P2 > work/full_correlation/kat/gul_S1_pltcalc_P2 ) 2>> log/stderror.err & pid89=$!
+( eltcalc -s < fifo/full_correlation/gul_S2_eltcalc_P2 > work/full_correlation/kat/gul_S2_eltcalc_P2 ) 2>> log/stderror.err & pid90=$!
+( summarycalctocsv -s < fifo/full_correlation/gul_S2_summarycalc_P2 > work/full_correlation/kat/gul_S2_summarycalc_P2 ) 2>> log/stderror.err & pid91=$!
+( pltcalc -s < fifo/full_correlation/gul_S2_pltcalc_P2 > work/full_correlation/kat/gul_S2_pltcalc_P2 ) 2>> log/stderror.err & pid92=$!
+( eltcalc -s < fifo/full_correlation/gul_S1_eltcalc_P3 > work/full_correlation/kat/gul_S1_eltcalc_P3 ) 2>> log/stderror.err & pid93=$!
+( summarycalctocsv -s < fifo/full_correlation/gul_S1_summarycalc_P3 > work/full_correlation/kat/gul_S1_summarycalc_P3 ) 2>> log/stderror.err & pid94=$!
+( pltcalc -s < fifo/full_correlation/gul_S1_pltcalc_P3 > work/full_correlation/kat/gul_S1_pltcalc_P3 ) 2>> log/stderror.err & pid95=$!
+( eltcalc -s < fifo/full_correlation/gul_S2_eltcalc_P3 > work/full_correlation/kat/gul_S2_eltcalc_P3 ) 2>> log/stderror.err & pid96=$!
+( summarycalctocsv -s < fifo/full_correlation/gul_S2_summarycalc_P3 > work/full_correlation/kat/gul_S2_summarycalc_P3 ) 2>> log/stderror.err & pid97=$!
+( pltcalc -s < fifo/full_correlation/gul_S2_pltcalc_P3 > work/full_correlation/kat/gul_S2_pltcalc_P3 ) 2>> log/stderror.err & pid98=$!
+( eltcalc -s < fifo/full_correlation/gul_S1_eltcalc_P4 > work/full_correlation/kat/gul_S1_eltcalc_P4 ) 2>> log/stderror.err & pid99=$!
+( summarycalctocsv -s < fifo/full_correlation/gul_S1_summarycalc_P4 > work/full_correlation/kat/gul_S1_summarycalc_P4 ) 2>> log/stderror.err & pid100=$!
+( pltcalc -s < fifo/full_correlation/gul_S1_pltcalc_P4 > work/full_correlation/kat/gul_S1_pltcalc_P4 ) 2>> log/stderror.err & pid101=$!
+( eltcalc -s < fifo/full_correlation/gul_S2_eltcalc_P4 > work/full_correlation/kat/gul_S2_eltcalc_P4 ) 2>> log/stderror.err & pid102=$!
+( summarycalctocsv -s < fifo/full_correlation/gul_S2_summarycalc_P4 > work/full_correlation/kat/gul_S2_summarycalc_P4 ) 2>> log/stderror.err & pid103=$!
+( pltcalc -s < fifo/full_correlation/gul_S2_pltcalc_P4 > work/full_correlation/kat/gul_S2_pltcalc_P4 ) 2>> log/stderror.err & pid104=$!
+( eltcalc -s < fifo/full_correlation/gul_S1_eltcalc_P5 > work/full_correlation/kat/gul_S1_eltcalc_P5 ) 2>> log/stderror.err & pid105=$!
+( summarycalctocsv -s < fifo/full_correlation/gul_S1_summarycalc_P5 > work/full_correlation/kat/gul_S1_summarycalc_P5 ) 2>> log/stderror.err & pid106=$!
+( pltcalc -s < fifo/full_correlation/gul_S1_pltcalc_P5 > work/full_correlation/kat/gul_S1_pltcalc_P5 ) 2>> log/stderror.err & pid107=$!
+( eltcalc -s < fifo/full_correlation/gul_S2_eltcalc_P5 > work/full_correlation/kat/gul_S2_eltcalc_P5 ) 2>> log/stderror.err & pid108=$!
+( summarycalctocsv -s < fifo/full_correlation/gul_S2_summarycalc_P5 > work/full_correlation/kat/gul_S2_summarycalc_P5 ) 2>> log/stderror.err & pid109=$!
+( pltcalc -s < fifo/full_correlation/gul_S2_pltcalc_P5 > work/full_correlation/kat/gul_S2_pltcalc_P5 ) 2>> log/stderror.err & pid110=$!
+( eltcalc -s < fifo/full_correlation/gul_S1_eltcalc_P6 > work/full_correlation/kat/gul_S1_eltcalc_P6 ) 2>> log/stderror.err & pid111=$!
+( summarycalctocsv -s < fifo/full_correlation/gul_S1_summarycalc_P6 > work/full_correlation/kat/gul_S1_summarycalc_P6 ) 2>> log/stderror.err & pid112=$!
+( pltcalc -s < fifo/full_correlation/gul_S1_pltcalc_P6 > work/full_correlation/kat/gul_S1_pltcalc_P6 ) 2>> log/stderror.err & pid113=$!
+( eltcalc -s < fifo/full_correlation/gul_S2_eltcalc_P6 > work/full_correlation/kat/gul_S2_eltcalc_P6 ) 2>> log/stderror.err & pid114=$!
+( summarycalctocsv -s < fifo/full_correlation/gul_S2_summarycalc_P6 > work/full_correlation/kat/gul_S2_summarycalc_P6 ) 2>> log/stderror.err & pid115=$!
+( pltcalc -s < fifo/full_correlation/gul_S2_pltcalc_P6 > work/full_correlation/kat/gul_S2_pltcalc_P6 ) 2>> log/stderror.err & pid116=$!
+( eltcalc -s < fifo/full_correlation/gul_S1_eltcalc_P7 > work/full_correlation/kat/gul_S1_eltcalc_P7 ) 2>> log/stderror.err & pid117=$!
+( summarycalctocsv -s < fifo/full_correlation/gul_S1_summarycalc_P7 > work/full_correlation/kat/gul_S1_summarycalc_P7 ) 2>> log/stderror.err & pid118=$!
+( pltcalc -s < fifo/full_correlation/gul_S1_pltcalc_P7 > work/full_correlation/kat/gul_S1_pltcalc_P7 ) 2>> log/stderror.err & pid119=$!
+( eltcalc -s < fifo/full_correlation/gul_S2_eltcalc_P7 > work/full_correlation/kat/gul_S2_eltcalc_P7 ) 2>> log/stderror.err & pid120=$!
+( summarycalctocsv -s < fifo/full_correlation/gul_S2_summarycalc_P7 > work/full_correlation/kat/gul_S2_summarycalc_P7 ) 2>> log/stderror.err & pid121=$!
+( pltcalc -s < fifo/full_correlation/gul_S2_pltcalc_P7 > work/full_correlation/kat/gul_S2_pltcalc_P7 ) 2>> log/stderror.err & pid122=$!
+( eltcalc -s < fifo/full_correlation/gul_S1_eltcalc_P8 > work/full_correlation/kat/gul_S1_eltcalc_P8 ) 2>> log/stderror.err & pid123=$!
+( summarycalctocsv -s < fifo/full_correlation/gul_S1_summarycalc_P8 > work/full_correlation/kat/gul_S1_summarycalc_P8 ) 2>> log/stderror.err & pid124=$!
+( pltcalc -s < fifo/full_correlation/gul_S1_pltcalc_P8 > work/full_correlation/kat/gul_S1_pltcalc_P8 ) 2>> log/stderror.err & pid125=$!
+( eltcalc -s < fifo/full_correlation/gul_S2_eltcalc_P8 > work/full_correlation/kat/gul_S2_eltcalc_P8 ) 2>> log/stderror.err & pid126=$!
+( summarycalctocsv -s < fifo/full_correlation/gul_S2_summarycalc_P8 > work/full_correlation/kat/gul_S2_summarycalc_P8 ) 2>> log/stderror.err & pid127=$!
+( pltcalc -s < fifo/full_correlation/gul_S2_pltcalc_P8 > work/full_correlation/kat/gul_S2_pltcalc_P8 ) 2>> log/stderror.err & pid128=$!
+( eltcalc -s < fifo/full_correlation/gul_S1_eltcalc_P9 > work/full_correlation/kat/gul_S1_eltcalc_P9 ) 2>> log/stderror.err & pid129=$!
+( summarycalctocsv -s < fifo/full_correlation/gul_S1_summarycalc_P9 > work/full_correlation/kat/gul_S1_summarycalc_P9 ) 2>> log/stderror.err & pid130=$!
+( pltcalc -s < fifo/full_correlation/gul_S1_pltcalc_P9 > work/full_correlation/kat/gul_S1_pltcalc_P9 ) 2>> log/stderror.err & pid131=$!
+( eltcalc -s < fifo/full_correlation/gul_S2_eltcalc_P9 > work/full_correlation/kat/gul_S2_eltcalc_P9 ) 2>> log/stderror.err & pid132=$!
+( summarycalctocsv -s < fifo/full_correlation/gul_S2_summarycalc_P9 > work/full_correlation/kat/gul_S2_summarycalc_P9 ) 2>> log/stderror.err & pid133=$!
+( pltcalc -s < fifo/full_correlation/gul_S2_pltcalc_P9 > work/full_correlation/kat/gul_S2_pltcalc_P9 ) 2>> log/stderror.err & pid134=$!
+( eltcalc -s < fifo/full_correlation/gul_S1_eltcalc_P10 > work/full_correlation/kat/gul_S1_eltcalc_P10 ) 2>> log/stderror.err & pid135=$!
+( summarycalctocsv -s < fifo/full_correlation/gul_S1_summarycalc_P10 > work/full_correlation/kat/gul_S1_summarycalc_P10 ) 2>> log/stderror.err & pid136=$!
+( pltcalc -s < fifo/full_correlation/gul_S1_pltcalc_P10 > work/full_correlation/kat/gul_S1_pltcalc_P10 ) 2>> log/stderror.err & pid137=$!
+( eltcalc -s < fifo/full_correlation/gul_S2_eltcalc_P10 > work/full_correlation/kat/gul_S2_eltcalc_P10 ) 2>> log/stderror.err & pid138=$!
+( summarycalctocsv -s < fifo/full_correlation/gul_S2_summarycalc_P10 > work/full_correlation/kat/gul_S2_summarycalc_P10 ) 2>> log/stderror.err & pid139=$!
+( pltcalc -s < fifo/full_correlation/gul_S2_pltcalc_P10 > work/full_correlation/kat/gul_S2_pltcalc_P10 ) 2>> log/stderror.err & pid140=$!
+
+tee < fifo/full_correlation/gul_S1_summary_P1 fifo/full_correlation/gul_S1_eltcalc_P1 fifo/full_correlation/gul_S1_summarycalc_P1 fifo/full_correlation/gul_S1_pltcalc_P1 work/full_correlation/gul_S1_summaryaalcalc/P1.bin work/full_correlation/gul_S1_summaryleccalc/P1.bin > /dev/null & pid141=$!
+tee < fifo/full_correlation/gul_S2_summary_P1 fifo/full_correlation/gul_S2_eltcalc_P1 fifo/full_correlation/gul_S2_summarycalc_P1 fifo/full_correlation/gul_S2_pltcalc_P1 work/full_correlation/gul_S2_summaryaalcalc/P1.bin work/full_correlation/gul_S2_summaryleccalc/P1.bin > /dev/null & pid142=$!
+tee < fifo/full_correlation/gul_S1_summary_P2 fifo/full_correlation/gul_S1_eltcalc_P2 fifo/full_correlation/gul_S1_summarycalc_P2 fifo/full_correlation/gul_S1_pltcalc_P2 work/full_correlation/gul_S1_summaryaalcalc/P2.bin work/full_correlation/gul_S1_summaryleccalc/P2.bin > /dev/null & pid143=$!
+tee < fifo/full_correlation/gul_S2_summary_P2 fifo/full_correlation/gul_S2_eltcalc_P2 fifo/full_correlation/gul_S2_summarycalc_P2 fifo/full_correlation/gul_S2_pltcalc_P2 work/full_correlation/gul_S2_summaryaalcalc/P2.bin work/full_correlation/gul_S2_summaryleccalc/P2.bin > /dev/null & pid144=$!
+tee < fifo/full_correlation/gul_S1_summary_P3 fifo/full_correlation/gul_S1_eltcalc_P3 fifo/full_correlation/gul_S1_summarycalc_P3 fifo/full_correlation/gul_S1_pltcalc_P3 work/full_correlation/gul_S1_summaryaalcalc/P3.bin work/full_correlation/gul_S1_summaryleccalc/P3.bin > /dev/null & pid145=$!
+tee < fifo/full_correlation/gul_S2_summary_P3 fifo/full_correlation/gul_S2_eltcalc_P3 fifo/full_correlation/gul_S2_summarycalc_P3 fifo/full_correlation/gul_S2_pltcalc_P3 work/full_correlation/gul_S2_summaryaalcalc/P3.bin work/full_correlation/gul_S2_summaryleccalc/P3.bin > /dev/null & pid146=$!
+tee < fifo/full_correlation/gul_S1_summary_P4 fifo/full_correlation/gul_S1_eltcalc_P4 fifo/full_correlation/gul_S1_summarycalc_P4 fifo/full_correlation/gul_S1_pltcalc_P4 work/full_correlation/gul_S1_summaryaalcalc/P4.bin work/full_correlation/gul_S1_summaryleccalc/P4.bin > /dev/null & pid147=$!
+tee < fifo/full_correlation/gul_S2_summary_P4 fifo/full_correlation/gul_S2_eltcalc_P4 fifo/full_correlation/gul_S2_summarycalc_P4 fifo/full_correlation/gul_S2_pltcalc_P4 work/full_correlation/gul_S2_summaryaalcalc/P4.bin work/full_correlation/gul_S2_summaryleccalc/P4.bin > /dev/null & pid148=$!
+tee < fifo/full_correlation/gul_S1_summary_P5 fifo/full_correlation/gul_S1_eltcalc_P5 fifo/full_correlation/gul_S1_summarycalc_P5 fifo/full_correlation/gul_S1_pltcalc_P5 work/full_correlation/gul_S1_summaryaalcalc/P5.bin work/full_correlation/gul_S1_summaryleccalc/P5.bin > /dev/null & pid149=$!
+tee < fifo/full_correlation/gul_S2_summary_P5 fifo/full_correlation/gul_S2_eltcalc_P5 fifo/full_correlation/gul_S2_summarycalc_P5 fifo/full_correlation/gul_S2_pltcalc_P5 work/full_correlation/gul_S2_summaryaalcalc/P5.bin work/full_correlation/gul_S2_summaryleccalc/P5.bin > /dev/null & pid150=$!
+tee < fifo/full_correlation/gul_S1_summary_P6 fifo/full_correlation/gul_S1_eltcalc_P6 fifo/full_correlation/gul_S1_summarycalc_P6 fifo/full_correlation/gul_S1_pltcalc_P6 work/full_correlation/gul_S1_summaryaalcalc/P6.bin work/full_correlation/gul_S1_summaryleccalc/P6.bin > /dev/null & pid151=$!
+tee < fifo/full_correlation/gul_S2_summary_P6 fifo/full_correlation/gul_S2_eltcalc_P6 fifo/full_correlation/gul_S2_summarycalc_P6 fifo/full_correlation/gul_S2_pltcalc_P6 work/full_correlation/gul_S2_summaryaalcalc/P6.bin work/full_correlation/gul_S2_summaryleccalc/P6.bin > /dev/null & pid152=$!
+tee < fifo/full_correlation/gul_S1_summary_P7 fifo/full_correlation/gul_S1_eltcalc_P7 fifo/full_correlation/gul_S1_summarycalc_P7 fifo/full_correlation/gul_S1_pltcalc_P7 work/full_correlation/gul_S1_summaryaalcalc/P7.bin work/full_correlation/gul_S1_summaryleccalc/P7.bin > /dev/null & pid153=$!
+tee < fifo/full_correlation/gul_S2_summary_P7 fifo/full_correlation/gul_S2_eltcalc_P7 fifo/full_correlation/gul_S2_summarycalc_P7 fifo/full_correlation/gul_S2_pltcalc_P7 work/full_correlation/gul_S2_summaryaalcalc/P7.bin work/full_correlation/gul_S2_summaryleccalc/P7.bin > /dev/null & pid154=$!
+tee < fifo/full_correlation/gul_S1_summary_P8 fifo/full_correlation/gul_S1_eltcalc_P8 fifo/full_correlation/gul_S1_summarycalc_P8 fifo/full_correlation/gul_S1_pltcalc_P8 work/full_correlation/gul_S1_summaryaalcalc/P8.bin work/full_correlation/gul_S1_summaryleccalc/P8.bin > /dev/null & pid155=$!
+tee < fifo/full_correlation/gul_S2_summary_P8 fifo/full_correlation/gul_S2_eltcalc_P8 fifo/full_correlation/gul_S2_summarycalc_P8 fifo/full_correlation/gul_S2_pltcalc_P8 work/full_correlation/gul_S2_summaryaalcalc/P8.bin work/full_correlation/gul_S2_summaryleccalc/P8.bin > /dev/null & pid156=$!
+tee < fifo/full_correlation/gul_S1_summary_P9 fifo/full_correlation/gul_S1_eltcalc_P9 fifo/full_correlation/gul_S1_summarycalc_P9 fifo/full_correlation/gul_S1_pltcalc_P9 work/full_correlation/gul_S1_summaryaalcalc/P9.bin work/full_correlation/gul_S1_summaryleccalc/P9.bin > /dev/null & pid157=$!
+tee < fifo/full_correlation/gul_S2_summary_P9 fifo/full_correlation/gul_S2_eltcalc_P9 fifo/full_correlation/gul_S2_summarycalc_P9 fifo/full_correlation/gul_S2_pltcalc_P9 work/full_correlation/gul_S2_summaryaalcalc/P9.bin work/full_correlation/gul_S2_summaryleccalc/P9.bin > /dev/null & pid158=$!
+tee < fifo/full_correlation/gul_S1_summary_P10 fifo/full_correlation/gul_S1_eltcalc_P10 fifo/full_correlation/gul_S1_summarycalc_P10 fifo/full_correlation/gul_S1_pltcalc_P10 work/full_correlation/gul_S1_summaryaalcalc/P10.bin work/full_correlation/gul_S1_summaryleccalc/P10.bin > /dev/null & pid159=$!
+tee < fifo/full_correlation/gul_S2_summary_P10 fifo/full_correlation/gul_S2_eltcalc_P10 fifo/full_correlation/gul_S2_summarycalc_P10 fifo/full_correlation/gul_S2_pltcalc_P10 work/full_correlation/gul_S2_summaryaalcalc/P10.bin work/full_correlation/gul_S2_summaryleccalc/P10.bin > /dev/null & pid160=$!
+
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P1 -2 fifo/full_correlation/gul_S2_summary_P1 < fifo/full_correlation/gul_P1 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P2 -2 fifo/full_correlation/gul_S2_summary_P2 < fifo/full_correlation/gul_P2 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P3 -2 fifo/full_correlation/gul_S2_summary_P3 < fifo/full_correlation/gul_P3 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P4 -2 fifo/full_correlation/gul_S2_summary_P4 < fifo/full_correlation/gul_P4 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P5 -2 fifo/full_correlation/gul_S2_summary_P5 < fifo/full_correlation/gul_P5 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P6 -2 fifo/full_correlation/gul_S2_summary_P6 < fifo/full_correlation/gul_P6 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P7 -2 fifo/full_correlation/gul_S2_summary_P7 < fifo/full_correlation/gul_P7 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P8 -2 fifo/full_correlation/gul_S2_summary_P8 < fifo/full_correlation/gul_P8 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P9 -2 fifo/full_correlation/gul_S2_summary_P9 < fifo/full_correlation/gul_P9 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P10 -2 fifo/full_correlation/gul_S2_summary_P10 < fifo/full_correlation/gul_P10 ) 2>> log/stderror.err  &
+
+( eve 1 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P1 -a1 -i - > fifo/gul_P1  ) 2>> log/stderror.err &
+( eve 2 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P2 -a1 -i - > fifo/gul_P2  ) 2>> log/stderror.err &
+( eve 3 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P3 -a1 -i - > fifo/gul_P3  ) 2>> log/stderror.err &
+( eve 4 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P4 -a1 -i - > fifo/gul_P4  ) 2>> log/stderror.err &
+( eve 5 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P5 -a1 -i - > fifo/gul_P5  ) 2>> log/stderror.err &
+( eve 6 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P6 -a1 -i - > fifo/gul_P6  ) 2>> log/stderror.err &
+( eve 7 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P7 -a1 -i - > fifo/gul_P7  ) 2>> log/stderror.err &
+( eve 8 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P8 -a1 -i - > fifo/gul_P8  ) 2>> log/stderror.err &
+( eve 9 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P9 -a1 -i - > fifo/gul_P9  ) 2>> log/stderror.err &
+( eve 10 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P10 -a1 -i - > fifo/gul_P10  ) 2>> log/stderror.err &
+
+wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 $pid13 $pid14 $pid15 $pid16 $pid17 $pid18 $pid19 $pid20 $pid21 $pid22 $pid23 $pid24 $pid25 $pid26 $pid27 $pid28 $pid29 $pid30 $pid31 $pid32 $pid33 $pid34 $pid35 $pid36 $pid37 $pid38 $pid39 $pid40 $pid41 $pid42 $pid43 $pid44 $pid45 $pid46 $pid47 $pid48 $pid49 $pid50 $pid51 $pid52 $pid53 $pid54 $pid55 $pid56 $pid57 $pid58 $pid59 $pid60 $pid61 $pid62 $pid63 $pid64 $pid65 $pid66 $pid67 $pid68 $pid69 $pid70 $pid71 $pid72 $pid73 $pid74 $pid75 $pid76 $pid77 $pid78 $pid79 $pid80 $pid81 $pid82 $pid83 $pid84 $pid85 $pid86 $pid87 $pid88 $pid89 $pid90 $pid91 $pid92 $pid93 $pid94 $pid95 $pid96 $pid97 $pid98 $pid99 $pid100 $pid101 $pid102 $pid103 $pid104 $pid105 $pid106 $pid107 $pid108 $pid109 $pid110 $pid111 $pid112 $pid113 $pid114 $pid115 $pid116 $pid117 $pid118 $pid119 $pid120 $pid121 $pid122 $pid123 $pid124 $pid125 $pid126 $pid127 $pid128 $pid129 $pid130 $pid131 $pid132 $pid133 $pid134 $pid135 $pid136 $pid137 $pid138 $pid139 $pid140 $pid141 $pid142 $pid143 $pid144 $pid145 $pid146 $pid147 $pid148 $pid149 $pid150 $pid151 $pid152 $pid153 $pid154 $pid155 $pid156 $pid157 $pid158 $pid159 $pid160
+
+
+# --- Do ground up loss kats ---
+
+kat -s work/kat/gul_S1_eltcalc_P1 work/kat/gul_S1_eltcalc_P2 work/kat/gul_S1_eltcalc_P3 work/kat/gul_S1_eltcalc_P4 work/kat/gul_S1_eltcalc_P5 work/kat/gul_S1_eltcalc_P6 work/kat/gul_S1_eltcalc_P7 work/kat/gul_S1_eltcalc_P8 work/kat/gul_S1_eltcalc_P9 work/kat/gul_S1_eltcalc_P10 > output/gul_S1_eltcalc.csv & kpid1=$!
+kat work/kat/gul_S1_pltcalc_P1 work/kat/gul_S1_pltcalc_P2 work/kat/gul_S1_pltcalc_P3 work/kat/gul_S1_pltcalc_P4 work/kat/gul_S1_pltcalc_P5 work/kat/gul_S1_pltcalc_P6 work/kat/gul_S1_pltcalc_P7 work/kat/gul_S1_pltcalc_P8 work/kat/gul_S1_pltcalc_P9 work/kat/gul_S1_pltcalc_P10 > output/gul_S1_pltcalc.csv & kpid2=$!
+kat work/kat/gul_S1_summarycalc_P1 work/kat/gul_S1_summarycalc_P2 work/kat/gul_S1_summarycalc_P3 work/kat/gul_S1_summarycalc_P4 work/kat/gul_S1_summarycalc_P5 work/kat/gul_S1_summarycalc_P6 work/kat/gul_S1_summarycalc_P7 work/kat/gul_S1_summarycalc_P8 work/kat/gul_S1_summarycalc_P9 work/kat/gul_S1_summarycalc_P10 > output/gul_S1_summarycalc.csv & kpid3=$!
+kat -s work/kat/gul_S2_eltcalc_P1 work/kat/gul_S2_eltcalc_P2 work/kat/gul_S2_eltcalc_P3 work/kat/gul_S2_eltcalc_P4 work/kat/gul_S2_eltcalc_P5 work/kat/gul_S2_eltcalc_P6 work/kat/gul_S2_eltcalc_P7 work/kat/gul_S2_eltcalc_P8 work/kat/gul_S2_eltcalc_P9 work/kat/gul_S2_eltcalc_P10 > output/gul_S2_eltcalc.csv & kpid4=$!
+kat work/kat/gul_S2_pltcalc_P1 work/kat/gul_S2_pltcalc_P2 work/kat/gul_S2_pltcalc_P3 work/kat/gul_S2_pltcalc_P4 work/kat/gul_S2_pltcalc_P5 work/kat/gul_S2_pltcalc_P6 work/kat/gul_S2_pltcalc_P7 work/kat/gul_S2_pltcalc_P8 work/kat/gul_S2_pltcalc_P9 work/kat/gul_S2_pltcalc_P10 > output/gul_S2_pltcalc.csv & kpid5=$!
+kat work/kat/gul_S2_summarycalc_P1 work/kat/gul_S2_summarycalc_P2 work/kat/gul_S2_summarycalc_P3 work/kat/gul_S2_summarycalc_P4 work/kat/gul_S2_summarycalc_P5 work/kat/gul_S2_summarycalc_P6 work/kat/gul_S2_summarycalc_P7 work/kat/gul_S2_summarycalc_P8 work/kat/gul_S2_summarycalc_P9 work/kat/gul_S2_summarycalc_P10 > output/gul_S2_summarycalc.csv & kpid6=$!
+
+# --- Do ground up loss kats for fully correlated output ---
+
+kat -s work/full_correlation/kat/gul_S1_eltcalc_P1 work/full_correlation/kat/gul_S1_eltcalc_P2 work/full_correlation/kat/gul_S1_eltcalc_P3 work/full_correlation/kat/gul_S1_eltcalc_P4 work/full_correlation/kat/gul_S1_eltcalc_P5 work/full_correlation/kat/gul_S1_eltcalc_P6 work/full_correlation/kat/gul_S1_eltcalc_P7 work/full_correlation/kat/gul_S1_eltcalc_P8 work/full_correlation/kat/gul_S1_eltcalc_P9 work/full_correlation/kat/gul_S1_eltcalc_P10 > output/full_correlation/gul_S1_eltcalc.csv & kpid7=$!
+kat work/full_correlation/kat/gul_S1_pltcalc_P1 work/full_correlation/kat/gul_S1_pltcalc_P2 work/full_correlation/kat/gul_S1_pltcalc_P3 work/full_correlation/kat/gul_S1_pltcalc_P4 work/full_correlation/kat/gul_S1_pltcalc_P5 work/full_correlation/kat/gul_S1_pltcalc_P6 work/full_correlation/kat/gul_S1_pltcalc_P7 work/full_correlation/kat/gul_S1_pltcalc_P8 work/full_correlation/kat/gul_S1_pltcalc_P9 work/full_correlation/kat/gul_S1_pltcalc_P10 > output/full_correlation/gul_S1_pltcalc.csv & kpid8=$!
+kat work/full_correlation/kat/gul_S1_summarycalc_P1 work/full_correlation/kat/gul_S1_summarycalc_P2 work/full_correlation/kat/gul_S1_summarycalc_P3 work/full_correlation/kat/gul_S1_summarycalc_P4 work/full_correlation/kat/gul_S1_summarycalc_P5 work/full_correlation/kat/gul_S1_summarycalc_P6 work/full_correlation/kat/gul_S1_summarycalc_P7 work/full_correlation/kat/gul_S1_summarycalc_P8 work/full_correlation/kat/gul_S1_summarycalc_P9 work/full_correlation/kat/gul_S1_summarycalc_P10 > output/full_correlation/gul_S1_summarycalc.csv & kpid9=$!
+kat -s work/full_correlation/kat/gul_S2_eltcalc_P1 work/full_correlation/kat/gul_S2_eltcalc_P2 work/full_correlation/kat/gul_S2_eltcalc_P3 work/full_correlation/kat/gul_S2_eltcalc_P4 work/full_correlation/kat/gul_S2_eltcalc_P5 work/full_correlation/kat/gul_S2_eltcalc_P6 work/full_correlation/kat/gul_S2_eltcalc_P7 work/full_correlation/kat/gul_S2_eltcalc_P8 work/full_correlation/kat/gul_S2_eltcalc_P9 work/full_correlation/kat/gul_S2_eltcalc_P10 > output/full_correlation/gul_S2_eltcalc.csv & kpid10=$!
+kat work/full_correlation/kat/gul_S2_pltcalc_P1 work/full_correlation/kat/gul_S2_pltcalc_P2 work/full_correlation/kat/gul_S2_pltcalc_P3 work/full_correlation/kat/gul_S2_pltcalc_P4 work/full_correlation/kat/gul_S2_pltcalc_P5 work/full_correlation/kat/gul_S2_pltcalc_P6 work/full_correlation/kat/gul_S2_pltcalc_P7 work/full_correlation/kat/gul_S2_pltcalc_P8 work/full_correlation/kat/gul_S2_pltcalc_P9 work/full_correlation/kat/gul_S2_pltcalc_P10 > output/full_correlation/gul_S2_pltcalc.csv & kpid11=$!
+kat work/full_correlation/kat/gul_S2_summarycalc_P1 work/full_correlation/kat/gul_S2_summarycalc_P2 work/full_correlation/kat/gul_S2_summarycalc_P3 work/full_correlation/kat/gul_S2_summarycalc_P4 work/full_correlation/kat/gul_S2_summarycalc_P5 work/full_correlation/kat/gul_S2_summarycalc_P6 work/full_correlation/kat/gul_S2_summarycalc_P7 work/full_correlation/kat/gul_S2_summarycalc_P8 work/full_correlation/kat/gul_S2_summarycalc_P9 work/full_correlation/kat/gul_S2_summarycalc_P10 > output/full_correlation/gul_S2_summarycalc.csv & kpid12=$!
+wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpid11 $kpid12
+
+
+( aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv ) 2>> log/stderror.err & lpid1=$!
+( ordleccalc -r -Kgul_S1_summaryleccalc -F -S -s -M -m -W -w -O output/gul_S1_ept.csv -o output/gul_S1_psept.csv ) 2>> log/stderror.err & lpid2=$!
+( leccalc -r -Kgul_S1_summaryleccalc -F output/gul_S1_leccalc_full_uncertainty_aep.csv -f output/gul_S1_leccalc_full_uncertainty_oep.csv -S output/gul_S1_leccalc_sample_mean_aep.csv -s output/gul_S1_leccalc_sample_mean_oep.csv -W output/gul_S1_leccalc_wheatsheaf_aep.csv -M output/gul_S1_leccalc_wheatsheaf_mean_aep.csv -m output/gul_S1_leccalc_wheatsheaf_mean_oep.csv -w output/gul_S1_leccalc_wheatsheaf_oep.csv ) 2>> log/stderror.err & lpid3=$!
+( aalcalc -Kgul_S2_summaryaalcalc > output/gul_S2_aalcalc.csv ) 2>> log/stderror.err & lpid4=$!
+( ordleccalc -r -Kgul_S2_summaryleccalc -F -S -s -M -m -W -w -O output/gul_S2_ept.csv -o output/gul_S2_psept.csv ) 2>> log/stderror.err & lpid5=$!
+( leccalc -r -Kgul_S2_summaryleccalc -F output/gul_S2_leccalc_full_uncertainty_aep.csv -f output/gul_S2_leccalc_full_uncertainty_oep.csv -S output/gul_S2_leccalc_sample_mean_aep.csv -s output/gul_S2_leccalc_sample_mean_oep.csv -W output/gul_S2_leccalc_wheatsheaf_aep.csv -M output/gul_S2_leccalc_wheatsheaf_mean_aep.csv -m output/gul_S2_leccalc_wheatsheaf_mean_oep.csv -w output/gul_S2_leccalc_wheatsheaf_oep.csv ) 2>> log/stderror.err & lpid6=$!
+( aalcalc -Kfull_correlation/gul_S1_summaryaalcalc > output/full_correlation/gul_S1_aalcalc.csv ) 2>> log/stderror.err & lpid7=$!
+( ordleccalc -r -Kfull_correlation/gul_S1_summaryleccalc -F -S -s -M -m -W -w -O output/full_correlation/gul_S1_ept.csv -o output/full_correlation/gul_S1_psept.csv ) 2>> log/stderror.err & lpid8=$!
+( leccalc -r -Kfull_correlation/gul_S1_summaryleccalc -F output/full_correlation/gul_S1_leccalc_full_uncertainty_aep.csv -f output/full_correlation/gul_S1_leccalc_full_uncertainty_oep.csv -S output/full_correlation/gul_S1_leccalc_sample_mean_aep.csv -s output/full_correlation/gul_S1_leccalc_sample_mean_oep.csv -W output/full_correlation/gul_S1_leccalc_wheatsheaf_aep.csv -M output/full_correlation/gul_S1_leccalc_wheatsheaf_mean_aep.csv -m output/full_correlation/gul_S1_leccalc_wheatsheaf_mean_oep.csv -w output/full_correlation/gul_S1_leccalc_wheatsheaf_oep.csv ) 2>> log/stderror.err & lpid9=$!
+( aalcalc -Kfull_correlation/gul_S2_summaryaalcalc > output/full_correlation/gul_S2_aalcalc.csv ) 2>> log/stderror.err & lpid10=$!
+( ordleccalc -r -Kfull_correlation/gul_S2_summaryleccalc -F -S -s -M -m -W -w -O output/full_correlation/gul_S2_ept.csv -o output/full_correlation/gul_S2_psept.csv ) 2>> log/stderror.err & lpid11=$!
+( leccalc -r -Kfull_correlation/gul_S2_summaryleccalc -F output/full_correlation/gul_S2_leccalc_full_uncertainty_aep.csv -f output/full_correlation/gul_S2_leccalc_full_uncertainty_oep.csv -S output/full_correlation/gul_S2_leccalc_sample_mean_aep.csv -s output/full_correlation/gul_S2_leccalc_sample_mean_oep.csv -W output/full_correlation/gul_S2_leccalc_wheatsheaf_aep.csv -M output/full_correlation/gul_S2_leccalc_wheatsheaf_mean_aep.csv -m output/full_correlation/gul_S2_leccalc_wheatsheaf_mean_oep.csv -w output/full_correlation/gul_S2_leccalc_wheatsheaf_oep.csv ) 2>> log/stderror.err & lpid12=$!
+wait $lpid1 $lpid2 $lpid3 $lpid4 $lpid5 $lpid6 $lpid7 $lpid8 $lpid9 $lpid10 $lpid11 $lpid12
+
+rm -R -f work/*
+rm -R -f fifo/*
+
+check_complete
+exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_ord_ept_psept_lec_2_output_10_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_ord_ept_psept_lec_2_output_10_partition.sh
@@ -29,7 +29,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
    ps f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk -F: '$1>$script_pid' | grep -v celery | grep -v python | grep -v $group_pid | grep -v run_ktools)
+   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | grep -v *.sh)
    echo "$PIDS_KILL" >> log/killout.txt
    kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
    exit $exit_code

--- a/tests/model_execution/err_fc_kparse_reference/gul_ord_psept_2_output_10_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_ord_psept_2_output_10_partition.sh
@@ -1,0 +1,258 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+
+touch log/stderror.err
+ktools_monitor.sh $$ & pid0=$!
+
+exit_handler(){
+   exit_code=$?
+   kill -9 $pid0 2> /dev/null
+   if [ "$exit_code" -gt 0 ]; then
+       echo 'Ktools Run Error - exitcode='$exit_code
+   else
+       echo 'Run Completed'
+   fi
+
+   set +x
+   group_pid=$(ps -p $$ -o pgid --no-headers)
+   sess_pid=$(ps -p $$ -o sess --no-headers)
+   script_pid=$$
+   printf "Script PID:%d, GPID:%s, SPID:%d
+" $script_pid $group_pid $sess_pid >> log/killout.txt
+
+   ps f -g $sess_pid > log/subprocess_list
+   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk -F: '$1>$script_pid' | grep -v celery | grep -v python | grep -v $group_pid | grep -v run_ktools)
+   echo "$PIDS_KILL" >> log/killout.txt
+   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+   exit $exit_code
+}
+trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
+
+check_complete(){
+    set +e
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
+    has_error=0
+    for p in $proc_list; do
+        started=$(find log -name "$p*.log" | wc -l)
+        finished=$(find log -name "$p*.log" -exec grep -l "finish" {} + | wc -l)
+        if [ "$finished" -lt "$started" ]; then
+            echo "[ERROR] $p - $((started-finished)) processes lost"
+            has_error=1
+        elif [ "$started" -gt 0 ]; then
+            echo "[OK] $p"
+        fi
+    done
+    if [ "$has_error" -ne 0 ]; then
+        false # raise non-zero exit code
+    fi
+}
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+mkdir output/full_correlation/
+
+rm -R -f fifo/*
+mkdir fifo/full_correlation/
+rm -R -f work/*
+mkdir work/kat/
+mkdir work/full_correlation/
+mkdir work/full_correlation/kat/
+
+mkdir work/gul_S1_summaryleccalc
+mkdir work/gul_S2_summaryleccalc
+mkdir work/full_correlation/gul_S1_summaryleccalc
+mkdir work/full_correlation/gul_S2_summaryleccalc
+
+mkfifo fifo/gul_P1
+mkfifo fifo/gul_P2
+mkfifo fifo/gul_P3
+mkfifo fifo/gul_P4
+mkfifo fifo/gul_P5
+mkfifo fifo/gul_P6
+mkfifo fifo/gul_P7
+mkfifo fifo/gul_P8
+mkfifo fifo/gul_P9
+mkfifo fifo/gul_P10
+
+mkfifo fifo/gul_S1_summary_P1
+mkfifo fifo/gul_S2_summary_P1
+
+mkfifo fifo/gul_S1_summary_P2
+mkfifo fifo/gul_S2_summary_P2
+
+mkfifo fifo/gul_S1_summary_P3
+mkfifo fifo/gul_S2_summary_P3
+
+mkfifo fifo/gul_S1_summary_P4
+mkfifo fifo/gul_S2_summary_P4
+
+mkfifo fifo/gul_S1_summary_P5
+mkfifo fifo/gul_S2_summary_P5
+
+mkfifo fifo/gul_S1_summary_P6
+mkfifo fifo/gul_S2_summary_P6
+
+mkfifo fifo/gul_S1_summary_P7
+mkfifo fifo/gul_S2_summary_P7
+
+mkfifo fifo/gul_S1_summary_P8
+mkfifo fifo/gul_S2_summary_P8
+
+mkfifo fifo/gul_S1_summary_P9
+mkfifo fifo/gul_S2_summary_P9
+
+mkfifo fifo/gul_S1_summary_P10
+mkfifo fifo/gul_S2_summary_P10
+
+mkfifo fifo/full_correlation/gul_P1
+mkfifo fifo/full_correlation/gul_P2
+mkfifo fifo/full_correlation/gul_P3
+mkfifo fifo/full_correlation/gul_P4
+mkfifo fifo/full_correlation/gul_P5
+mkfifo fifo/full_correlation/gul_P6
+mkfifo fifo/full_correlation/gul_P7
+mkfifo fifo/full_correlation/gul_P8
+mkfifo fifo/full_correlation/gul_P9
+mkfifo fifo/full_correlation/gul_P10
+
+mkfifo fifo/full_correlation/gul_S1_summary_P1
+mkfifo fifo/full_correlation/gul_S2_summary_P1
+
+mkfifo fifo/full_correlation/gul_S1_summary_P2
+mkfifo fifo/full_correlation/gul_S2_summary_P2
+
+mkfifo fifo/full_correlation/gul_S1_summary_P3
+mkfifo fifo/full_correlation/gul_S2_summary_P3
+
+mkfifo fifo/full_correlation/gul_S1_summary_P4
+mkfifo fifo/full_correlation/gul_S2_summary_P4
+
+mkfifo fifo/full_correlation/gul_S1_summary_P5
+mkfifo fifo/full_correlation/gul_S2_summary_P5
+
+mkfifo fifo/full_correlation/gul_S1_summary_P6
+mkfifo fifo/full_correlation/gul_S2_summary_P6
+
+mkfifo fifo/full_correlation/gul_S1_summary_P7
+mkfifo fifo/full_correlation/gul_S2_summary_P7
+
+mkfifo fifo/full_correlation/gul_S1_summary_P8
+mkfifo fifo/full_correlation/gul_S2_summary_P8
+
+mkfifo fifo/full_correlation/gul_S1_summary_P9
+mkfifo fifo/full_correlation/gul_S2_summary_P9
+
+mkfifo fifo/full_correlation/gul_S1_summary_P10
+mkfifo fifo/full_correlation/gul_S2_summary_P10
+
+
+
+# --- Do ground up loss computes ---
+
+
+tee < fifo/gul_S1_summary_P1 work/gul_S1_summaryleccalc/P1.bin > /dev/null & pid1=$!
+tee < fifo/gul_S2_summary_P1 work/gul_S2_summaryleccalc/P1.bin > /dev/null & pid2=$!
+tee < fifo/gul_S1_summary_P2 work/gul_S1_summaryleccalc/P2.bin > /dev/null & pid3=$!
+tee < fifo/gul_S2_summary_P2 work/gul_S2_summaryleccalc/P2.bin > /dev/null & pid4=$!
+tee < fifo/gul_S1_summary_P3 work/gul_S1_summaryleccalc/P3.bin > /dev/null & pid5=$!
+tee < fifo/gul_S2_summary_P3 work/gul_S2_summaryleccalc/P3.bin > /dev/null & pid6=$!
+tee < fifo/gul_S1_summary_P4 work/gul_S1_summaryleccalc/P4.bin > /dev/null & pid7=$!
+tee < fifo/gul_S2_summary_P4 work/gul_S2_summaryleccalc/P4.bin > /dev/null & pid8=$!
+tee < fifo/gul_S1_summary_P5 work/gul_S1_summaryleccalc/P5.bin > /dev/null & pid9=$!
+tee < fifo/gul_S2_summary_P5 work/gul_S2_summaryleccalc/P5.bin > /dev/null & pid10=$!
+tee < fifo/gul_S1_summary_P6 work/gul_S1_summaryleccalc/P6.bin > /dev/null & pid11=$!
+tee < fifo/gul_S2_summary_P6 work/gul_S2_summaryleccalc/P6.bin > /dev/null & pid12=$!
+tee < fifo/gul_S1_summary_P7 work/gul_S1_summaryleccalc/P7.bin > /dev/null & pid13=$!
+tee < fifo/gul_S2_summary_P7 work/gul_S2_summaryleccalc/P7.bin > /dev/null & pid14=$!
+tee < fifo/gul_S1_summary_P8 work/gul_S1_summaryleccalc/P8.bin > /dev/null & pid15=$!
+tee < fifo/gul_S2_summary_P8 work/gul_S2_summaryleccalc/P8.bin > /dev/null & pid16=$!
+tee < fifo/gul_S1_summary_P9 work/gul_S1_summaryleccalc/P9.bin > /dev/null & pid17=$!
+tee < fifo/gul_S2_summary_P9 work/gul_S2_summaryleccalc/P9.bin > /dev/null & pid18=$!
+tee < fifo/gul_S1_summary_P10 work/gul_S1_summaryleccalc/P10.bin > /dev/null & pid19=$!
+tee < fifo/gul_S2_summary_P10 work/gul_S2_summaryleccalc/P10.bin > /dev/null & pid20=$!
+
+( summarycalc -i  -1 fifo/gul_S1_summary_P1 -2 fifo/gul_S2_summary_P1 < fifo/gul_P1 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P2 -2 fifo/gul_S2_summary_P2 < fifo/gul_P2 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P3 -2 fifo/gul_S2_summary_P3 < fifo/gul_P3 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P4 -2 fifo/gul_S2_summary_P4 < fifo/gul_P4 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P5 -2 fifo/gul_S2_summary_P5 < fifo/gul_P5 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P6 -2 fifo/gul_S2_summary_P6 < fifo/gul_P6 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P7 -2 fifo/gul_S2_summary_P7 < fifo/gul_P7 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P8 -2 fifo/gul_S2_summary_P8 < fifo/gul_P8 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P9 -2 fifo/gul_S2_summary_P9 < fifo/gul_P9 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P10 -2 fifo/gul_S2_summary_P10 < fifo/gul_P10 ) 2>> log/stderror.err  &
+
+# --- Do ground up loss computes ---
+
+
+tee < fifo/full_correlation/gul_S1_summary_P1 work/full_correlation/gul_S1_summaryleccalc/P1.bin > /dev/null & pid21=$!
+tee < fifo/full_correlation/gul_S2_summary_P1 work/full_correlation/gul_S2_summaryleccalc/P1.bin > /dev/null & pid22=$!
+tee < fifo/full_correlation/gul_S1_summary_P2 work/full_correlation/gul_S1_summaryleccalc/P2.bin > /dev/null & pid23=$!
+tee < fifo/full_correlation/gul_S2_summary_P2 work/full_correlation/gul_S2_summaryleccalc/P2.bin > /dev/null & pid24=$!
+tee < fifo/full_correlation/gul_S1_summary_P3 work/full_correlation/gul_S1_summaryleccalc/P3.bin > /dev/null & pid25=$!
+tee < fifo/full_correlation/gul_S2_summary_P3 work/full_correlation/gul_S2_summaryleccalc/P3.bin > /dev/null & pid26=$!
+tee < fifo/full_correlation/gul_S1_summary_P4 work/full_correlation/gul_S1_summaryleccalc/P4.bin > /dev/null & pid27=$!
+tee < fifo/full_correlation/gul_S2_summary_P4 work/full_correlation/gul_S2_summaryleccalc/P4.bin > /dev/null & pid28=$!
+tee < fifo/full_correlation/gul_S1_summary_P5 work/full_correlation/gul_S1_summaryleccalc/P5.bin > /dev/null & pid29=$!
+tee < fifo/full_correlation/gul_S2_summary_P5 work/full_correlation/gul_S2_summaryleccalc/P5.bin > /dev/null & pid30=$!
+tee < fifo/full_correlation/gul_S1_summary_P6 work/full_correlation/gul_S1_summaryleccalc/P6.bin > /dev/null & pid31=$!
+tee < fifo/full_correlation/gul_S2_summary_P6 work/full_correlation/gul_S2_summaryleccalc/P6.bin > /dev/null & pid32=$!
+tee < fifo/full_correlation/gul_S1_summary_P7 work/full_correlation/gul_S1_summaryleccalc/P7.bin > /dev/null & pid33=$!
+tee < fifo/full_correlation/gul_S2_summary_P7 work/full_correlation/gul_S2_summaryleccalc/P7.bin > /dev/null & pid34=$!
+tee < fifo/full_correlation/gul_S1_summary_P8 work/full_correlation/gul_S1_summaryleccalc/P8.bin > /dev/null & pid35=$!
+tee < fifo/full_correlation/gul_S2_summary_P8 work/full_correlation/gul_S2_summaryleccalc/P8.bin > /dev/null & pid36=$!
+tee < fifo/full_correlation/gul_S1_summary_P9 work/full_correlation/gul_S1_summaryleccalc/P9.bin > /dev/null & pid37=$!
+tee < fifo/full_correlation/gul_S2_summary_P9 work/full_correlation/gul_S2_summaryleccalc/P9.bin > /dev/null & pid38=$!
+tee < fifo/full_correlation/gul_S1_summary_P10 work/full_correlation/gul_S1_summaryleccalc/P10.bin > /dev/null & pid39=$!
+tee < fifo/full_correlation/gul_S2_summary_P10 work/full_correlation/gul_S2_summaryleccalc/P10.bin > /dev/null & pid40=$!
+
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P1 -2 fifo/full_correlation/gul_S2_summary_P1 < fifo/full_correlation/gul_P1 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P2 -2 fifo/full_correlation/gul_S2_summary_P2 < fifo/full_correlation/gul_P2 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P3 -2 fifo/full_correlation/gul_S2_summary_P3 < fifo/full_correlation/gul_P3 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P4 -2 fifo/full_correlation/gul_S2_summary_P4 < fifo/full_correlation/gul_P4 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P5 -2 fifo/full_correlation/gul_S2_summary_P5 < fifo/full_correlation/gul_P5 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P6 -2 fifo/full_correlation/gul_S2_summary_P6 < fifo/full_correlation/gul_P6 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P7 -2 fifo/full_correlation/gul_S2_summary_P7 < fifo/full_correlation/gul_P7 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P8 -2 fifo/full_correlation/gul_S2_summary_P8 < fifo/full_correlation/gul_P8 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P9 -2 fifo/full_correlation/gul_S2_summary_P9 < fifo/full_correlation/gul_P9 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P10 -2 fifo/full_correlation/gul_S2_summary_P10 < fifo/full_correlation/gul_P10 ) 2>> log/stderror.err  &
+
+( eve 1 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P1 -a1 -i - > fifo/gul_P1  ) 2>> log/stderror.err &
+( eve 2 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P2 -a1 -i - > fifo/gul_P2  ) 2>> log/stderror.err &
+( eve 3 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P3 -a1 -i - > fifo/gul_P3  ) 2>> log/stderror.err &
+( eve 4 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P4 -a1 -i - > fifo/gul_P4  ) 2>> log/stderror.err &
+( eve 5 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P5 -a1 -i - > fifo/gul_P5  ) 2>> log/stderror.err &
+( eve 6 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P6 -a1 -i - > fifo/gul_P6  ) 2>> log/stderror.err &
+( eve 7 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P7 -a1 -i - > fifo/gul_P7  ) 2>> log/stderror.err &
+( eve 8 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P8 -a1 -i - > fifo/gul_P8  ) 2>> log/stderror.err &
+( eve 9 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P9 -a1 -i - > fifo/gul_P9  ) 2>> log/stderror.err &
+( eve 10 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P10 -a1 -i - > fifo/gul_P10  ) 2>> log/stderror.err &
+
+wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 $pid13 $pid14 $pid15 $pid16 $pid17 $pid18 $pid19 $pid20 $pid21 $pid22 $pid23 $pid24 $pid25 $pid26 $pid27 $pid28 $pid29 $pid30 $pid31 $pid32 $pid33 $pid34 $pid35 $pid36 $pid37 $pid38 $pid39 $pid40
+
+
+# --- Do ground up loss kats ---
+
+
+# --- Do ground up loss kats for fully correlated output ---
+
+
+( ordleccalc  -Kgul_S1_summaryleccalc -W -w -o output/gul_S1_psept.csv ) 2>> log/stderror.err & lpid1=$!
+( ordleccalc -r -Kgul_S2_summaryleccalc -W -w -o output/gul_S2_psept.csv ) 2>> log/stderror.err & lpid2=$!
+( ordleccalc  -Kfull_correlation/gul_S1_summaryleccalc -W -w -o output/full_correlation/gul_S1_psept.csv ) 2>> log/stderror.err & lpid3=$!
+( ordleccalc -r -Kfull_correlation/gul_S2_summaryleccalc -W -w -o output/full_correlation/gul_S2_psept.csv ) 2>> log/stderror.err & lpid4=$!
+wait $lpid1 $lpid2 $lpid3 $lpid4
+
+rm -R -f work/*
+rm -R -f fifo/*
+
+check_complete
+exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_ord_psept_2_output_10_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_ord_psept_2_output_10_partition.sh
@@ -29,7 +29,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
    ps f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk -F: '$1>$script_pid' | grep -v celery | grep -v python | grep -v $group_pid | grep -v run_ktools)
+   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | grep -v *.sh)
    echo "$PIDS_KILL" >> log/killout.txt
    kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
    exit $exit_code

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/il_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_lec_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/il_lec_1_output_2_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_lec_1_output_2_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/il_lec_2_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_lec_2_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/il_lec_2_output_2_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_lec_2_output_2_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/il_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_no_lec_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/il_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_no_lec_1_output_2_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/il_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_no_lec_2_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/il_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_no_lec_2_output_2_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/analysis_settings_1_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/analysis_settings_1_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/analysis_settings_2_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/analysis_settings_2_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/analysis_settings_5_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/analysis_settings_5_1_reins_layer_1_partition.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+
+touch log/stderror.err
+ktools_monitor.sh $$ & pid0=$!
+
+exit_handler(){
+   exit_code=$?
+   kill -9 $pid0 2> /dev/null
+   if [ "$exit_code" -gt 0 ]; then
+       echo 'Ktools Run Error - exitcode='$exit_code
+   else
+       echo 'Run Completed'
+   fi
+
+   set +x
+   group_pid=$(ps -p $$ -o pgid --no-headers)
+   sess_pid=$(ps -p $$ -o sess --no-headers)
+   script_pid=$$
+   printf "Script PID:%d, GPID:%s, SPID:%d
+" $script_pid $group_pid $sess_pid >> log/killout.txt
+
+   ps f -g $sess_pid > log/subprocess_list
+   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk -F: '$1>$script_pid' | grep -v celery | grep -v python | grep -v $group_pid | grep -v run_ktools)
+   echo "$PIDS_KILL" >> log/killout.txt
+   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+   exit $exit_code
+}
+trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
+
+check_complete(){
+    set +e
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
+    has_error=0
+    for p in $proc_list; do
+        started=$(find log -name "$p*.log" | wc -l)
+        finished=$(find log -name "$p*.log" -exec grep -l "finish" {} + | wc -l)
+        if [ "$finished" -lt "$started" ]; then
+            echo "[ERROR] $p - $((started-finished)) processes lost"
+            has_error=1
+        elif [ "$started" -gt 0 ]; then
+            echo "[OK] $p"
+        fi
+    done
+    if [ "$has_error" -ne 0 ]; then
+        false # raise non-zero exit code
+    fi
+}
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+
+rm -R -f fifo/*
+rm -R -f work/*
+mkdir work/kat/
+
+mkdir work/gul_S1_summaryaalcalc
+mkdir work/il_S1_summaryleccalc
+mkdir work/ri_S1_summaryleccalc
+
+mkfifo fifo/gul_P1
+
+mkfifo fifo/gul_S1_summary_P1
+mkfifo fifo/gul_S1_eltcalc_P1
+mkfifo fifo/gul_S1_summarycalc_P1
+mkfifo fifo/gul_S1_pltcalc_P1
+
+mkfifo fifo/il_P1
+
+mkfifo fifo/il_S1_summary_P1
+
+mkfifo fifo/ri_P1
+
+mkfifo fifo/ri_S1_summary_P1
+
+
+
+# --- Do reinsurance loss computes ---
+
+
+tee < fifo/ri_S1_summary_P1 work/ri_S1_summaryleccalc/P1.bin > /dev/null & pid1=$!
+
+( summarycalc -f -p RI_1 -1 fifo/ri_S1_summary_P1 < fifo/ri_P1 ) 2>> log/stderror.err  &
+
+# --- Do insured loss computes ---
+
+
+tee < fifo/il_S1_summary_P1 work/il_S1_summaryleccalc/P1.bin > /dev/null & pid2=$!
+
+( summarycalc -f  -1 fifo/il_S1_summary_P1 < fifo/il_P1 ) 2>> log/stderror.err  &
+
+# --- Do ground up loss computes ---
+
+( eltcalc < fifo/gul_S1_eltcalc_P1 > work/kat/gul_S1_eltcalc_P1 ) 2>> log/stderror.err & pid3=$!
+( summarycalctocsv < fifo/gul_S1_summarycalc_P1 > work/kat/gul_S1_summarycalc_P1 ) 2>> log/stderror.err & pid4=$!
+( pltcalc < fifo/gul_S1_pltcalc_P1 > work/kat/gul_S1_pltcalc_P1 ) 2>> log/stderror.err & pid5=$!
+
+tee < fifo/gul_S1_summary_P1 fifo/gul_S1_eltcalc_P1 fifo/gul_S1_summarycalc_P1 fifo/gul_S1_pltcalc_P1 work/gul_S1_summaryaalcalc/P1.bin > /dev/null & pid6=$!
+
+( summarycalc -i  -1 fifo/gul_S1_summary_P1 < fifo/gul_P1 ) 2>> log/stderror.err  &
+
+( eve 1 1 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee fifo/gul_P1 | fmcalc -a2 | tee fifo/il_P1 | fmcalc -a3 -n -p RI_1 > fifo/ri_P1 ) 2>> log/stderror.err &
+
+wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6
+
+
+# --- Do reinsurance loss kats ---
+
+
+# --- Do insured loss kats ---
+
+
+# --- Do ground up loss kats ---
+
+kat -s work/kat/gul_S1_eltcalc_P1 > output/gul_S1_eltcalc.csv & kpid1=$!
+kat work/kat/gul_S1_pltcalc_P1 > output/gul_S1_pltcalc.csv & kpid2=$!
+kat work/kat/gul_S1_summarycalc_P1 > output/gul_S1_summarycalc.csv & kpid3=$!
+wait $kpid1 $kpid2 $kpid3
+
+
+( ordleccalc -r -Kri_S1_summaryleccalc -F -f -S -s -M -m -W -w -O output/ri_S1_ept.csv -o output/ri_S1_psept.csv ) 2>> log/stderror.err & lpid1=$!
+( ordleccalc  -Kil_S1_summaryleccalc -F -S -s -M -m -O output/il_S1_ept.csv ) 2>> log/stderror.err & lpid2=$!
+( aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv ) 2>> log/stderror.err & lpid3=$!
+wait $lpid1 $lpid2 $lpid3
+
+rm -R -f work/*
+rm -R -f fifo/*
+
+check_complete
+exit_handler

--- a/tests/model_execution/err_kparse_reference/analysis_settings_5_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/analysis_settings_5_1_reins_layer_1_partition.sh
@@ -29,7 +29,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
    ps f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk -F: '$1>$script_pid' | grep -v celery | grep -v python | grep -v $group_pid | grep -v run_ktools)
+   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | grep -v *.sh)
    echo "$PIDS_KILL" >> log/killout.txt
    kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
    exit $exit_code

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_1_output_2_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_1_output_2_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_2_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_2_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/gul_il_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_no_lec_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/gul_il_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_no_lec_1_output_2_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/gul_il_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_no_lec_2_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/gul_il_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_no_lec_2_output_2_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/gul_il_ord_ept_psept_2_output_10_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_ord_ept_psept_2_output_10_partition.sh
@@ -1,0 +1,516 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+
+touch log/stderror.err
+ktools_monitor.sh $$ & pid0=$!
+
+exit_handler(){
+   exit_code=$?
+   kill -9 $pid0 2> /dev/null
+   if [ "$exit_code" -gt 0 ]; then
+       echo 'Ktools Run Error - exitcode='$exit_code
+   else
+       echo 'Run Completed'
+   fi
+
+   set +x
+   group_pid=$(ps -p $$ -o pgid --no-headers)
+   sess_pid=$(ps -p $$ -o sess --no-headers)
+   script_pid=$$
+   printf "Script PID:%d, GPID:%s, SPID:%d
+" $script_pid $group_pid $sess_pid >> log/killout.txt
+
+   ps f -g $sess_pid > log/subprocess_list
+   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk -F: '$1>$script_pid' | grep -v celery | grep -v python | grep -v $group_pid | grep -v run_ktools)
+   echo "$PIDS_KILL" >> log/killout.txt
+   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+   exit $exit_code
+}
+trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
+
+check_complete(){
+    set +e
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
+    has_error=0
+    for p in $proc_list; do
+        started=$(find log -name "$p*.log" | wc -l)
+        finished=$(find log -name "$p*.log" -exec grep -l "finish" {} + | wc -l)
+        if [ "$finished" -lt "$started" ]; then
+            echo "[ERROR] $p - $((started-finished)) processes lost"
+            has_error=1
+        elif [ "$started" -gt 0 ]; then
+            echo "[OK] $p"
+        fi
+    done
+    if [ "$has_error" -ne 0 ]; then
+        false # raise non-zero exit code
+    fi
+}
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+
+rm -R -f fifo/*
+rm -R -f work/*
+mkdir work/kat/
+
+mkdir work/gul_S1_summaryleccalc
+mkdir work/gul_S1_summaryaalcalc
+mkdir work/gul_S2_summaryleccalc
+mkdir work/gul_S2_summaryaalcalc
+mkdir work/il_S1_summaryleccalc
+mkdir work/il_S1_summaryaalcalc
+mkdir work/il_S2_summaryleccalc
+mkdir work/il_S2_summaryaalcalc
+
+mkfifo fifo/gul_P1
+mkfifo fifo/gul_P2
+mkfifo fifo/gul_P3
+mkfifo fifo/gul_P4
+mkfifo fifo/gul_P5
+mkfifo fifo/gul_P6
+mkfifo fifo/gul_P7
+mkfifo fifo/gul_P8
+mkfifo fifo/gul_P9
+mkfifo fifo/gul_P10
+
+mkfifo fifo/gul_S1_summary_P1
+mkfifo fifo/gul_S1_eltcalc_P1
+mkfifo fifo/gul_S1_summarycalc_P1
+mkfifo fifo/gul_S1_pltcalc_P1
+mkfifo fifo/gul_S2_summary_P1
+mkfifo fifo/gul_S2_eltcalc_P1
+mkfifo fifo/gul_S2_summarycalc_P1
+mkfifo fifo/gul_S2_pltcalc_P1
+
+mkfifo fifo/gul_S1_summary_P2
+mkfifo fifo/gul_S1_eltcalc_P2
+mkfifo fifo/gul_S1_summarycalc_P2
+mkfifo fifo/gul_S1_pltcalc_P2
+mkfifo fifo/gul_S2_summary_P2
+mkfifo fifo/gul_S2_eltcalc_P2
+mkfifo fifo/gul_S2_summarycalc_P2
+mkfifo fifo/gul_S2_pltcalc_P2
+
+mkfifo fifo/gul_S1_summary_P3
+mkfifo fifo/gul_S1_eltcalc_P3
+mkfifo fifo/gul_S1_summarycalc_P3
+mkfifo fifo/gul_S1_pltcalc_P3
+mkfifo fifo/gul_S2_summary_P3
+mkfifo fifo/gul_S2_eltcalc_P3
+mkfifo fifo/gul_S2_summarycalc_P3
+mkfifo fifo/gul_S2_pltcalc_P3
+
+mkfifo fifo/gul_S1_summary_P4
+mkfifo fifo/gul_S1_eltcalc_P4
+mkfifo fifo/gul_S1_summarycalc_P4
+mkfifo fifo/gul_S1_pltcalc_P4
+mkfifo fifo/gul_S2_summary_P4
+mkfifo fifo/gul_S2_eltcalc_P4
+mkfifo fifo/gul_S2_summarycalc_P4
+mkfifo fifo/gul_S2_pltcalc_P4
+
+mkfifo fifo/gul_S1_summary_P5
+mkfifo fifo/gul_S1_eltcalc_P5
+mkfifo fifo/gul_S1_summarycalc_P5
+mkfifo fifo/gul_S1_pltcalc_P5
+mkfifo fifo/gul_S2_summary_P5
+mkfifo fifo/gul_S2_eltcalc_P5
+mkfifo fifo/gul_S2_summarycalc_P5
+mkfifo fifo/gul_S2_pltcalc_P5
+
+mkfifo fifo/gul_S1_summary_P6
+mkfifo fifo/gul_S1_eltcalc_P6
+mkfifo fifo/gul_S1_summarycalc_P6
+mkfifo fifo/gul_S1_pltcalc_P6
+mkfifo fifo/gul_S2_summary_P6
+mkfifo fifo/gul_S2_eltcalc_P6
+mkfifo fifo/gul_S2_summarycalc_P6
+mkfifo fifo/gul_S2_pltcalc_P6
+
+mkfifo fifo/gul_S1_summary_P7
+mkfifo fifo/gul_S1_eltcalc_P7
+mkfifo fifo/gul_S1_summarycalc_P7
+mkfifo fifo/gul_S1_pltcalc_P7
+mkfifo fifo/gul_S2_summary_P7
+mkfifo fifo/gul_S2_eltcalc_P7
+mkfifo fifo/gul_S2_summarycalc_P7
+mkfifo fifo/gul_S2_pltcalc_P7
+
+mkfifo fifo/gul_S1_summary_P8
+mkfifo fifo/gul_S1_eltcalc_P8
+mkfifo fifo/gul_S1_summarycalc_P8
+mkfifo fifo/gul_S1_pltcalc_P8
+mkfifo fifo/gul_S2_summary_P8
+mkfifo fifo/gul_S2_eltcalc_P8
+mkfifo fifo/gul_S2_summarycalc_P8
+mkfifo fifo/gul_S2_pltcalc_P8
+
+mkfifo fifo/gul_S1_summary_P9
+mkfifo fifo/gul_S1_eltcalc_P9
+mkfifo fifo/gul_S1_summarycalc_P9
+mkfifo fifo/gul_S1_pltcalc_P9
+mkfifo fifo/gul_S2_summary_P9
+mkfifo fifo/gul_S2_eltcalc_P9
+mkfifo fifo/gul_S2_summarycalc_P9
+mkfifo fifo/gul_S2_pltcalc_P9
+
+mkfifo fifo/gul_S1_summary_P10
+mkfifo fifo/gul_S1_eltcalc_P10
+mkfifo fifo/gul_S1_summarycalc_P10
+mkfifo fifo/gul_S1_pltcalc_P10
+mkfifo fifo/gul_S2_summary_P10
+mkfifo fifo/gul_S2_eltcalc_P10
+mkfifo fifo/gul_S2_summarycalc_P10
+mkfifo fifo/gul_S2_pltcalc_P10
+
+mkfifo fifo/il_P1
+mkfifo fifo/il_P2
+mkfifo fifo/il_P3
+mkfifo fifo/il_P4
+mkfifo fifo/il_P5
+mkfifo fifo/il_P6
+mkfifo fifo/il_P7
+mkfifo fifo/il_P8
+mkfifo fifo/il_P9
+mkfifo fifo/il_P10
+
+mkfifo fifo/il_S1_summary_P1
+mkfifo fifo/il_S1_eltcalc_P1
+mkfifo fifo/il_S1_summarycalc_P1
+mkfifo fifo/il_S1_pltcalc_P1
+mkfifo fifo/il_S2_summary_P1
+mkfifo fifo/il_S2_eltcalc_P1
+mkfifo fifo/il_S2_summarycalc_P1
+mkfifo fifo/il_S2_pltcalc_P1
+
+mkfifo fifo/il_S1_summary_P2
+mkfifo fifo/il_S1_eltcalc_P2
+mkfifo fifo/il_S1_summarycalc_P2
+mkfifo fifo/il_S1_pltcalc_P2
+mkfifo fifo/il_S2_summary_P2
+mkfifo fifo/il_S2_eltcalc_P2
+mkfifo fifo/il_S2_summarycalc_P2
+mkfifo fifo/il_S2_pltcalc_P2
+
+mkfifo fifo/il_S1_summary_P3
+mkfifo fifo/il_S1_eltcalc_P3
+mkfifo fifo/il_S1_summarycalc_P3
+mkfifo fifo/il_S1_pltcalc_P3
+mkfifo fifo/il_S2_summary_P3
+mkfifo fifo/il_S2_eltcalc_P3
+mkfifo fifo/il_S2_summarycalc_P3
+mkfifo fifo/il_S2_pltcalc_P3
+
+mkfifo fifo/il_S1_summary_P4
+mkfifo fifo/il_S1_eltcalc_P4
+mkfifo fifo/il_S1_summarycalc_P4
+mkfifo fifo/il_S1_pltcalc_P4
+mkfifo fifo/il_S2_summary_P4
+mkfifo fifo/il_S2_eltcalc_P4
+mkfifo fifo/il_S2_summarycalc_P4
+mkfifo fifo/il_S2_pltcalc_P4
+
+mkfifo fifo/il_S1_summary_P5
+mkfifo fifo/il_S1_eltcalc_P5
+mkfifo fifo/il_S1_summarycalc_P5
+mkfifo fifo/il_S1_pltcalc_P5
+mkfifo fifo/il_S2_summary_P5
+mkfifo fifo/il_S2_eltcalc_P5
+mkfifo fifo/il_S2_summarycalc_P5
+mkfifo fifo/il_S2_pltcalc_P5
+
+mkfifo fifo/il_S1_summary_P6
+mkfifo fifo/il_S1_eltcalc_P6
+mkfifo fifo/il_S1_summarycalc_P6
+mkfifo fifo/il_S1_pltcalc_P6
+mkfifo fifo/il_S2_summary_P6
+mkfifo fifo/il_S2_eltcalc_P6
+mkfifo fifo/il_S2_summarycalc_P6
+mkfifo fifo/il_S2_pltcalc_P6
+
+mkfifo fifo/il_S1_summary_P7
+mkfifo fifo/il_S1_eltcalc_P7
+mkfifo fifo/il_S1_summarycalc_P7
+mkfifo fifo/il_S1_pltcalc_P7
+mkfifo fifo/il_S2_summary_P7
+mkfifo fifo/il_S2_eltcalc_P7
+mkfifo fifo/il_S2_summarycalc_P7
+mkfifo fifo/il_S2_pltcalc_P7
+
+mkfifo fifo/il_S1_summary_P8
+mkfifo fifo/il_S1_eltcalc_P8
+mkfifo fifo/il_S1_summarycalc_P8
+mkfifo fifo/il_S1_pltcalc_P8
+mkfifo fifo/il_S2_summary_P8
+mkfifo fifo/il_S2_eltcalc_P8
+mkfifo fifo/il_S2_summarycalc_P8
+mkfifo fifo/il_S2_pltcalc_P8
+
+mkfifo fifo/il_S1_summary_P9
+mkfifo fifo/il_S1_eltcalc_P9
+mkfifo fifo/il_S1_summarycalc_P9
+mkfifo fifo/il_S1_pltcalc_P9
+mkfifo fifo/il_S2_summary_P9
+mkfifo fifo/il_S2_eltcalc_P9
+mkfifo fifo/il_S2_summarycalc_P9
+mkfifo fifo/il_S2_pltcalc_P9
+
+mkfifo fifo/il_S1_summary_P10
+mkfifo fifo/il_S1_eltcalc_P10
+mkfifo fifo/il_S1_summarycalc_P10
+mkfifo fifo/il_S1_pltcalc_P10
+mkfifo fifo/il_S2_summary_P10
+mkfifo fifo/il_S2_eltcalc_P10
+mkfifo fifo/il_S2_summarycalc_P10
+mkfifo fifo/il_S2_pltcalc_P10
+
+
+
+# --- Do insured loss computes ---
+
+( eltcalc < fifo/il_S1_eltcalc_P1 > work/kat/il_S1_eltcalc_P1 ) 2>> log/stderror.err & pid1=$!
+( summarycalctocsv < fifo/il_S1_summarycalc_P1 > work/kat/il_S1_summarycalc_P1 ) 2>> log/stderror.err & pid2=$!
+( pltcalc < fifo/il_S1_pltcalc_P1 > work/kat/il_S1_pltcalc_P1 ) 2>> log/stderror.err & pid3=$!
+( eltcalc < fifo/il_S2_eltcalc_P1 > work/kat/il_S2_eltcalc_P1 ) 2>> log/stderror.err & pid4=$!
+( summarycalctocsv < fifo/il_S2_summarycalc_P1 > work/kat/il_S2_summarycalc_P1 ) 2>> log/stderror.err & pid5=$!
+( pltcalc < fifo/il_S2_pltcalc_P1 > work/kat/il_S2_pltcalc_P1 ) 2>> log/stderror.err & pid6=$!
+( eltcalc -s < fifo/il_S1_eltcalc_P2 > work/kat/il_S1_eltcalc_P2 ) 2>> log/stderror.err & pid7=$!
+( summarycalctocsv -s < fifo/il_S1_summarycalc_P2 > work/kat/il_S1_summarycalc_P2 ) 2>> log/stderror.err & pid8=$!
+( pltcalc -s < fifo/il_S1_pltcalc_P2 > work/kat/il_S1_pltcalc_P2 ) 2>> log/stderror.err & pid9=$!
+( eltcalc -s < fifo/il_S2_eltcalc_P2 > work/kat/il_S2_eltcalc_P2 ) 2>> log/stderror.err & pid10=$!
+( summarycalctocsv -s < fifo/il_S2_summarycalc_P2 > work/kat/il_S2_summarycalc_P2 ) 2>> log/stderror.err & pid11=$!
+( pltcalc -s < fifo/il_S2_pltcalc_P2 > work/kat/il_S2_pltcalc_P2 ) 2>> log/stderror.err & pid12=$!
+( eltcalc -s < fifo/il_S1_eltcalc_P3 > work/kat/il_S1_eltcalc_P3 ) 2>> log/stderror.err & pid13=$!
+( summarycalctocsv -s < fifo/il_S1_summarycalc_P3 > work/kat/il_S1_summarycalc_P3 ) 2>> log/stderror.err & pid14=$!
+( pltcalc -s < fifo/il_S1_pltcalc_P3 > work/kat/il_S1_pltcalc_P3 ) 2>> log/stderror.err & pid15=$!
+( eltcalc -s < fifo/il_S2_eltcalc_P3 > work/kat/il_S2_eltcalc_P3 ) 2>> log/stderror.err & pid16=$!
+( summarycalctocsv -s < fifo/il_S2_summarycalc_P3 > work/kat/il_S2_summarycalc_P3 ) 2>> log/stderror.err & pid17=$!
+( pltcalc -s < fifo/il_S2_pltcalc_P3 > work/kat/il_S2_pltcalc_P3 ) 2>> log/stderror.err & pid18=$!
+( eltcalc -s < fifo/il_S1_eltcalc_P4 > work/kat/il_S1_eltcalc_P4 ) 2>> log/stderror.err & pid19=$!
+( summarycalctocsv -s < fifo/il_S1_summarycalc_P4 > work/kat/il_S1_summarycalc_P4 ) 2>> log/stderror.err & pid20=$!
+( pltcalc -s < fifo/il_S1_pltcalc_P4 > work/kat/il_S1_pltcalc_P4 ) 2>> log/stderror.err & pid21=$!
+( eltcalc -s < fifo/il_S2_eltcalc_P4 > work/kat/il_S2_eltcalc_P4 ) 2>> log/stderror.err & pid22=$!
+( summarycalctocsv -s < fifo/il_S2_summarycalc_P4 > work/kat/il_S2_summarycalc_P4 ) 2>> log/stderror.err & pid23=$!
+( pltcalc -s < fifo/il_S2_pltcalc_P4 > work/kat/il_S2_pltcalc_P4 ) 2>> log/stderror.err & pid24=$!
+( eltcalc -s < fifo/il_S1_eltcalc_P5 > work/kat/il_S1_eltcalc_P5 ) 2>> log/stderror.err & pid25=$!
+( summarycalctocsv -s < fifo/il_S1_summarycalc_P5 > work/kat/il_S1_summarycalc_P5 ) 2>> log/stderror.err & pid26=$!
+( pltcalc -s < fifo/il_S1_pltcalc_P5 > work/kat/il_S1_pltcalc_P5 ) 2>> log/stderror.err & pid27=$!
+( eltcalc -s < fifo/il_S2_eltcalc_P5 > work/kat/il_S2_eltcalc_P5 ) 2>> log/stderror.err & pid28=$!
+( summarycalctocsv -s < fifo/il_S2_summarycalc_P5 > work/kat/il_S2_summarycalc_P5 ) 2>> log/stderror.err & pid29=$!
+( pltcalc -s < fifo/il_S2_pltcalc_P5 > work/kat/il_S2_pltcalc_P5 ) 2>> log/stderror.err & pid30=$!
+( eltcalc -s < fifo/il_S1_eltcalc_P6 > work/kat/il_S1_eltcalc_P6 ) 2>> log/stderror.err & pid31=$!
+( summarycalctocsv -s < fifo/il_S1_summarycalc_P6 > work/kat/il_S1_summarycalc_P6 ) 2>> log/stderror.err & pid32=$!
+( pltcalc -s < fifo/il_S1_pltcalc_P6 > work/kat/il_S1_pltcalc_P6 ) 2>> log/stderror.err & pid33=$!
+( eltcalc -s < fifo/il_S2_eltcalc_P6 > work/kat/il_S2_eltcalc_P6 ) 2>> log/stderror.err & pid34=$!
+( summarycalctocsv -s < fifo/il_S2_summarycalc_P6 > work/kat/il_S2_summarycalc_P6 ) 2>> log/stderror.err & pid35=$!
+( pltcalc -s < fifo/il_S2_pltcalc_P6 > work/kat/il_S2_pltcalc_P6 ) 2>> log/stderror.err & pid36=$!
+( eltcalc -s < fifo/il_S1_eltcalc_P7 > work/kat/il_S1_eltcalc_P7 ) 2>> log/stderror.err & pid37=$!
+( summarycalctocsv -s < fifo/il_S1_summarycalc_P7 > work/kat/il_S1_summarycalc_P7 ) 2>> log/stderror.err & pid38=$!
+( pltcalc -s < fifo/il_S1_pltcalc_P7 > work/kat/il_S1_pltcalc_P7 ) 2>> log/stderror.err & pid39=$!
+( eltcalc -s < fifo/il_S2_eltcalc_P7 > work/kat/il_S2_eltcalc_P7 ) 2>> log/stderror.err & pid40=$!
+( summarycalctocsv -s < fifo/il_S2_summarycalc_P7 > work/kat/il_S2_summarycalc_P7 ) 2>> log/stderror.err & pid41=$!
+( pltcalc -s < fifo/il_S2_pltcalc_P7 > work/kat/il_S2_pltcalc_P7 ) 2>> log/stderror.err & pid42=$!
+( eltcalc -s < fifo/il_S1_eltcalc_P8 > work/kat/il_S1_eltcalc_P8 ) 2>> log/stderror.err & pid43=$!
+( summarycalctocsv -s < fifo/il_S1_summarycalc_P8 > work/kat/il_S1_summarycalc_P8 ) 2>> log/stderror.err & pid44=$!
+( pltcalc -s < fifo/il_S1_pltcalc_P8 > work/kat/il_S1_pltcalc_P8 ) 2>> log/stderror.err & pid45=$!
+( eltcalc -s < fifo/il_S2_eltcalc_P8 > work/kat/il_S2_eltcalc_P8 ) 2>> log/stderror.err & pid46=$!
+( summarycalctocsv -s < fifo/il_S2_summarycalc_P8 > work/kat/il_S2_summarycalc_P8 ) 2>> log/stderror.err & pid47=$!
+( pltcalc -s < fifo/il_S2_pltcalc_P8 > work/kat/il_S2_pltcalc_P8 ) 2>> log/stderror.err & pid48=$!
+( eltcalc -s < fifo/il_S1_eltcalc_P9 > work/kat/il_S1_eltcalc_P9 ) 2>> log/stderror.err & pid49=$!
+( summarycalctocsv -s < fifo/il_S1_summarycalc_P9 > work/kat/il_S1_summarycalc_P9 ) 2>> log/stderror.err & pid50=$!
+( pltcalc -s < fifo/il_S1_pltcalc_P9 > work/kat/il_S1_pltcalc_P9 ) 2>> log/stderror.err & pid51=$!
+( eltcalc -s < fifo/il_S2_eltcalc_P9 > work/kat/il_S2_eltcalc_P9 ) 2>> log/stderror.err & pid52=$!
+( summarycalctocsv -s < fifo/il_S2_summarycalc_P9 > work/kat/il_S2_summarycalc_P9 ) 2>> log/stderror.err & pid53=$!
+( pltcalc -s < fifo/il_S2_pltcalc_P9 > work/kat/il_S2_pltcalc_P9 ) 2>> log/stderror.err & pid54=$!
+( eltcalc -s < fifo/il_S1_eltcalc_P10 > work/kat/il_S1_eltcalc_P10 ) 2>> log/stderror.err & pid55=$!
+( summarycalctocsv -s < fifo/il_S1_summarycalc_P10 > work/kat/il_S1_summarycalc_P10 ) 2>> log/stderror.err & pid56=$!
+( pltcalc -s < fifo/il_S1_pltcalc_P10 > work/kat/il_S1_pltcalc_P10 ) 2>> log/stderror.err & pid57=$!
+( eltcalc -s < fifo/il_S2_eltcalc_P10 > work/kat/il_S2_eltcalc_P10 ) 2>> log/stderror.err & pid58=$!
+( summarycalctocsv -s < fifo/il_S2_summarycalc_P10 > work/kat/il_S2_summarycalc_P10 ) 2>> log/stderror.err & pid59=$!
+( pltcalc -s < fifo/il_S2_pltcalc_P10 > work/kat/il_S2_pltcalc_P10 ) 2>> log/stderror.err & pid60=$!
+
+tee < fifo/il_S1_summary_P1 fifo/il_S1_eltcalc_P1 fifo/il_S1_summarycalc_P1 fifo/il_S1_pltcalc_P1 work/il_S1_summaryaalcalc/P1.bin work/il_S1_summaryleccalc/P1.bin > /dev/null & pid61=$!
+tee < fifo/il_S2_summary_P1 fifo/il_S2_eltcalc_P1 fifo/il_S2_summarycalc_P1 fifo/il_S2_pltcalc_P1 work/il_S2_summaryaalcalc/P1.bin work/il_S2_summaryleccalc/P1.bin > /dev/null & pid62=$!
+tee < fifo/il_S1_summary_P2 fifo/il_S1_eltcalc_P2 fifo/il_S1_summarycalc_P2 fifo/il_S1_pltcalc_P2 work/il_S1_summaryaalcalc/P2.bin work/il_S1_summaryleccalc/P2.bin > /dev/null & pid63=$!
+tee < fifo/il_S2_summary_P2 fifo/il_S2_eltcalc_P2 fifo/il_S2_summarycalc_P2 fifo/il_S2_pltcalc_P2 work/il_S2_summaryaalcalc/P2.bin work/il_S2_summaryleccalc/P2.bin > /dev/null & pid64=$!
+tee < fifo/il_S1_summary_P3 fifo/il_S1_eltcalc_P3 fifo/il_S1_summarycalc_P3 fifo/il_S1_pltcalc_P3 work/il_S1_summaryaalcalc/P3.bin work/il_S1_summaryleccalc/P3.bin > /dev/null & pid65=$!
+tee < fifo/il_S2_summary_P3 fifo/il_S2_eltcalc_P3 fifo/il_S2_summarycalc_P3 fifo/il_S2_pltcalc_P3 work/il_S2_summaryaalcalc/P3.bin work/il_S2_summaryleccalc/P3.bin > /dev/null & pid66=$!
+tee < fifo/il_S1_summary_P4 fifo/il_S1_eltcalc_P4 fifo/il_S1_summarycalc_P4 fifo/il_S1_pltcalc_P4 work/il_S1_summaryaalcalc/P4.bin work/il_S1_summaryleccalc/P4.bin > /dev/null & pid67=$!
+tee < fifo/il_S2_summary_P4 fifo/il_S2_eltcalc_P4 fifo/il_S2_summarycalc_P4 fifo/il_S2_pltcalc_P4 work/il_S2_summaryaalcalc/P4.bin work/il_S2_summaryleccalc/P4.bin > /dev/null & pid68=$!
+tee < fifo/il_S1_summary_P5 fifo/il_S1_eltcalc_P5 fifo/il_S1_summarycalc_P5 fifo/il_S1_pltcalc_P5 work/il_S1_summaryaalcalc/P5.bin work/il_S1_summaryleccalc/P5.bin > /dev/null & pid69=$!
+tee < fifo/il_S2_summary_P5 fifo/il_S2_eltcalc_P5 fifo/il_S2_summarycalc_P5 fifo/il_S2_pltcalc_P5 work/il_S2_summaryaalcalc/P5.bin work/il_S2_summaryleccalc/P5.bin > /dev/null & pid70=$!
+tee < fifo/il_S1_summary_P6 fifo/il_S1_eltcalc_P6 fifo/il_S1_summarycalc_P6 fifo/il_S1_pltcalc_P6 work/il_S1_summaryaalcalc/P6.bin work/il_S1_summaryleccalc/P6.bin > /dev/null & pid71=$!
+tee < fifo/il_S2_summary_P6 fifo/il_S2_eltcalc_P6 fifo/il_S2_summarycalc_P6 fifo/il_S2_pltcalc_P6 work/il_S2_summaryaalcalc/P6.bin work/il_S2_summaryleccalc/P6.bin > /dev/null & pid72=$!
+tee < fifo/il_S1_summary_P7 fifo/il_S1_eltcalc_P7 fifo/il_S1_summarycalc_P7 fifo/il_S1_pltcalc_P7 work/il_S1_summaryaalcalc/P7.bin work/il_S1_summaryleccalc/P7.bin > /dev/null & pid73=$!
+tee < fifo/il_S2_summary_P7 fifo/il_S2_eltcalc_P7 fifo/il_S2_summarycalc_P7 fifo/il_S2_pltcalc_P7 work/il_S2_summaryaalcalc/P7.bin work/il_S2_summaryleccalc/P7.bin > /dev/null & pid74=$!
+tee < fifo/il_S1_summary_P8 fifo/il_S1_eltcalc_P8 fifo/il_S1_summarycalc_P8 fifo/il_S1_pltcalc_P8 work/il_S1_summaryaalcalc/P8.bin work/il_S1_summaryleccalc/P8.bin > /dev/null & pid75=$!
+tee < fifo/il_S2_summary_P8 fifo/il_S2_eltcalc_P8 fifo/il_S2_summarycalc_P8 fifo/il_S2_pltcalc_P8 work/il_S2_summaryaalcalc/P8.bin work/il_S2_summaryleccalc/P8.bin > /dev/null & pid76=$!
+tee < fifo/il_S1_summary_P9 fifo/il_S1_eltcalc_P9 fifo/il_S1_summarycalc_P9 fifo/il_S1_pltcalc_P9 work/il_S1_summaryaalcalc/P9.bin work/il_S1_summaryleccalc/P9.bin > /dev/null & pid77=$!
+tee < fifo/il_S2_summary_P9 fifo/il_S2_eltcalc_P9 fifo/il_S2_summarycalc_P9 fifo/il_S2_pltcalc_P9 work/il_S2_summaryaalcalc/P9.bin work/il_S2_summaryleccalc/P9.bin > /dev/null & pid78=$!
+tee < fifo/il_S1_summary_P10 fifo/il_S1_eltcalc_P10 fifo/il_S1_summarycalc_P10 fifo/il_S1_pltcalc_P10 work/il_S1_summaryaalcalc/P10.bin work/il_S1_summaryleccalc/P10.bin > /dev/null & pid79=$!
+tee < fifo/il_S2_summary_P10 fifo/il_S2_eltcalc_P10 fifo/il_S2_summarycalc_P10 fifo/il_S2_pltcalc_P10 work/il_S2_summaryaalcalc/P10.bin work/il_S2_summaryleccalc/P10.bin > /dev/null & pid80=$!
+
+( summarycalc -f  -1 fifo/il_S1_summary_P1 -2 fifo/il_S2_summary_P1 < fifo/il_P1 ) 2>> log/stderror.err  &
+( summarycalc -f  -1 fifo/il_S1_summary_P2 -2 fifo/il_S2_summary_P2 < fifo/il_P2 ) 2>> log/stderror.err  &
+( summarycalc -f  -1 fifo/il_S1_summary_P3 -2 fifo/il_S2_summary_P3 < fifo/il_P3 ) 2>> log/stderror.err  &
+( summarycalc -f  -1 fifo/il_S1_summary_P4 -2 fifo/il_S2_summary_P4 < fifo/il_P4 ) 2>> log/stderror.err  &
+( summarycalc -f  -1 fifo/il_S1_summary_P5 -2 fifo/il_S2_summary_P5 < fifo/il_P5 ) 2>> log/stderror.err  &
+( summarycalc -f  -1 fifo/il_S1_summary_P6 -2 fifo/il_S2_summary_P6 < fifo/il_P6 ) 2>> log/stderror.err  &
+( summarycalc -f  -1 fifo/il_S1_summary_P7 -2 fifo/il_S2_summary_P7 < fifo/il_P7 ) 2>> log/stderror.err  &
+( summarycalc -f  -1 fifo/il_S1_summary_P8 -2 fifo/il_S2_summary_P8 < fifo/il_P8 ) 2>> log/stderror.err  &
+( summarycalc -f  -1 fifo/il_S1_summary_P9 -2 fifo/il_S2_summary_P9 < fifo/il_P9 ) 2>> log/stderror.err  &
+( summarycalc -f  -1 fifo/il_S1_summary_P10 -2 fifo/il_S2_summary_P10 < fifo/il_P10 ) 2>> log/stderror.err  &
+
+# --- Do ground up loss computes ---
+
+( eltcalc < fifo/gul_S1_eltcalc_P1 > work/kat/gul_S1_eltcalc_P1 ) 2>> log/stderror.err & pid81=$!
+( summarycalctocsv < fifo/gul_S1_summarycalc_P1 > work/kat/gul_S1_summarycalc_P1 ) 2>> log/stderror.err & pid82=$!
+( pltcalc < fifo/gul_S1_pltcalc_P1 > work/kat/gul_S1_pltcalc_P1 ) 2>> log/stderror.err & pid83=$!
+( eltcalc < fifo/gul_S2_eltcalc_P1 > work/kat/gul_S2_eltcalc_P1 ) 2>> log/stderror.err & pid84=$!
+( summarycalctocsv < fifo/gul_S2_summarycalc_P1 > work/kat/gul_S2_summarycalc_P1 ) 2>> log/stderror.err & pid85=$!
+( pltcalc < fifo/gul_S2_pltcalc_P1 > work/kat/gul_S2_pltcalc_P1 ) 2>> log/stderror.err & pid86=$!
+( eltcalc -s < fifo/gul_S1_eltcalc_P2 > work/kat/gul_S1_eltcalc_P2 ) 2>> log/stderror.err & pid87=$!
+( summarycalctocsv -s < fifo/gul_S1_summarycalc_P2 > work/kat/gul_S1_summarycalc_P2 ) 2>> log/stderror.err & pid88=$!
+( pltcalc -s < fifo/gul_S1_pltcalc_P2 > work/kat/gul_S1_pltcalc_P2 ) 2>> log/stderror.err & pid89=$!
+( eltcalc -s < fifo/gul_S2_eltcalc_P2 > work/kat/gul_S2_eltcalc_P2 ) 2>> log/stderror.err & pid90=$!
+( summarycalctocsv -s < fifo/gul_S2_summarycalc_P2 > work/kat/gul_S2_summarycalc_P2 ) 2>> log/stderror.err & pid91=$!
+( pltcalc -s < fifo/gul_S2_pltcalc_P2 > work/kat/gul_S2_pltcalc_P2 ) 2>> log/stderror.err & pid92=$!
+( eltcalc -s < fifo/gul_S1_eltcalc_P3 > work/kat/gul_S1_eltcalc_P3 ) 2>> log/stderror.err & pid93=$!
+( summarycalctocsv -s < fifo/gul_S1_summarycalc_P3 > work/kat/gul_S1_summarycalc_P3 ) 2>> log/stderror.err & pid94=$!
+( pltcalc -s < fifo/gul_S1_pltcalc_P3 > work/kat/gul_S1_pltcalc_P3 ) 2>> log/stderror.err & pid95=$!
+( eltcalc -s < fifo/gul_S2_eltcalc_P3 > work/kat/gul_S2_eltcalc_P3 ) 2>> log/stderror.err & pid96=$!
+( summarycalctocsv -s < fifo/gul_S2_summarycalc_P3 > work/kat/gul_S2_summarycalc_P3 ) 2>> log/stderror.err & pid97=$!
+( pltcalc -s < fifo/gul_S2_pltcalc_P3 > work/kat/gul_S2_pltcalc_P3 ) 2>> log/stderror.err & pid98=$!
+( eltcalc -s < fifo/gul_S1_eltcalc_P4 > work/kat/gul_S1_eltcalc_P4 ) 2>> log/stderror.err & pid99=$!
+( summarycalctocsv -s < fifo/gul_S1_summarycalc_P4 > work/kat/gul_S1_summarycalc_P4 ) 2>> log/stderror.err & pid100=$!
+( pltcalc -s < fifo/gul_S1_pltcalc_P4 > work/kat/gul_S1_pltcalc_P4 ) 2>> log/stderror.err & pid101=$!
+( eltcalc -s < fifo/gul_S2_eltcalc_P4 > work/kat/gul_S2_eltcalc_P4 ) 2>> log/stderror.err & pid102=$!
+( summarycalctocsv -s < fifo/gul_S2_summarycalc_P4 > work/kat/gul_S2_summarycalc_P4 ) 2>> log/stderror.err & pid103=$!
+( pltcalc -s < fifo/gul_S2_pltcalc_P4 > work/kat/gul_S2_pltcalc_P4 ) 2>> log/stderror.err & pid104=$!
+( eltcalc -s < fifo/gul_S1_eltcalc_P5 > work/kat/gul_S1_eltcalc_P5 ) 2>> log/stderror.err & pid105=$!
+( summarycalctocsv -s < fifo/gul_S1_summarycalc_P5 > work/kat/gul_S1_summarycalc_P5 ) 2>> log/stderror.err & pid106=$!
+( pltcalc -s < fifo/gul_S1_pltcalc_P5 > work/kat/gul_S1_pltcalc_P5 ) 2>> log/stderror.err & pid107=$!
+( eltcalc -s < fifo/gul_S2_eltcalc_P5 > work/kat/gul_S2_eltcalc_P5 ) 2>> log/stderror.err & pid108=$!
+( summarycalctocsv -s < fifo/gul_S2_summarycalc_P5 > work/kat/gul_S2_summarycalc_P5 ) 2>> log/stderror.err & pid109=$!
+( pltcalc -s < fifo/gul_S2_pltcalc_P5 > work/kat/gul_S2_pltcalc_P5 ) 2>> log/stderror.err & pid110=$!
+( eltcalc -s < fifo/gul_S1_eltcalc_P6 > work/kat/gul_S1_eltcalc_P6 ) 2>> log/stderror.err & pid111=$!
+( summarycalctocsv -s < fifo/gul_S1_summarycalc_P6 > work/kat/gul_S1_summarycalc_P6 ) 2>> log/stderror.err & pid112=$!
+( pltcalc -s < fifo/gul_S1_pltcalc_P6 > work/kat/gul_S1_pltcalc_P6 ) 2>> log/stderror.err & pid113=$!
+( eltcalc -s < fifo/gul_S2_eltcalc_P6 > work/kat/gul_S2_eltcalc_P6 ) 2>> log/stderror.err & pid114=$!
+( summarycalctocsv -s < fifo/gul_S2_summarycalc_P6 > work/kat/gul_S2_summarycalc_P6 ) 2>> log/stderror.err & pid115=$!
+( pltcalc -s < fifo/gul_S2_pltcalc_P6 > work/kat/gul_S2_pltcalc_P6 ) 2>> log/stderror.err & pid116=$!
+( eltcalc -s < fifo/gul_S1_eltcalc_P7 > work/kat/gul_S1_eltcalc_P7 ) 2>> log/stderror.err & pid117=$!
+( summarycalctocsv -s < fifo/gul_S1_summarycalc_P7 > work/kat/gul_S1_summarycalc_P7 ) 2>> log/stderror.err & pid118=$!
+( pltcalc -s < fifo/gul_S1_pltcalc_P7 > work/kat/gul_S1_pltcalc_P7 ) 2>> log/stderror.err & pid119=$!
+( eltcalc -s < fifo/gul_S2_eltcalc_P7 > work/kat/gul_S2_eltcalc_P7 ) 2>> log/stderror.err & pid120=$!
+( summarycalctocsv -s < fifo/gul_S2_summarycalc_P7 > work/kat/gul_S2_summarycalc_P7 ) 2>> log/stderror.err & pid121=$!
+( pltcalc -s < fifo/gul_S2_pltcalc_P7 > work/kat/gul_S2_pltcalc_P7 ) 2>> log/stderror.err & pid122=$!
+( eltcalc -s < fifo/gul_S1_eltcalc_P8 > work/kat/gul_S1_eltcalc_P8 ) 2>> log/stderror.err & pid123=$!
+( summarycalctocsv -s < fifo/gul_S1_summarycalc_P8 > work/kat/gul_S1_summarycalc_P8 ) 2>> log/stderror.err & pid124=$!
+( pltcalc -s < fifo/gul_S1_pltcalc_P8 > work/kat/gul_S1_pltcalc_P8 ) 2>> log/stderror.err & pid125=$!
+( eltcalc -s < fifo/gul_S2_eltcalc_P8 > work/kat/gul_S2_eltcalc_P8 ) 2>> log/stderror.err & pid126=$!
+( summarycalctocsv -s < fifo/gul_S2_summarycalc_P8 > work/kat/gul_S2_summarycalc_P8 ) 2>> log/stderror.err & pid127=$!
+( pltcalc -s < fifo/gul_S2_pltcalc_P8 > work/kat/gul_S2_pltcalc_P8 ) 2>> log/stderror.err & pid128=$!
+( eltcalc -s < fifo/gul_S1_eltcalc_P9 > work/kat/gul_S1_eltcalc_P9 ) 2>> log/stderror.err & pid129=$!
+( summarycalctocsv -s < fifo/gul_S1_summarycalc_P9 > work/kat/gul_S1_summarycalc_P9 ) 2>> log/stderror.err & pid130=$!
+( pltcalc -s < fifo/gul_S1_pltcalc_P9 > work/kat/gul_S1_pltcalc_P9 ) 2>> log/stderror.err & pid131=$!
+( eltcalc -s < fifo/gul_S2_eltcalc_P9 > work/kat/gul_S2_eltcalc_P9 ) 2>> log/stderror.err & pid132=$!
+( summarycalctocsv -s < fifo/gul_S2_summarycalc_P9 > work/kat/gul_S2_summarycalc_P9 ) 2>> log/stderror.err & pid133=$!
+( pltcalc -s < fifo/gul_S2_pltcalc_P9 > work/kat/gul_S2_pltcalc_P9 ) 2>> log/stderror.err & pid134=$!
+( eltcalc -s < fifo/gul_S1_eltcalc_P10 > work/kat/gul_S1_eltcalc_P10 ) 2>> log/stderror.err & pid135=$!
+( summarycalctocsv -s < fifo/gul_S1_summarycalc_P10 > work/kat/gul_S1_summarycalc_P10 ) 2>> log/stderror.err & pid136=$!
+( pltcalc -s < fifo/gul_S1_pltcalc_P10 > work/kat/gul_S1_pltcalc_P10 ) 2>> log/stderror.err & pid137=$!
+( eltcalc -s < fifo/gul_S2_eltcalc_P10 > work/kat/gul_S2_eltcalc_P10 ) 2>> log/stderror.err & pid138=$!
+( summarycalctocsv -s < fifo/gul_S2_summarycalc_P10 > work/kat/gul_S2_summarycalc_P10 ) 2>> log/stderror.err & pid139=$!
+( pltcalc -s < fifo/gul_S2_pltcalc_P10 > work/kat/gul_S2_pltcalc_P10 ) 2>> log/stderror.err & pid140=$!
+
+tee < fifo/gul_S1_summary_P1 fifo/gul_S1_eltcalc_P1 fifo/gul_S1_summarycalc_P1 fifo/gul_S1_pltcalc_P1 work/gul_S1_summaryaalcalc/P1.bin work/gul_S1_summaryleccalc/P1.bin > /dev/null & pid141=$!
+tee < fifo/gul_S2_summary_P1 fifo/gul_S2_eltcalc_P1 fifo/gul_S2_summarycalc_P1 fifo/gul_S2_pltcalc_P1 work/gul_S2_summaryaalcalc/P1.bin work/gul_S2_summaryleccalc/P1.bin > /dev/null & pid142=$!
+tee < fifo/gul_S1_summary_P2 fifo/gul_S1_eltcalc_P2 fifo/gul_S1_summarycalc_P2 fifo/gul_S1_pltcalc_P2 work/gul_S1_summaryaalcalc/P2.bin work/gul_S1_summaryleccalc/P2.bin > /dev/null & pid143=$!
+tee < fifo/gul_S2_summary_P2 fifo/gul_S2_eltcalc_P2 fifo/gul_S2_summarycalc_P2 fifo/gul_S2_pltcalc_P2 work/gul_S2_summaryaalcalc/P2.bin work/gul_S2_summaryleccalc/P2.bin > /dev/null & pid144=$!
+tee < fifo/gul_S1_summary_P3 fifo/gul_S1_eltcalc_P3 fifo/gul_S1_summarycalc_P3 fifo/gul_S1_pltcalc_P3 work/gul_S1_summaryaalcalc/P3.bin work/gul_S1_summaryleccalc/P3.bin > /dev/null & pid145=$!
+tee < fifo/gul_S2_summary_P3 fifo/gul_S2_eltcalc_P3 fifo/gul_S2_summarycalc_P3 fifo/gul_S2_pltcalc_P3 work/gul_S2_summaryaalcalc/P3.bin work/gul_S2_summaryleccalc/P3.bin > /dev/null & pid146=$!
+tee < fifo/gul_S1_summary_P4 fifo/gul_S1_eltcalc_P4 fifo/gul_S1_summarycalc_P4 fifo/gul_S1_pltcalc_P4 work/gul_S1_summaryaalcalc/P4.bin work/gul_S1_summaryleccalc/P4.bin > /dev/null & pid147=$!
+tee < fifo/gul_S2_summary_P4 fifo/gul_S2_eltcalc_P4 fifo/gul_S2_summarycalc_P4 fifo/gul_S2_pltcalc_P4 work/gul_S2_summaryaalcalc/P4.bin work/gul_S2_summaryleccalc/P4.bin > /dev/null & pid148=$!
+tee < fifo/gul_S1_summary_P5 fifo/gul_S1_eltcalc_P5 fifo/gul_S1_summarycalc_P5 fifo/gul_S1_pltcalc_P5 work/gul_S1_summaryaalcalc/P5.bin work/gul_S1_summaryleccalc/P5.bin > /dev/null & pid149=$!
+tee < fifo/gul_S2_summary_P5 fifo/gul_S2_eltcalc_P5 fifo/gul_S2_summarycalc_P5 fifo/gul_S2_pltcalc_P5 work/gul_S2_summaryaalcalc/P5.bin work/gul_S2_summaryleccalc/P5.bin > /dev/null & pid150=$!
+tee < fifo/gul_S1_summary_P6 fifo/gul_S1_eltcalc_P6 fifo/gul_S1_summarycalc_P6 fifo/gul_S1_pltcalc_P6 work/gul_S1_summaryaalcalc/P6.bin work/gul_S1_summaryleccalc/P6.bin > /dev/null & pid151=$!
+tee < fifo/gul_S2_summary_P6 fifo/gul_S2_eltcalc_P6 fifo/gul_S2_summarycalc_P6 fifo/gul_S2_pltcalc_P6 work/gul_S2_summaryaalcalc/P6.bin work/gul_S2_summaryleccalc/P6.bin > /dev/null & pid152=$!
+tee < fifo/gul_S1_summary_P7 fifo/gul_S1_eltcalc_P7 fifo/gul_S1_summarycalc_P7 fifo/gul_S1_pltcalc_P7 work/gul_S1_summaryaalcalc/P7.bin work/gul_S1_summaryleccalc/P7.bin > /dev/null & pid153=$!
+tee < fifo/gul_S2_summary_P7 fifo/gul_S2_eltcalc_P7 fifo/gul_S2_summarycalc_P7 fifo/gul_S2_pltcalc_P7 work/gul_S2_summaryaalcalc/P7.bin work/gul_S2_summaryleccalc/P7.bin > /dev/null & pid154=$!
+tee < fifo/gul_S1_summary_P8 fifo/gul_S1_eltcalc_P8 fifo/gul_S1_summarycalc_P8 fifo/gul_S1_pltcalc_P8 work/gul_S1_summaryaalcalc/P8.bin work/gul_S1_summaryleccalc/P8.bin > /dev/null & pid155=$!
+tee < fifo/gul_S2_summary_P8 fifo/gul_S2_eltcalc_P8 fifo/gul_S2_summarycalc_P8 fifo/gul_S2_pltcalc_P8 work/gul_S2_summaryaalcalc/P8.bin work/gul_S2_summaryleccalc/P8.bin > /dev/null & pid156=$!
+tee < fifo/gul_S1_summary_P9 fifo/gul_S1_eltcalc_P9 fifo/gul_S1_summarycalc_P9 fifo/gul_S1_pltcalc_P9 work/gul_S1_summaryaalcalc/P9.bin work/gul_S1_summaryleccalc/P9.bin > /dev/null & pid157=$!
+tee < fifo/gul_S2_summary_P9 fifo/gul_S2_eltcalc_P9 fifo/gul_S2_summarycalc_P9 fifo/gul_S2_pltcalc_P9 work/gul_S2_summaryaalcalc/P9.bin work/gul_S2_summaryleccalc/P9.bin > /dev/null & pid158=$!
+tee < fifo/gul_S1_summary_P10 fifo/gul_S1_eltcalc_P10 fifo/gul_S1_summarycalc_P10 fifo/gul_S1_pltcalc_P10 work/gul_S1_summaryaalcalc/P10.bin work/gul_S1_summaryleccalc/P10.bin > /dev/null & pid159=$!
+tee < fifo/gul_S2_summary_P10 fifo/gul_S2_eltcalc_P10 fifo/gul_S2_summarycalc_P10 fifo/gul_S2_pltcalc_P10 work/gul_S2_summaryaalcalc/P10.bin work/gul_S2_summaryleccalc/P10.bin > /dev/null & pid160=$!
+
+( summarycalc -i  -1 fifo/gul_S1_summary_P1 -2 fifo/gul_S2_summary_P1 < fifo/gul_P1 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P2 -2 fifo/gul_S2_summary_P2 < fifo/gul_P2 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P3 -2 fifo/gul_S2_summary_P3 < fifo/gul_P3 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P4 -2 fifo/gul_S2_summary_P4 < fifo/gul_P4 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P5 -2 fifo/gul_S2_summary_P5 < fifo/gul_P5 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P6 -2 fifo/gul_S2_summary_P6 < fifo/gul_P6 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P7 -2 fifo/gul_S2_summary_P7 < fifo/gul_P7 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P8 -2 fifo/gul_S2_summary_P8 < fifo/gul_P8 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P9 -2 fifo/gul_S2_summary_P9 < fifo/gul_P9 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P10 -2 fifo/gul_S2_summary_P10 < fifo/gul_P10 ) 2>> log/stderror.err  &
+
+( eve 1 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee fifo/gul_P1 | fmcalc -a2 > fifo/il_P1  ) 2>> log/stderror.err &
+( eve 2 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee fifo/gul_P2 | fmcalc -a2 > fifo/il_P2  ) 2>> log/stderror.err &
+( eve 3 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee fifo/gul_P3 | fmcalc -a2 > fifo/il_P3  ) 2>> log/stderror.err &
+( eve 4 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee fifo/gul_P4 | fmcalc -a2 > fifo/il_P4  ) 2>> log/stderror.err &
+( eve 5 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee fifo/gul_P5 | fmcalc -a2 > fifo/il_P5  ) 2>> log/stderror.err &
+( eve 6 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee fifo/gul_P6 | fmcalc -a2 > fifo/il_P6  ) 2>> log/stderror.err &
+( eve 7 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee fifo/gul_P7 | fmcalc -a2 > fifo/il_P7  ) 2>> log/stderror.err &
+( eve 8 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee fifo/gul_P8 | fmcalc -a2 > fifo/il_P8  ) 2>> log/stderror.err &
+( eve 9 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee fifo/gul_P9 | fmcalc -a2 > fifo/il_P9  ) 2>> log/stderror.err &
+( eve 10 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee fifo/gul_P10 | fmcalc -a2 > fifo/il_P10  ) 2>> log/stderror.err &
+
+wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 $pid13 $pid14 $pid15 $pid16 $pid17 $pid18 $pid19 $pid20 $pid21 $pid22 $pid23 $pid24 $pid25 $pid26 $pid27 $pid28 $pid29 $pid30 $pid31 $pid32 $pid33 $pid34 $pid35 $pid36 $pid37 $pid38 $pid39 $pid40 $pid41 $pid42 $pid43 $pid44 $pid45 $pid46 $pid47 $pid48 $pid49 $pid50 $pid51 $pid52 $pid53 $pid54 $pid55 $pid56 $pid57 $pid58 $pid59 $pid60 $pid61 $pid62 $pid63 $pid64 $pid65 $pid66 $pid67 $pid68 $pid69 $pid70 $pid71 $pid72 $pid73 $pid74 $pid75 $pid76 $pid77 $pid78 $pid79 $pid80 $pid81 $pid82 $pid83 $pid84 $pid85 $pid86 $pid87 $pid88 $pid89 $pid90 $pid91 $pid92 $pid93 $pid94 $pid95 $pid96 $pid97 $pid98 $pid99 $pid100 $pid101 $pid102 $pid103 $pid104 $pid105 $pid106 $pid107 $pid108 $pid109 $pid110 $pid111 $pid112 $pid113 $pid114 $pid115 $pid116 $pid117 $pid118 $pid119 $pid120 $pid121 $pid122 $pid123 $pid124 $pid125 $pid126 $pid127 $pid128 $pid129 $pid130 $pid131 $pid132 $pid133 $pid134 $pid135 $pid136 $pid137 $pid138 $pid139 $pid140 $pid141 $pid142 $pid143 $pid144 $pid145 $pid146 $pid147 $pid148 $pid149 $pid150 $pid151 $pid152 $pid153 $pid154 $pid155 $pid156 $pid157 $pid158 $pid159 $pid160
+
+
+# --- Do insured loss kats ---
+
+kat -s work/kat/il_S1_eltcalc_P1 work/kat/il_S1_eltcalc_P2 work/kat/il_S1_eltcalc_P3 work/kat/il_S1_eltcalc_P4 work/kat/il_S1_eltcalc_P5 work/kat/il_S1_eltcalc_P6 work/kat/il_S1_eltcalc_P7 work/kat/il_S1_eltcalc_P8 work/kat/il_S1_eltcalc_P9 work/kat/il_S1_eltcalc_P10 > output/il_S1_eltcalc.csv & kpid1=$!
+kat work/kat/il_S1_pltcalc_P1 work/kat/il_S1_pltcalc_P2 work/kat/il_S1_pltcalc_P3 work/kat/il_S1_pltcalc_P4 work/kat/il_S1_pltcalc_P5 work/kat/il_S1_pltcalc_P6 work/kat/il_S1_pltcalc_P7 work/kat/il_S1_pltcalc_P8 work/kat/il_S1_pltcalc_P9 work/kat/il_S1_pltcalc_P10 > output/il_S1_pltcalc.csv & kpid2=$!
+kat work/kat/il_S1_summarycalc_P1 work/kat/il_S1_summarycalc_P2 work/kat/il_S1_summarycalc_P3 work/kat/il_S1_summarycalc_P4 work/kat/il_S1_summarycalc_P5 work/kat/il_S1_summarycalc_P6 work/kat/il_S1_summarycalc_P7 work/kat/il_S1_summarycalc_P8 work/kat/il_S1_summarycalc_P9 work/kat/il_S1_summarycalc_P10 > output/il_S1_summarycalc.csv & kpid3=$!
+kat -s work/kat/il_S2_eltcalc_P1 work/kat/il_S2_eltcalc_P2 work/kat/il_S2_eltcalc_P3 work/kat/il_S2_eltcalc_P4 work/kat/il_S2_eltcalc_P5 work/kat/il_S2_eltcalc_P6 work/kat/il_S2_eltcalc_P7 work/kat/il_S2_eltcalc_P8 work/kat/il_S2_eltcalc_P9 work/kat/il_S2_eltcalc_P10 > output/il_S2_eltcalc.csv & kpid4=$!
+kat work/kat/il_S2_pltcalc_P1 work/kat/il_S2_pltcalc_P2 work/kat/il_S2_pltcalc_P3 work/kat/il_S2_pltcalc_P4 work/kat/il_S2_pltcalc_P5 work/kat/il_S2_pltcalc_P6 work/kat/il_S2_pltcalc_P7 work/kat/il_S2_pltcalc_P8 work/kat/il_S2_pltcalc_P9 work/kat/il_S2_pltcalc_P10 > output/il_S2_pltcalc.csv & kpid5=$!
+kat work/kat/il_S2_summarycalc_P1 work/kat/il_S2_summarycalc_P2 work/kat/il_S2_summarycalc_P3 work/kat/il_S2_summarycalc_P4 work/kat/il_S2_summarycalc_P5 work/kat/il_S2_summarycalc_P6 work/kat/il_S2_summarycalc_P7 work/kat/il_S2_summarycalc_P8 work/kat/il_S2_summarycalc_P9 work/kat/il_S2_summarycalc_P10 > output/il_S2_summarycalc.csv & kpid6=$!
+
+# --- Do ground up loss kats ---
+
+kat -s work/kat/gul_S1_eltcalc_P1 work/kat/gul_S1_eltcalc_P2 work/kat/gul_S1_eltcalc_P3 work/kat/gul_S1_eltcalc_P4 work/kat/gul_S1_eltcalc_P5 work/kat/gul_S1_eltcalc_P6 work/kat/gul_S1_eltcalc_P7 work/kat/gul_S1_eltcalc_P8 work/kat/gul_S1_eltcalc_P9 work/kat/gul_S1_eltcalc_P10 > output/gul_S1_eltcalc.csv & kpid7=$!
+kat work/kat/gul_S1_pltcalc_P1 work/kat/gul_S1_pltcalc_P2 work/kat/gul_S1_pltcalc_P3 work/kat/gul_S1_pltcalc_P4 work/kat/gul_S1_pltcalc_P5 work/kat/gul_S1_pltcalc_P6 work/kat/gul_S1_pltcalc_P7 work/kat/gul_S1_pltcalc_P8 work/kat/gul_S1_pltcalc_P9 work/kat/gul_S1_pltcalc_P10 > output/gul_S1_pltcalc.csv & kpid8=$!
+kat work/kat/gul_S1_summarycalc_P1 work/kat/gul_S1_summarycalc_P2 work/kat/gul_S1_summarycalc_P3 work/kat/gul_S1_summarycalc_P4 work/kat/gul_S1_summarycalc_P5 work/kat/gul_S1_summarycalc_P6 work/kat/gul_S1_summarycalc_P7 work/kat/gul_S1_summarycalc_P8 work/kat/gul_S1_summarycalc_P9 work/kat/gul_S1_summarycalc_P10 > output/gul_S1_summarycalc.csv & kpid9=$!
+kat -s work/kat/gul_S2_eltcalc_P1 work/kat/gul_S2_eltcalc_P2 work/kat/gul_S2_eltcalc_P3 work/kat/gul_S2_eltcalc_P4 work/kat/gul_S2_eltcalc_P5 work/kat/gul_S2_eltcalc_P6 work/kat/gul_S2_eltcalc_P7 work/kat/gul_S2_eltcalc_P8 work/kat/gul_S2_eltcalc_P9 work/kat/gul_S2_eltcalc_P10 > output/gul_S2_eltcalc.csv & kpid10=$!
+kat work/kat/gul_S2_pltcalc_P1 work/kat/gul_S2_pltcalc_P2 work/kat/gul_S2_pltcalc_P3 work/kat/gul_S2_pltcalc_P4 work/kat/gul_S2_pltcalc_P5 work/kat/gul_S2_pltcalc_P6 work/kat/gul_S2_pltcalc_P7 work/kat/gul_S2_pltcalc_P8 work/kat/gul_S2_pltcalc_P9 work/kat/gul_S2_pltcalc_P10 > output/gul_S2_pltcalc.csv & kpid11=$!
+kat work/kat/gul_S2_summarycalc_P1 work/kat/gul_S2_summarycalc_P2 work/kat/gul_S2_summarycalc_P3 work/kat/gul_S2_summarycalc_P4 work/kat/gul_S2_summarycalc_P5 work/kat/gul_S2_summarycalc_P6 work/kat/gul_S2_summarycalc_P7 work/kat/gul_S2_summarycalc_P8 work/kat/gul_S2_summarycalc_P9 work/kat/gul_S2_summarycalc_P10 > output/gul_S2_summarycalc.csv & kpid12=$!
+wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpid11 $kpid12
+
+
+( aalcalc -Kil_S1_summaryaalcalc > output/il_S1_aalcalc.csv ) 2>> log/stderror.err & lpid1=$!
+( ordleccalc -r -Kil_S1_summaryleccalc -F -S -s -M -m -W -w -O output/il_S1_ept.csv -o output/il_S1_psept.csv ) 2>> log/stderror.err & lpid2=$!
+( aalcalc -Kil_S2_summaryaalcalc > output/il_S2_aalcalc.csv ) 2>> log/stderror.err & lpid3=$!
+( ordleccalc -r -Kil_S2_summaryleccalc -F -S -s -M -m -W -w -O output/il_S2_ept.csv -o output/il_S2_psept.csv ) 2>> log/stderror.err & lpid4=$!
+( aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv ) 2>> log/stderror.err & lpid5=$!
+( ordleccalc -r -Kgul_S1_summaryleccalc -F -S -s -M -m -W -w -O output/gul_S1_ept.csv -o output/gul_S1_psept.csv ) 2>> log/stderror.err & lpid6=$!
+( aalcalc -Kgul_S2_summaryaalcalc > output/gul_S2_aalcalc.csv ) 2>> log/stderror.err & lpid7=$!
+( ordleccalc -r -Kgul_S2_summaryleccalc -F -S -s -M -m -W -w -O output/gul_S2_ept.csv -o output/gul_S2_psept.csv ) 2>> log/stderror.err & lpid8=$!
+wait $lpid1 $lpid2 $lpid3 $lpid4 $lpid5 $lpid6 $lpid7 $lpid8
+
+rm -R -f work/*
+rm -R -f fifo/*
+
+check_complete
+exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_il_ord_ept_psept_2_output_10_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_ord_ept_psept_2_output_10_partition.sh
@@ -29,7 +29,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
    ps f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk -F: '$1>$script_pid' | grep -v celery | grep -v python | grep -v $group_pid | grep -v run_ktools)
+   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | grep -v *.sh)
    echo "$PIDS_KILL" >> log/killout.txt
    kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
    exit $exit_code

--- a/tests/model_execution/err_kparse_reference/gul_il_ord_psept_lec_1_output_10_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_ord_psept_lec_1_output_10_partition.sh
@@ -1,0 +1,344 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+
+touch log/stderror.err
+ktools_monitor.sh $$ & pid0=$!
+
+exit_handler(){
+   exit_code=$?
+   kill -9 $pid0 2> /dev/null
+   if [ "$exit_code" -gt 0 ]; then
+       echo 'Ktools Run Error - exitcode='$exit_code
+   else
+       echo 'Run Completed'
+   fi
+
+   set +x
+   group_pid=$(ps -p $$ -o pgid --no-headers)
+   sess_pid=$(ps -p $$ -o sess --no-headers)
+   script_pid=$$
+   printf "Script PID:%d, GPID:%s, SPID:%d
+" $script_pid $group_pid $sess_pid >> log/killout.txt
+
+   ps f -g $sess_pid > log/subprocess_list
+   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk -F: '$1>$script_pid' | grep -v celery | grep -v python | grep -v $group_pid | grep -v run_ktools)
+   echo "$PIDS_KILL" >> log/killout.txt
+   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+   exit $exit_code
+}
+trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
+
+check_complete(){
+    set +e
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
+    has_error=0
+    for p in $proc_list; do
+        started=$(find log -name "$p*.log" | wc -l)
+        finished=$(find log -name "$p*.log" -exec grep -l "finish" {} + | wc -l)
+        if [ "$finished" -lt "$started" ]; then
+            echo "[ERROR] $p - $((started-finished)) processes lost"
+            has_error=1
+        elif [ "$started" -gt 0 ]; then
+            echo "[OK] $p"
+        fi
+    done
+    if [ "$has_error" -ne 0 ]; then
+        false # raise non-zero exit code
+    fi
+}
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+
+rm -R -f fifo/*
+rm -R -f work/*
+mkdir work/kat/
+
+mkdir work/gul_S1_summaryleccalc
+mkdir work/gul_S1_summaryaalcalc
+mkdir work/il_S1_summaryleccalc
+mkdir work/il_S1_summaryaalcalc
+
+mkfifo fifo/gul_P1
+mkfifo fifo/gul_P2
+mkfifo fifo/gul_P3
+mkfifo fifo/gul_P4
+mkfifo fifo/gul_P5
+mkfifo fifo/gul_P6
+mkfifo fifo/gul_P7
+mkfifo fifo/gul_P8
+mkfifo fifo/gul_P9
+mkfifo fifo/gul_P10
+
+mkfifo fifo/gul_S1_summary_P1
+mkfifo fifo/gul_S1_eltcalc_P1
+mkfifo fifo/gul_S1_summarycalc_P1
+mkfifo fifo/gul_S1_pltcalc_P1
+
+mkfifo fifo/gul_S1_summary_P2
+mkfifo fifo/gul_S1_eltcalc_P2
+mkfifo fifo/gul_S1_summarycalc_P2
+mkfifo fifo/gul_S1_pltcalc_P2
+
+mkfifo fifo/gul_S1_summary_P3
+mkfifo fifo/gul_S1_eltcalc_P3
+mkfifo fifo/gul_S1_summarycalc_P3
+mkfifo fifo/gul_S1_pltcalc_P3
+
+mkfifo fifo/gul_S1_summary_P4
+mkfifo fifo/gul_S1_eltcalc_P4
+mkfifo fifo/gul_S1_summarycalc_P4
+mkfifo fifo/gul_S1_pltcalc_P4
+
+mkfifo fifo/gul_S1_summary_P5
+mkfifo fifo/gul_S1_eltcalc_P5
+mkfifo fifo/gul_S1_summarycalc_P5
+mkfifo fifo/gul_S1_pltcalc_P5
+
+mkfifo fifo/gul_S1_summary_P6
+mkfifo fifo/gul_S1_eltcalc_P6
+mkfifo fifo/gul_S1_summarycalc_P6
+mkfifo fifo/gul_S1_pltcalc_P6
+
+mkfifo fifo/gul_S1_summary_P7
+mkfifo fifo/gul_S1_eltcalc_P7
+mkfifo fifo/gul_S1_summarycalc_P7
+mkfifo fifo/gul_S1_pltcalc_P7
+
+mkfifo fifo/gul_S1_summary_P8
+mkfifo fifo/gul_S1_eltcalc_P8
+mkfifo fifo/gul_S1_summarycalc_P8
+mkfifo fifo/gul_S1_pltcalc_P8
+
+mkfifo fifo/gul_S1_summary_P9
+mkfifo fifo/gul_S1_eltcalc_P9
+mkfifo fifo/gul_S1_summarycalc_P9
+mkfifo fifo/gul_S1_pltcalc_P9
+
+mkfifo fifo/gul_S1_summary_P10
+mkfifo fifo/gul_S1_eltcalc_P10
+mkfifo fifo/gul_S1_summarycalc_P10
+mkfifo fifo/gul_S1_pltcalc_P10
+
+mkfifo fifo/il_P1
+mkfifo fifo/il_P2
+mkfifo fifo/il_P3
+mkfifo fifo/il_P4
+mkfifo fifo/il_P5
+mkfifo fifo/il_P6
+mkfifo fifo/il_P7
+mkfifo fifo/il_P8
+mkfifo fifo/il_P9
+mkfifo fifo/il_P10
+
+mkfifo fifo/il_S1_summary_P1
+mkfifo fifo/il_S1_eltcalc_P1
+mkfifo fifo/il_S1_summarycalc_P1
+mkfifo fifo/il_S1_pltcalc_P1
+
+mkfifo fifo/il_S1_summary_P2
+mkfifo fifo/il_S1_eltcalc_P2
+mkfifo fifo/il_S1_summarycalc_P2
+mkfifo fifo/il_S1_pltcalc_P2
+
+mkfifo fifo/il_S1_summary_P3
+mkfifo fifo/il_S1_eltcalc_P3
+mkfifo fifo/il_S1_summarycalc_P3
+mkfifo fifo/il_S1_pltcalc_P3
+
+mkfifo fifo/il_S1_summary_P4
+mkfifo fifo/il_S1_eltcalc_P4
+mkfifo fifo/il_S1_summarycalc_P4
+mkfifo fifo/il_S1_pltcalc_P4
+
+mkfifo fifo/il_S1_summary_P5
+mkfifo fifo/il_S1_eltcalc_P5
+mkfifo fifo/il_S1_summarycalc_P5
+mkfifo fifo/il_S1_pltcalc_P5
+
+mkfifo fifo/il_S1_summary_P6
+mkfifo fifo/il_S1_eltcalc_P6
+mkfifo fifo/il_S1_summarycalc_P6
+mkfifo fifo/il_S1_pltcalc_P6
+
+mkfifo fifo/il_S1_summary_P7
+mkfifo fifo/il_S1_eltcalc_P7
+mkfifo fifo/il_S1_summarycalc_P7
+mkfifo fifo/il_S1_pltcalc_P7
+
+mkfifo fifo/il_S1_summary_P8
+mkfifo fifo/il_S1_eltcalc_P8
+mkfifo fifo/il_S1_summarycalc_P8
+mkfifo fifo/il_S1_pltcalc_P8
+
+mkfifo fifo/il_S1_summary_P9
+mkfifo fifo/il_S1_eltcalc_P9
+mkfifo fifo/il_S1_summarycalc_P9
+mkfifo fifo/il_S1_pltcalc_P9
+
+mkfifo fifo/il_S1_summary_P10
+mkfifo fifo/il_S1_eltcalc_P10
+mkfifo fifo/il_S1_summarycalc_P10
+mkfifo fifo/il_S1_pltcalc_P10
+
+
+
+# --- Do insured loss computes ---
+
+( eltcalc < fifo/il_S1_eltcalc_P1 > work/kat/il_S1_eltcalc_P1 ) 2>> log/stderror.err & pid1=$!
+( summarycalctocsv < fifo/il_S1_summarycalc_P1 > work/kat/il_S1_summarycalc_P1 ) 2>> log/stderror.err & pid2=$!
+( pltcalc < fifo/il_S1_pltcalc_P1 > work/kat/il_S1_pltcalc_P1 ) 2>> log/stderror.err & pid3=$!
+( eltcalc -s < fifo/il_S1_eltcalc_P2 > work/kat/il_S1_eltcalc_P2 ) 2>> log/stderror.err & pid4=$!
+( summarycalctocsv -s < fifo/il_S1_summarycalc_P2 > work/kat/il_S1_summarycalc_P2 ) 2>> log/stderror.err & pid5=$!
+( pltcalc -s < fifo/il_S1_pltcalc_P2 > work/kat/il_S1_pltcalc_P2 ) 2>> log/stderror.err & pid6=$!
+( eltcalc -s < fifo/il_S1_eltcalc_P3 > work/kat/il_S1_eltcalc_P3 ) 2>> log/stderror.err & pid7=$!
+( summarycalctocsv -s < fifo/il_S1_summarycalc_P3 > work/kat/il_S1_summarycalc_P3 ) 2>> log/stderror.err & pid8=$!
+( pltcalc -s < fifo/il_S1_pltcalc_P3 > work/kat/il_S1_pltcalc_P3 ) 2>> log/stderror.err & pid9=$!
+( eltcalc -s < fifo/il_S1_eltcalc_P4 > work/kat/il_S1_eltcalc_P4 ) 2>> log/stderror.err & pid10=$!
+( summarycalctocsv -s < fifo/il_S1_summarycalc_P4 > work/kat/il_S1_summarycalc_P4 ) 2>> log/stderror.err & pid11=$!
+( pltcalc -s < fifo/il_S1_pltcalc_P4 > work/kat/il_S1_pltcalc_P4 ) 2>> log/stderror.err & pid12=$!
+( eltcalc -s < fifo/il_S1_eltcalc_P5 > work/kat/il_S1_eltcalc_P5 ) 2>> log/stderror.err & pid13=$!
+( summarycalctocsv -s < fifo/il_S1_summarycalc_P5 > work/kat/il_S1_summarycalc_P5 ) 2>> log/stderror.err & pid14=$!
+( pltcalc -s < fifo/il_S1_pltcalc_P5 > work/kat/il_S1_pltcalc_P5 ) 2>> log/stderror.err & pid15=$!
+( eltcalc -s < fifo/il_S1_eltcalc_P6 > work/kat/il_S1_eltcalc_P6 ) 2>> log/stderror.err & pid16=$!
+( summarycalctocsv -s < fifo/il_S1_summarycalc_P6 > work/kat/il_S1_summarycalc_P6 ) 2>> log/stderror.err & pid17=$!
+( pltcalc -s < fifo/il_S1_pltcalc_P6 > work/kat/il_S1_pltcalc_P6 ) 2>> log/stderror.err & pid18=$!
+( eltcalc -s < fifo/il_S1_eltcalc_P7 > work/kat/il_S1_eltcalc_P7 ) 2>> log/stderror.err & pid19=$!
+( summarycalctocsv -s < fifo/il_S1_summarycalc_P7 > work/kat/il_S1_summarycalc_P7 ) 2>> log/stderror.err & pid20=$!
+( pltcalc -s < fifo/il_S1_pltcalc_P7 > work/kat/il_S1_pltcalc_P7 ) 2>> log/stderror.err & pid21=$!
+( eltcalc -s < fifo/il_S1_eltcalc_P8 > work/kat/il_S1_eltcalc_P8 ) 2>> log/stderror.err & pid22=$!
+( summarycalctocsv -s < fifo/il_S1_summarycalc_P8 > work/kat/il_S1_summarycalc_P8 ) 2>> log/stderror.err & pid23=$!
+( pltcalc -s < fifo/il_S1_pltcalc_P8 > work/kat/il_S1_pltcalc_P8 ) 2>> log/stderror.err & pid24=$!
+( eltcalc -s < fifo/il_S1_eltcalc_P9 > work/kat/il_S1_eltcalc_P9 ) 2>> log/stderror.err & pid25=$!
+( summarycalctocsv -s < fifo/il_S1_summarycalc_P9 > work/kat/il_S1_summarycalc_P9 ) 2>> log/stderror.err & pid26=$!
+( pltcalc -s < fifo/il_S1_pltcalc_P9 > work/kat/il_S1_pltcalc_P9 ) 2>> log/stderror.err & pid27=$!
+( eltcalc -s < fifo/il_S1_eltcalc_P10 > work/kat/il_S1_eltcalc_P10 ) 2>> log/stderror.err & pid28=$!
+( summarycalctocsv -s < fifo/il_S1_summarycalc_P10 > work/kat/il_S1_summarycalc_P10 ) 2>> log/stderror.err & pid29=$!
+( pltcalc -s < fifo/il_S1_pltcalc_P10 > work/kat/il_S1_pltcalc_P10 ) 2>> log/stderror.err & pid30=$!
+
+tee < fifo/il_S1_summary_P1 fifo/il_S1_eltcalc_P1 fifo/il_S1_summarycalc_P1 fifo/il_S1_pltcalc_P1 work/il_S1_summaryaalcalc/P1.bin work/il_S1_summaryleccalc/P1.bin > /dev/null & pid31=$!
+tee < fifo/il_S1_summary_P2 fifo/il_S1_eltcalc_P2 fifo/il_S1_summarycalc_P2 fifo/il_S1_pltcalc_P2 work/il_S1_summaryaalcalc/P2.bin work/il_S1_summaryleccalc/P2.bin > /dev/null & pid32=$!
+tee < fifo/il_S1_summary_P3 fifo/il_S1_eltcalc_P3 fifo/il_S1_summarycalc_P3 fifo/il_S1_pltcalc_P3 work/il_S1_summaryaalcalc/P3.bin work/il_S1_summaryleccalc/P3.bin > /dev/null & pid33=$!
+tee < fifo/il_S1_summary_P4 fifo/il_S1_eltcalc_P4 fifo/il_S1_summarycalc_P4 fifo/il_S1_pltcalc_P4 work/il_S1_summaryaalcalc/P4.bin work/il_S1_summaryleccalc/P4.bin > /dev/null & pid34=$!
+tee < fifo/il_S1_summary_P5 fifo/il_S1_eltcalc_P5 fifo/il_S1_summarycalc_P5 fifo/il_S1_pltcalc_P5 work/il_S1_summaryaalcalc/P5.bin work/il_S1_summaryleccalc/P5.bin > /dev/null & pid35=$!
+tee < fifo/il_S1_summary_P6 fifo/il_S1_eltcalc_P6 fifo/il_S1_summarycalc_P6 fifo/il_S1_pltcalc_P6 work/il_S1_summaryaalcalc/P6.bin work/il_S1_summaryleccalc/P6.bin > /dev/null & pid36=$!
+tee < fifo/il_S1_summary_P7 fifo/il_S1_eltcalc_P7 fifo/il_S1_summarycalc_P7 fifo/il_S1_pltcalc_P7 work/il_S1_summaryaalcalc/P7.bin work/il_S1_summaryleccalc/P7.bin > /dev/null & pid37=$!
+tee < fifo/il_S1_summary_P8 fifo/il_S1_eltcalc_P8 fifo/il_S1_summarycalc_P8 fifo/il_S1_pltcalc_P8 work/il_S1_summaryaalcalc/P8.bin work/il_S1_summaryleccalc/P8.bin > /dev/null & pid38=$!
+tee < fifo/il_S1_summary_P9 fifo/il_S1_eltcalc_P9 fifo/il_S1_summarycalc_P9 fifo/il_S1_pltcalc_P9 work/il_S1_summaryaalcalc/P9.bin work/il_S1_summaryleccalc/P9.bin > /dev/null & pid39=$!
+tee < fifo/il_S1_summary_P10 fifo/il_S1_eltcalc_P10 fifo/il_S1_summarycalc_P10 fifo/il_S1_pltcalc_P10 work/il_S1_summaryaalcalc/P10.bin work/il_S1_summaryleccalc/P10.bin > /dev/null & pid40=$!
+
+( summarycalc -f  -1 fifo/il_S1_summary_P1 < fifo/il_P1 ) 2>> log/stderror.err  &
+( summarycalc -f  -1 fifo/il_S1_summary_P2 < fifo/il_P2 ) 2>> log/stderror.err  &
+( summarycalc -f  -1 fifo/il_S1_summary_P3 < fifo/il_P3 ) 2>> log/stderror.err  &
+( summarycalc -f  -1 fifo/il_S1_summary_P4 < fifo/il_P4 ) 2>> log/stderror.err  &
+( summarycalc -f  -1 fifo/il_S1_summary_P5 < fifo/il_P5 ) 2>> log/stderror.err  &
+( summarycalc -f  -1 fifo/il_S1_summary_P6 < fifo/il_P6 ) 2>> log/stderror.err  &
+( summarycalc -f  -1 fifo/il_S1_summary_P7 < fifo/il_P7 ) 2>> log/stderror.err  &
+( summarycalc -f  -1 fifo/il_S1_summary_P8 < fifo/il_P8 ) 2>> log/stderror.err  &
+( summarycalc -f  -1 fifo/il_S1_summary_P9 < fifo/il_P9 ) 2>> log/stderror.err  &
+( summarycalc -f  -1 fifo/il_S1_summary_P10 < fifo/il_P10 ) 2>> log/stderror.err  &
+
+# --- Do ground up loss computes ---
+
+( eltcalc < fifo/gul_S1_eltcalc_P1 > work/kat/gul_S1_eltcalc_P1 ) 2>> log/stderror.err & pid41=$!
+( summarycalctocsv < fifo/gul_S1_summarycalc_P1 > work/kat/gul_S1_summarycalc_P1 ) 2>> log/stderror.err & pid42=$!
+( pltcalc < fifo/gul_S1_pltcalc_P1 > work/kat/gul_S1_pltcalc_P1 ) 2>> log/stderror.err & pid43=$!
+( eltcalc -s < fifo/gul_S1_eltcalc_P2 > work/kat/gul_S1_eltcalc_P2 ) 2>> log/stderror.err & pid44=$!
+( summarycalctocsv -s < fifo/gul_S1_summarycalc_P2 > work/kat/gul_S1_summarycalc_P2 ) 2>> log/stderror.err & pid45=$!
+( pltcalc -s < fifo/gul_S1_pltcalc_P2 > work/kat/gul_S1_pltcalc_P2 ) 2>> log/stderror.err & pid46=$!
+( eltcalc -s < fifo/gul_S1_eltcalc_P3 > work/kat/gul_S1_eltcalc_P3 ) 2>> log/stderror.err & pid47=$!
+( summarycalctocsv -s < fifo/gul_S1_summarycalc_P3 > work/kat/gul_S1_summarycalc_P3 ) 2>> log/stderror.err & pid48=$!
+( pltcalc -s < fifo/gul_S1_pltcalc_P3 > work/kat/gul_S1_pltcalc_P3 ) 2>> log/stderror.err & pid49=$!
+( eltcalc -s < fifo/gul_S1_eltcalc_P4 > work/kat/gul_S1_eltcalc_P4 ) 2>> log/stderror.err & pid50=$!
+( summarycalctocsv -s < fifo/gul_S1_summarycalc_P4 > work/kat/gul_S1_summarycalc_P4 ) 2>> log/stderror.err & pid51=$!
+( pltcalc -s < fifo/gul_S1_pltcalc_P4 > work/kat/gul_S1_pltcalc_P4 ) 2>> log/stderror.err & pid52=$!
+( eltcalc -s < fifo/gul_S1_eltcalc_P5 > work/kat/gul_S1_eltcalc_P5 ) 2>> log/stderror.err & pid53=$!
+( summarycalctocsv -s < fifo/gul_S1_summarycalc_P5 > work/kat/gul_S1_summarycalc_P5 ) 2>> log/stderror.err & pid54=$!
+( pltcalc -s < fifo/gul_S1_pltcalc_P5 > work/kat/gul_S1_pltcalc_P5 ) 2>> log/stderror.err & pid55=$!
+( eltcalc -s < fifo/gul_S1_eltcalc_P6 > work/kat/gul_S1_eltcalc_P6 ) 2>> log/stderror.err & pid56=$!
+( summarycalctocsv -s < fifo/gul_S1_summarycalc_P6 > work/kat/gul_S1_summarycalc_P6 ) 2>> log/stderror.err & pid57=$!
+( pltcalc -s < fifo/gul_S1_pltcalc_P6 > work/kat/gul_S1_pltcalc_P6 ) 2>> log/stderror.err & pid58=$!
+( eltcalc -s < fifo/gul_S1_eltcalc_P7 > work/kat/gul_S1_eltcalc_P7 ) 2>> log/stderror.err & pid59=$!
+( summarycalctocsv -s < fifo/gul_S1_summarycalc_P7 > work/kat/gul_S1_summarycalc_P7 ) 2>> log/stderror.err & pid60=$!
+( pltcalc -s < fifo/gul_S1_pltcalc_P7 > work/kat/gul_S1_pltcalc_P7 ) 2>> log/stderror.err & pid61=$!
+( eltcalc -s < fifo/gul_S1_eltcalc_P8 > work/kat/gul_S1_eltcalc_P8 ) 2>> log/stderror.err & pid62=$!
+( summarycalctocsv -s < fifo/gul_S1_summarycalc_P8 > work/kat/gul_S1_summarycalc_P8 ) 2>> log/stderror.err & pid63=$!
+( pltcalc -s < fifo/gul_S1_pltcalc_P8 > work/kat/gul_S1_pltcalc_P8 ) 2>> log/stderror.err & pid64=$!
+( eltcalc -s < fifo/gul_S1_eltcalc_P9 > work/kat/gul_S1_eltcalc_P9 ) 2>> log/stderror.err & pid65=$!
+( summarycalctocsv -s < fifo/gul_S1_summarycalc_P9 > work/kat/gul_S1_summarycalc_P9 ) 2>> log/stderror.err & pid66=$!
+( pltcalc -s < fifo/gul_S1_pltcalc_P9 > work/kat/gul_S1_pltcalc_P9 ) 2>> log/stderror.err & pid67=$!
+( eltcalc -s < fifo/gul_S1_eltcalc_P10 > work/kat/gul_S1_eltcalc_P10 ) 2>> log/stderror.err & pid68=$!
+( summarycalctocsv -s < fifo/gul_S1_summarycalc_P10 > work/kat/gul_S1_summarycalc_P10 ) 2>> log/stderror.err & pid69=$!
+( pltcalc -s < fifo/gul_S1_pltcalc_P10 > work/kat/gul_S1_pltcalc_P10 ) 2>> log/stderror.err & pid70=$!
+
+tee < fifo/gul_S1_summary_P1 fifo/gul_S1_eltcalc_P1 fifo/gul_S1_summarycalc_P1 fifo/gul_S1_pltcalc_P1 work/gul_S1_summaryaalcalc/P1.bin work/gul_S1_summaryleccalc/P1.bin > /dev/null & pid71=$!
+tee < fifo/gul_S1_summary_P2 fifo/gul_S1_eltcalc_P2 fifo/gul_S1_summarycalc_P2 fifo/gul_S1_pltcalc_P2 work/gul_S1_summaryaalcalc/P2.bin work/gul_S1_summaryleccalc/P2.bin > /dev/null & pid72=$!
+tee < fifo/gul_S1_summary_P3 fifo/gul_S1_eltcalc_P3 fifo/gul_S1_summarycalc_P3 fifo/gul_S1_pltcalc_P3 work/gul_S1_summaryaalcalc/P3.bin work/gul_S1_summaryleccalc/P3.bin > /dev/null & pid73=$!
+tee < fifo/gul_S1_summary_P4 fifo/gul_S1_eltcalc_P4 fifo/gul_S1_summarycalc_P4 fifo/gul_S1_pltcalc_P4 work/gul_S1_summaryaalcalc/P4.bin work/gul_S1_summaryleccalc/P4.bin > /dev/null & pid74=$!
+tee < fifo/gul_S1_summary_P5 fifo/gul_S1_eltcalc_P5 fifo/gul_S1_summarycalc_P5 fifo/gul_S1_pltcalc_P5 work/gul_S1_summaryaalcalc/P5.bin work/gul_S1_summaryleccalc/P5.bin > /dev/null & pid75=$!
+tee < fifo/gul_S1_summary_P6 fifo/gul_S1_eltcalc_P6 fifo/gul_S1_summarycalc_P6 fifo/gul_S1_pltcalc_P6 work/gul_S1_summaryaalcalc/P6.bin work/gul_S1_summaryleccalc/P6.bin > /dev/null & pid76=$!
+tee < fifo/gul_S1_summary_P7 fifo/gul_S1_eltcalc_P7 fifo/gul_S1_summarycalc_P7 fifo/gul_S1_pltcalc_P7 work/gul_S1_summaryaalcalc/P7.bin work/gul_S1_summaryleccalc/P7.bin > /dev/null & pid77=$!
+tee < fifo/gul_S1_summary_P8 fifo/gul_S1_eltcalc_P8 fifo/gul_S1_summarycalc_P8 fifo/gul_S1_pltcalc_P8 work/gul_S1_summaryaalcalc/P8.bin work/gul_S1_summaryleccalc/P8.bin > /dev/null & pid78=$!
+tee < fifo/gul_S1_summary_P9 fifo/gul_S1_eltcalc_P9 fifo/gul_S1_summarycalc_P9 fifo/gul_S1_pltcalc_P9 work/gul_S1_summaryaalcalc/P9.bin work/gul_S1_summaryleccalc/P9.bin > /dev/null & pid79=$!
+tee < fifo/gul_S1_summary_P10 fifo/gul_S1_eltcalc_P10 fifo/gul_S1_summarycalc_P10 fifo/gul_S1_pltcalc_P10 work/gul_S1_summaryaalcalc/P10.bin work/gul_S1_summaryleccalc/P10.bin > /dev/null & pid80=$!
+
+( summarycalc -i  -1 fifo/gul_S1_summary_P1 < fifo/gul_P1 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P2 < fifo/gul_P2 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P3 < fifo/gul_P3 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P4 < fifo/gul_P4 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P5 < fifo/gul_P5 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P6 < fifo/gul_P6 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P7 < fifo/gul_P7 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P8 < fifo/gul_P8 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P9 < fifo/gul_P9 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P10 < fifo/gul_P10 ) 2>> log/stderror.err  &
+
+( eve 1 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee fifo/gul_P1 | fmcalc -a2 > fifo/il_P1  ) 2>> log/stderror.err &
+( eve 2 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee fifo/gul_P2 | fmcalc -a2 > fifo/il_P2  ) 2>> log/stderror.err &
+( eve 3 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee fifo/gul_P3 | fmcalc -a2 > fifo/il_P3  ) 2>> log/stderror.err &
+( eve 4 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee fifo/gul_P4 | fmcalc -a2 > fifo/il_P4  ) 2>> log/stderror.err &
+( eve 5 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee fifo/gul_P5 | fmcalc -a2 > fifo/il_P5  ) 2>> log/stderror.err &
+( eve 6 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee fifo/gul_P6 | fmcalc -a2 > fifo/il_P6  ) 2>> log/stderror.err &
+( eve 7 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee fifo/gul_P7 | fmcalc -a2 > fifo/il_P7  ) 2>> log/stderror.err &
+( eve 8 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee fifo/gul_P8 | fmcalc -a2 > fifo/il_P8  ) 2>> log/stderror.err &
+( eve 9 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee fifo/gul_P9 | fmcalc -a2 > fifo/il_P9  ) 2>> log/stderror.err &
+( eve 10 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee fifo/gul_P10 | fmcalc -a2 > fifo/il_P10  ) 2>> log/stderror.err &
+
+wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 $pid13 $pid14 $pid15 $pid16 $pid17 $pid18 $pid19 $pid20 $pid21 $pid22 $pid23 $pid24 $pid25 $pid26 $pid27 $pid28 $pid29 $pid30 $pid31 $pid32 $pid33 $pid34 $pid35 $pid36 $pid37 $pid38 $pid39 $pid40 $pid41 $pid42 $pid43 $pid44 $pid45 $pid46 $pid47 $pid48 $pid49 $pid50 $pid51 $pid52 $pid53 $pid54 $pid55 $pid56 $pid57 $pid58 $pid59 $pid60 $pid61 $pid62 $pid63 $pid64 $pid65 $pid66 $pid67 $pid68 $pid69 $pid70 $pid71 $pid72 $pid73 $pid74 $pid75 $pid76 $pid77 $pid78 $pid79 $pid80
+
+
+# --- Do insured loss kats ---
+
+kat -s work/kat/il_S1_eltcalc_P1 work/kat/il_S1_eltcalc_P2 work/kat/il_S1_eltcalc_P3 work/kat/il_S1_eltcalc_P4 work/kat/il_S1_eltcalc_P5 work/kat/il_S1_eltcalc_P6 work/kat/il_S1_eltcalc_P7 work/kat/il_S1_eltcalc_P8 work/kat/il_S1_eltcalc_P9 work/kat/il_S1_eltcalc_P10 > output/il_S1_eltcalc.csv & kpid1=$!
+kat work/kat/il_S1_pltcalc_P1 work/kat/il_S1_pltcalc_P2 work/kat/il_S1_pltcalc_P3 work/kat/il_S1_pltcalc_P4 work/kat/il_S1_pltcalc_P5 work/kat/il_S1_pltcalc_P6 work/kat/il_S1_pltcalc_P7 work/kat/il_S1_pltcalc_P8 work/kat/il_S1_pltcalc_P9 work/kat/il_S1_pltcalc_P10 > output/il_S1_pltcalc.csv & kpid2=$!
+kat work/kat/il_S1_summarycalc_P1 work/kat/il_S1_summarycalc_P2 work/kat/il_S1_summarycalc_P3 work/kat/il_S1_summarycalc_P4 work/kat/il_S1_summarycalc_P5 work/kat/il_S1_summarycalc_P6 work/kat/il_S1_summarycalc_P7 work/kat/il_S1_summarycalc_P8 work/kat/il_S1_summarycalc_P9 work/kat/il_S1_summarycalc_P10 > output/il_S1_summarycalc.csv & kpid3=$!
+
+# --- Do ground up loss kats ---
+
+kat -s work/kat/gul_S1_eltcalc_P1 work/kat/gul_S1_eltcalc_P2 work/kat/gul_S1_eltcalc_P3 work/kat/gul_S1_eltcalc_P4 work/kat/gul_S1_eltcalc_P5 work/kat/gul_S1_eltcalc_P6 work/kat/gul_S1_eltcalc_P7 work/kat/gul_S1_eltcalc_P8 work/kat/gul_S1_eltcalc_P9 work/kat/gul_S1_eltcalc_P10 > output/gul_S1_eltcalc.csv & kpid4=$!
+kat work/kat/gul_S1_pltcalc_P1 work/kat/gul_S1_pltcalc_P2 work/kat/gul_S1_pltcalc_P3 work/kat/gul_S1_pltcalc_P4 work/kat/gul_S1_pltcalc_P5 work/kat/gul_S1_pltcalc_P6 work/kat/gul_S1_pltcalc_P7 work/kat/gul_S1_pltcalc_P8 work/kat/gul_S1_pltcalc_P9 work/kat/gul_S1_pltcalc_P10 > output/gul_S1_pltcalc.csv & kpid5=$!
+kat work/kat/gul_S1_summarycalc_P1 work/kat/gul_S1_summarycalc_P2 work/kat/gul_S1_summarycalc_P3 work/kat/gul_S1_summarycalc_P4 work/kat/gul_S1_summarycalc_P5 work/kat/gul_S1_summarycalc_P6 work/kat/gul_S1_summarycalc_P7 work/kat/gul_S1_summarycalc_P8 work/kat/gul_S1_summarycalc_P9 work/kat/gul_S1_summarycalc_P10 > output/gul_S1_summarycalc.csv & kpid6=$!
+wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
+
+
+( aalcalc -Kil_S1_summaryaalcalc > output/il_S1_aalcalc.csv ) 2>> log/stderror.err & lpid1=$!
+( ordleccalc -r -Kil_S1_summaryleccalc -W -w -o output/il_S1_psept.csv ) 2>> log/stderror.err & lpid2=$!
+( leccalc -r -Kil_S1_summaryleccalc -F output/il_S1_leccalc_full_uncertainty_aep.csv -f output/il_S1_leccalc_full_uncertainty_oep.csv -S output/il_S1_leccalc_sample_mean_aep.csv -s output/il_S1_leccalc_sample_mean_oep.csv -W output/il_S1_leccalc_wheatsheaf_aep.csv -M output/il_S1_leccalc_wheatsheaf_mean_aep.csv -m output/il_S1_leccalc_wheatsheaf_mean_oep.csv -w output/il_S1_leccalc_wheatsheaf_oep.csv ) 2>> log/stderror.err & lpid3=$!
+( aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv ) 2>> log/stderror.err & lpid4=$!
+( ordleccalc  -Kgul_S1_summaryleccalc -W -w -o output/gul_S1_psept.csv ) 2>> log/stderror.err & lpid5=$!
+( leccalc -r -Kgul_S1_summaryleccalc -F output/gul_S1_leccalc_full_uncertainty_aep.csv -f output/gul_S1_leccalc_full_uncertainty_oep.csv -S output/gul_S1_leccalc_sample_mean_aep.csv -s output/gul_S1_leccalc_sample_mean_oep.csv -W output/gul_S1_leccalc_wheatsheaf_aep.csv -M output/gul_S1_leccalc_wheatsheaf_mean_aep.csv -m output/gul_S1_leccalc_wheatsheaf_mean_oep.csv -w output/gul_S1_leccalc_wheatsheaf_oep.csv ) 2>> log/stderror.err & lpid6=$!
+wait $lpid1 $lpid2 $lpid3 $lpid4 $lpid5 $lpid6
+
+rm -R -f work/*
+rm -R -f fifo/*
+
+check_complete
+exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_il_ord_psept_lec_1_output_10_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_ord_psept_lec_1_output_10_partition.sh
@@ -29,7 +29,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
    ps f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk -F: '$1>$script_pid' | grep -v celery | grep -v python | grep -v $group_pid | grep -v run_ktools)
+   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | grep -v *.sh)
    echo "$PIDS_KILL" >> log/killout.txt
    kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
    exit $exit_code

--- a/tests/model_execution/err_kparse_reference/gul_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_lec_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/gul_lec_1_output_2_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_lec_1_output_2_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/gul_lec_2_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_lec_2_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/gul_lec_2_output_2_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_lec_2_output_2_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/gul_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_no_lec_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/gul_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_no_lec_1_output_2_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/gul_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_no_lec_2_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/gul_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_no_lec_2_output_2_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/gul_ord_ept_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_ord_ept_1_output_1_partition.sh
@@ -29,7 +29,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
    ps f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk -F: '$1>$script_pid' | grep -v celery | grep -v python | grep -v $group_pid | grep -v run_ktools)
+   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | grep -v *.sh)
    echo "$PIDS_KILL" >> log/killout.txt
    kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
    exit $exit_code

--- a/tests/model_execution/err_kparse_reference/gul_ord_ept_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_ord_ept_1_output_1_partition.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+
+touch log/stderror.err
+ktools_monitor.sh $$ & pid0=$!
+
+exit_handler(){
+   exit_code=$?
+   kill -9 $pid0 2> /dev/null
+   if [ "$exit_code" -gt 0 ]; then
+       echo 'Ktools Run Error - exitcode='$exit_code
+   else
+       echo 'Run Completed'
+   fi
+
+   set +x
+   group_pid=$(ps -p $$ -o pgid --no-headers)
+   sess_pid=$(ps -p $$ -o sess --no-headers)
+   script_pid=$$
+   printf "Script PID:%d, GPID:%s, SPID:%d
+" $script_pid $group_pid $sess_pid >> log/killout.txt
+
+   ps f -g $sess_pid > log/subprocess_list
+   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk -F: '$1>$script_pid' | grep -v celery | grep -v python | grep -v $group_pid | grep -v run_ktools)
+   echo "$PIDS_KILL" >> log/killout.txt
+   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+   exit $exit_code
+}
+trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
+
+check_complete(){
+    set +e
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
+    has_error=0
+    for p in $proc_list; do
+        started=$(find log -name "$p*.log" | wc -l)
+        finished=$(find log -name "$p*.log" -exec grep -l "finish" {} + | wc -l)
+        if [ "$finished" -lt "$started" ]; then
+            echo "[ERROR] $p - $((started-finished)) processes lost"
+            has_error=1
+        elif [ "$started" -gt 0 ]; then
+            echo "[OK] $p"
+        fi
+    done
+    if [ "$has_error" -ne 0 ]; then
+        false # raise non-zero exit code
+    fi
+}
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+
+rm -R -f fifo/*
+rm -R -f work/*
+mkdir work/kat/
+
+mkdir work/gul_S1_summaryleccalc
+
+mkfifo fifo/gul_P1
+
+mkfifo fifo/gul_S1_summary_P1
+
+
+
+# --- Do ground up loss computes ---
+
+
+tee < fifo/gul_S1_summary_P1 work/gul_S1_summaryleccalc/P1.bin > /dev/null & pid1=$!
+
+( summarycalc -i  -1 fifo/gul_S1_summary_P1 < fifo/gul_P1 ) 2>> log/stderror.err  &
+
+( eve 1 1 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P1  ) 2>> log/stderror.err &
+
+wait $pid1
+
+
+# --- Do ground up loss kats ---
+
+
+( ordleccalc -r -Kgul_S1_summaryleccalc -F -f -S -s -M -m -O output/gul_S1_ept.csv ) 2>> log/stderror.err & lpid1=$!
+wait $lpid1
+
+rm -R -f work/*
+rm -R -f fifo/*
+
+check_complete
+exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_ord_ept_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_ord_ept_1_output_20_partition.sh
@@ -1,0 +1,209 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+
+touch log/stderror.err
+ktools_monitor.sh $$ & pid0=$!
+
+exit_handler(){
+   exit_code=$?
+   kill -9 $pid0 2> /dev/null
+   if [ "$exit_code" -gt 0 ]; then
+       echo 'Ktools Run Error - exitcode='$exit_code
+   else
+       echo 'Run Completed'
+   fi
+
+   set +x
+   group_pid=$(ps -p $$ -o pgid --no-headers)
+   sess_pid=$(ps -p $$ -o sess --no-headers)
+   script_pid=$$
+   printf "Script PID:%d, GPID:%s, SPID:%d
+" $script_pid $group_pid $sess_pid >> log/killout.txt
+
+   ps f -g $sess_pid > log/subprocess_list
+   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk -F: '$1>$script_pid' | grep -v celery | grep -v python | grep -v $group_pid | grep -v run_ktools)
+   echo "$PIDS_KILL" >> log/killout.txt
+   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+   exit $exit_code
+}
+trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
+
+check_complete(){
+    set +e
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
+    has_error=0
+    for p in $proc_list; do
+        started=$(find log -name "$p*.log" | wc -l)
+        finished=$(find log -name "$p*.log" -exec grep -l "finish" {} + | wc -l)
+        if [ "$finished" -lt "$started" ]; then
+            echo "[ERROR] $p - $((started-finished)) processes lost"
+            has_error=1
+        elif [ "$started" -gt 0 ]; then
+            echo "[OK] $p"
+        fi
+    done
+    if [ "$has_error" -ne 0 ]; then
+        false # raise non-zero exit code
+    fi
+}
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+
+rm -R -f fifo/*
+rm -R -f work/*
+mkdir work/kat/
+
+mkdir work/gul_S1_summaryleccalc
+
+mkfifo fifo/gul_P1
+mkfifo fifo/gul_P2
+mkfifo fifo/gul_P3
+mkfifo fifo/gul_P4
+mkfifo fifo/gul_P5
+mkfifo fifo/gul_P6
+mkfifo fifo/gul_P7
+mkfifo fifo/gul_P8
+mkfifo fifo/gul_P9
+mkfifo fifo/gul_P10
+mkfifo fifo/gul_P11
+mkfifo fifo/gul_P12
+mkfifo fifo/gul_P13
+mkfifo fifo/gul_P14
+mkfifo fifo/gul_P15
+mkfifo fifo/gul_P16
+mkfifo fifo/gul_P17
+mkfifo fifo/gul_P18
+mkfifo fifo/gul_P19
+mkfifo fifo/gul_P20
+
+mkfifo fifo/gul_S1_summary_P1
+
+mkfifo fifo/gul_S1_summary_P2
+
+mkfifo fifo/gul_S1_summary_P3
+
+mkfifo fifo/gul_S1_summary_P4
+
+mkfifo fifo/gul_S1_summary_P5
+
+mkfifo fifo/gul_S1_summary_P6
+
+mkfifo fifo/gul_S1_summary_P7
+
+mkfifo fifo/gul_S1_summary_P8
+
+mkfifo fifo/gul_S1_summary_P9
+
+mkfifo fifo/gul_S1_summary_P10
+
+mkfifo fifo/gul_S1_summary_P11
+
+mkfifo fifo/gul_S1_summary_P12
+
+mkfifo fifo/gul_S1_summary_P13
+
+mkfifo fifo/gul_S1_summary_P14
+
+mkfifo fifo/gul_S1_summary_P15
+
+mkfifo fifo/gul_S1_summary_P16
+
+mkfifo fifo/gul_S1_summary_P17
+
+mkfifo fifo/gul_S1_summary_P18
+
+mkfifo fifo/gul_S1_summary_P19
+
+mkfifo fifo/gul_S1_summary_P20
+
+
+
+# --- Do ground up loss computes ---
+
+
+tee < fifo/gul_S1_summary_P1 work/gul_S1_summaryleccalc/P1.bin > /dev/null & pid1=$!
+tee < fifo/gul_S1_summary_P2 work/gul_S1_summaryleccalc/P2.bin > /dev/null & pid2=$!
+tee < fifo/gul_S1_summary_P3 work/gul_S1_summaryleccalc/P3.bin > /dev/null & pid3=$!
+tee < fifo/gul_S1_summary_P4 work/gul_S1_summaryleccalc/P4.bin > /dev/null & pid4=$!
+tee < fifo/gul_S1_summary_P5 work/gul_S1_summaryleccalc/P5.bin > /dev/null & pid5=$!
+tee < fifo/gul_S1_summary_P6 work/gul_S1_summaryleccalc/P6.bin > /dev/null & pid6=$!
+tee < fifo/gul_S1_summary_P7 work/gul_S1_summaryleccalc/P7.bin > /dev/null & pid7=$!
+tee < fifo/gul_S1_summary_P8 work/gul_S1_summaryleccalc/P8.bin > /dev/null & pid8=$!
+tee < fifo/gul_S1_summary_P9 work/gul_S1_summaryleccalc/P9.bin > /dev/null & pid9=$!
+tee < fifo/gul_S1_summary_P10 work/gul_S1_summaryleccalc/P10.bin > /dev/null & pid10=$!
+tee < fifo/gul_S1_summary_P11 work/gul_S1_summaryleccalc/P11.bin > /dev/null & pid11=$!
+tee < fifo/gul_S1_summary_P12 work/gul_S1_summaryleccalc/P12.bin > /dev/null & pid12=$!
+tee < fifo/gul_S1_summary_P13 work/gul_S1_summaryleccalc/P13.bin > /dev/null & pid13=$!
+tee < fifo/gul_S1_summary_P14 work/gul_S1_summaryleccalc/P14.bin > /dev/null & pid14=$!
+tee < fifo/gul_S1_summary_P15 work/gul_S1_summaryleccalc/P15.bin > /dev/null & pid15=$!
+tee < fifo/gul_S1_summary_P16 work/gul_S1_summaryleccalc/P16.bin > /dev/null & pid16=$!
+tee < fifo/gul_S1_summary_P17 work/gul_S1_summaryleccalc/P17.bin > /dev/null & pid17=$!
+tee < fifo/gul_S1_summary_P18 work/gul_S1_summaryleccalc/P18.bin > /dev/null & pid18=$!
+tee < fifo/gul_S1_summary_P19 work/gul_S1_summaryleccalc/P19.bin > /dev/null & pid19=$!
+tee < fifo/gul_S1_summary_P20 work/gul_S1_summaryleccalc/P20.bin > /dev/null & pid20=$!
+
+( summarycalc -i  -1 fifo/gul_S1_summary_P1 < fifo/gul_P1 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P2 < fifo/gul_P2 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P3 < fifo/gul_P3 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P4 < fifo/gul_P4 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P5 < fifo/gul_P5 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P6 < fifo/gul_P6 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P7 < fifo/gul_P7 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P8 < fifo/gul_P8 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P9 < fifo/gul_P9 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P10 < fifo/gul_P10 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P11 < fifo/gul_P11 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P12 < fifo/gul_P12 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P13 < fifo/gul_P13 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P14 < fifo/gul_P14 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P15 < fifo/gul_P15 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P16 < fifo/gul_P16 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P17 < fifo/gul_P17 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P18 < fifo/gul_P18 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P19 < fifo/gul_P19 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P20 < fifo/gul_P20 ) 2>> log/stderror.err  &
+
+( eve 1 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P1  ) 2>> log/stderror.err &
+( eve 2 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P2  ) 2>> log/stderror.err &
+( eve 3 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P3  ) 2>> log/stderror.err &
+( eve 4 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P4  ) 2>> log/stderror.err &
+( eve 5 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P5  ) 2>> log/stderror.err &
+( eve 6 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P6  ) 2>> log/stderror.err &
+( eve 7 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P7  ) 2>> log/stderror.err &
+( eve 8 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P8  ) 2>> log/stderror.err &
+( eve 9 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P9  ) 2>> log/stderror.err &
+( eve 10 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P10  ) 2>> log/stderror.err &
+( eve 11 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P11  ) 2>> log/stderror.err &
+( eve 12 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P12  ) 2>> log/stderror.err &
+( eve 13 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P13  ) 2>> log/stderror.err &
+( eve 14 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P14  ) 2>> log/stderror.err &
+( eve 15 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P15  ) 2>> log/stderror.err &
+( eve 16 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P16  ) 2>> log/stderror.err &
+( eve 17 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P17  ) 2>> log/stderror.err &
+( eve 18 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P18  ) 2>> log/stderror.err &
+( eve 19 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P19  ) 2>> log/stderror.err &
+( eve 20 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P20  ) 2>> log/stderror.err &
+
+wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 $pid13 $pid14 $pid15 $pid16 $pid17 $pid18 $pid19 $pid20
+
+
+# --- Do ground up loss kats ---
+
+
+( ordleccalc -r -Kgul_S1_summaryleccalc -F -f -S -s -M -m -O output/gul_S1_ept.csv ) 2>> log/stderror.err & lpid1=$!
+wait $lpid1
+
+rm -R -f work/*
+rm -R -f fifo/*
+
+check_complete
+exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_ord_ept_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_ord_ept_1_output_20_partition.sh
@@ -29,7 +29,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
    ps f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk -F: '$1>$script_pid' | grep -v celery | grep -v python | grep -v $group_pid | grep -v run_ktools)
+   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | grep -v *.sh)
    echo "$PIDS_KILL" >> log/killout.txt
    kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
    exit $exit_code

--- a/tests/model_execution/err_kparse_reference/gul_ord_ept_psept_lec_2_output_10_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_ord_ept_psept_lec_2_output_10_partition.sh
@@ -1,0 +1,305 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+
+touch log/stderror.err
+ktools_monitor.sh $$ & pid0=$!
+
+exit_handler(){
+   exit_code=$?
+   kill -9 $pid0 2> /dev/null
+   if [ "$exit_code" -gt 0 ]; then
+       echo 'Ktools Run Error - exitcode='$exit_code
+   else
+       echo 'Run Completed'
+   fi
+
+   set +x
+   group_pid=$(ps -p $$ -o pgid --no-headers)
+   sess_pid=$(ps -p $$ -o sess --no-headers)
+   script_pid=$$
+   printf "Script PID:%d, GPID:%s, SPID:%d
+" $script_pid $group_pid $sess_pid >> log/killout.txt
+
+   ps f -g $sess_pid > log/subprocess_list
+   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk -F: '$1>$script_pid' | grep -v celery | grep -v python | grep -v $group_pid | grep -v run_ktools)
+   echo "$PIDS_KILL" >> log/killout.txt
+   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+   exit $exit_code
+}
+trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
+
+check_complete(){
+    set +e
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
+    has_error=0
+    for p in $proc_list; do
+        started=$(find log -name "$p*.log" | wc -l)
+        finished=$(find log -name "$p*.log" -exec grep -l "finish" {} + | wc -l)
+        if [ "$finished" -lt "$started" ]; then
+            echo "[ERROR] $p - $((started-finished)) processes lost"
+            has_error=1
+        elif [ "$started" -gt 0 ]; then
+            echo "[OK] $p"
+        fi
+    done
+    if [ "$has_error" -ne 0 ]; then
+        false # raise non-zero exit code
+    fi
+}
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+
+rm -R -f fifo/*
+rm -R -f work/*
+mkdir work/kat/
+
+mkdir work/gul_S1_summaryleccalc
+mkdir work/gul_S1_summaryaalcalc
+mkdir work/gul_S2_summaryleccalc
+mkdir work/gul_S2_summaryaalcalc
+
+mkfifo fifo/gul_P1
+mkfifo fifo/gul_P2
+mkfifo fifo/gul_P3
+mkfifo fifo/gul_P4
+mkfifo fifo/gul_P5
+mkfifo fifo/gul_P6
+mkfifo fifo/gul_P7
+mkfifo fifo/gul_P8
+mkfifo fifo/gul_P9
+mkfifo fifo/gul_P10
+
+mkfifo fifo/gul_S1_summary_P1
+mkfifo fifo/gul_S1_eltcalc_P1
+mkfifo fifo/gul_S1_summarycalc_P1
+mkfifo fifo/gul_S1_pltcalc_P1
+mkfifo fifo/gul_S2_summary_P1
+mkfifo fifo/gul_S2_eltcalc_P1
+mkfifo fifo/gul_S2_summarycalc_P1
+mkfifo fifo/gul_S2_pltcalc_P1
+
+mkfifo fifo/gul_S1_summary_P2
+mkfifo fifo/gul_S1_eltcalc_P2
+mkfifo fifo/gul_S1_summarycalc_P2
+mkfifo fifo/gul_S1_pltcalc_P2
+mkfifo fifo/gul_S2_summary_P2
+mkfifo fifo/gul_S2_eltcalc_P2
+mkfifo fifo/gul_S2_summarycalc_P2
+mkfifo fifo/gul_S2_pltcalc_P2
+
+mkfifo fifo/gul_S1_summary_P3
+mkfifo fifo/gul_S1_eltcalc_P3
+mkfifo fifo/gul_S1_summarycalc_P3
+mkfifo fifo/gul_S1_pltcalc_P3
+mkfifo fifo/gul_S2_summary_P3
+mkfifo fifo/gul_S2_eltcalc_P3
+mkfifo fifo/gul_S2_summarycalc_P3
+mkfifo fifo/gul_S2_pltcalc_P3
+
+mkfifo fifo/gul_S1_summary_P4
+mkfifo fifo/gul_S1_eltcalc_P4
+mkfifo fifo/gul_S1_summarycalc_P4
+mkfifo fifo/gul_S1_pltcalc_P4
+mkfifo fifo/gul_S2_summary_P4
+mkfifo fifo/gul_S2_eltcalc_P4
+mkfifo fifo/gul_S2_summarycalc_P4
+mkfifo fifo/gul_S2_pltcalc_P4
+
+mkfifo fifo/gul_S1_summary_P5
+mkfifo fifo/gul_S1_eltcalc_P5
+mkfifo fifo/gul_S1_summarycalc_P5
+mkfifo fifo/gul_S1_pltcalc_P5
+mkfifo fifo/gul_S2_summary_P5
+mkfifo fifo/gul_S2_eltcalc_P5
+mkfifo fifo/gul_S2_summarycalc_P5
+mkfifo fifo/gul_S2_pltcalc_P5
+
+mkfifo fifo/gul_S1_summary_P6
+mkfifo fifo/gul_S1_eltcalc_P6
+mkfifo fifo/gul_S1_summarycalc_P6
+mkfifo fifo/gul_S1_pltcalc_P6
+mkfifo fifo/gul_S2_summary_P6
+mkfifo fifo/gul_S2_eltcalc_P6
+mkfifo fifo/gul_S2_summarycalc_P6
+mkfifo fifo/gul_S2_pltcalc_P6
+
+mkfifo fifo/gul_S1_summary_P7
+mkfifo fifo/gul_S1_eltcalc_P7
+mkfifo fifo/gul_S1_summarycalc_P7
+mkfifo fifo/gul_S1_pltcalc_P7
+mkfifo fifo/gul_S2_summary_P7
+mkfifo fifo/gul_S2_eltcalc_P7
+mkfifo fifo/gul_S2_summarycalc_P7
+mkfifo fifo/gul_S2_pltcalc_P7
+
+mkfifo fifo/gul_S1_summary_P8
+mkfifo fifo/gul_S1_eltcalc_P8
+mkfifo fifo/gul_S1_summarycalc_P8
+mkfifo fifo/gul_S1_pltcalc_P8
+mkfifo fifo/gul_S2_summary_P8
+mkfifo fifo/gul_S2_eltcalc_P8
+mkfifo fifo/gul_S2_summarycalc_P8
+mkfifo fifo/gul_S2_pltcalc_P8
+
+mkfifo fifo/gul_S1_summary_P9
+mkfifo fifo/gul_S1_eltcalc_P9
+mkfifo fifo/gul_S1_summarycalc_P9
+mkfifo fifo/gul_S1_pltcalc_P9
+mkfifo fifo/gul_S2_summary_P9
+mkfifo fifo/gul_S2_eltcalc_P9
+mkfifo fifo/gul_S2_summarycalc_P9
+mkfifo fifo/gul_S2_pltcalc_P9
+
+mkfifo fifo/gul_S1_summary_P10
+mkfifo fifo/gul_S1_eltcalc_P10
+mkfifo fifo/gul_S1_summarycalc_P10
+mkfifo fifo/gul_S1_pltcalc_P10
+mkfifo fifo/gul_S2_summary_P10
+mkfifo fifo/gul_S2_eltcalc_P10
+mkfifo fifo/gul_S2_summarycalc_P10
+mkfifo fifo/gul_S2_pltcalc_P10
+
+
+
+# --- Do ground up loss computes ---
+
+( eltcalc < fifo/gul_S1_eltcalc_P1 > work/kat/gul_S1_eltcalc_P1 ) 2>> log/stderror.err & pid1=$!
+( summarycalctocsv < fifo/gul_S1_summarycalc_P1 > work/kat/gul_S1_summarycalc_P1 ) 2>> log/stderror.err & pid2=$!
+( pltcalc < fifo/gul_S1_pltcalc_P1 > work/kat/gul_S1_pltcalc_P1 ) 2>> log/stderror.err & pid3=$!
+( eltcalc < fifo/gul_S2_eltcalc_P1 > work/kat/gul_S2_eltcalc_P1 ) 2>> log/stderror.err & pid4=$!
+( summarycalctocsv < fifo/gul_S2_summarycalc_P1 > work/kat/gul_S2_summarycalc_P1 ) 2>> log/stderror.err & pid5=$!
+( pltcalc < fifo/gul_S2_pltcalc_P1 > work/kat/gul_S2_pltcalc_P1 ) 2>> log/stderror.err & pid6=$!
+( eltcalc -s < fifo/gul_S1_eltcalc_P2 > work/kat/gul_S1_eltcalc_P2 ) 2>> log/stderror.err & pid7=$!
+( summarycalctocsv -s < fifo/gul_S1_summarycalc_P2 > work/kat/gul_S1_summarycalc_P2 ) 2>> log/stderror.err & pid8=$!
+( pltcalc -s < fifo/gul_S1_pltcalc_P2 > work/kat/gul_S1_pltcalc_P2 ) 2>> log/stderror.err & pid9=$!
+( eltcalc -s < fifo/gul_S2_eltcalc_P2 > work/kat/gul_S2_eltcalc_P2 ) 2>> log/stderror.err & pid10=$!
+( summarycalctocsv -s < fifo/gul_S2_summarycalc_P2 > work/kat/gul_S2_summarycalc_P2 ) 2>> log/stderror.err & pid11=$!
+( pltcalc -s < fifo/gul_S2_pltcalc_P2 > work/kat/gul_S2_pltcalc_P2 ) 2>> log/stderror.err & pid12=$!
+( eltcalc -s < fifo/gul_S1_eltcalc_P3 > work/kat/gul_S1_eltcalc_P3 ) 2>> log/stderror.err & pid13=$!
+( summarycalctocsv -s < fifo/gul_S1_summarycalc_P3 > work/kat/gul_S1_summarycalc_P3 ) 2>> log/stderror.err & pid14=$!
+( pltcalc -s < fifo/gul_S1_pltcalc_P3 > work/kat/gul_S1_pltcalc_P3 ) 2>> log/stderror.err & pid15=$!
+( eltcalc -s < fifo/gul_S2_eltcalc_P3 > work/kat/gul_S2_eltcalc_P3 ) 2>> log/stderror.err & pid16=$!
+( summarycalctocsv -s < fifo/gul_S2_summarycalc_P3 > work/kat/gul_S2_summarycalc_P3 ) 2>> log/stderror.err & pid17=$!
+( pltcalc -s < fifo/gul_S2_pltcalc_P3 > work/kat/gul_S2_pltcalc_P3 ) 2>> log/stderror.err & pid18=$!
+( eltcalc -s < fifo/gul_S1_eltcalc_P4 > work/kat/gul_S1_eltcalc_P4 ) 2>> log/stderror.err & pid19=$!
+( summarycalctocsv -s < fifo/gul_S1_summarycalc_P4 > work/kat/gul_S1_summarycalc_P4 ) 2>> log/stderror.err & pid20=$!
+( pltcalc -s < fifo/gul_S1_pltcalc_P4 > work/kat/gul_S1_pltcalc_P4 ) 2>> log/stderror.err & pid21=$!
+( eltcalc -s < fifo/gul_S2_eltcalc_P4 > work/kat/gul_S2_eltcalc_P4 ) 2>> log/stderror.err & pid22=$!
+( summarycalctocsv -s < fifo/gul_S2_summarycalc_P4 > work/kat/gul_S2_summarycalc_P4 ) 2>> log/stderror.err & pid23=$!
+( pltcalc -s < fifo/gul_S2_pltcalc_P4 > work/kat/gul_S2_pltcalc_P4 ) 2>> log/stderror.err & pid24=$!
+( eltcalc -s < fifo/gul_S1_eltcalc_P5 > work/kat/gul_S1_eltcalc_P5 ) 2>> log/stderror.err & pid25=$!
+( summarycalctocsv -s < fifo/gul_S1_summarycalc_P5 > work/kat/gul_S1_summarycalc_P5 ) 2>> log/stderror.err & pid26=$!
+( pltcalc -s < fifo/gul_S1_pltcalc_P5 > work/kat/gul_S1_pltcalc_P5 ) 2>> log/stderror.err & pid27=$!
+( eltcalc -s < fifo/gul_S2_eltcalc_P5 > work/kat/gul_S2_eltcalc_P5 ) 2>> log/stderror.err & pid28=$!
+( summarycalctocsv -s < fifo/gul_S2_summarycalc_P5 > work/kat/gul_S2_summarycalc_P5 ) 2>> log/stderror.err & pid29=$!
+( pltcalc -s < fifo/gul_S2_pltcalc_P5 > work/kat/gul_S2_pltcalc_P5 ) 2>> log/stderror.err & pid30=$!
+( eltcalc -s < fifo/gul_S1_eltcalc_P6 > work/kat/gul_S1_eltcalc_P6 ) 2>> log/stderror.err & pid31=$!
+( summarycalctocsv -s < fifo/gul_S1_summarycalc_P6 > work/kat/gul_S1_summarycalc_P6 ) 2>> log/stderror.err & pid32=$!
+( pltcalc -s < fifo/gul_S1_pltcalc_P6 > work/kat/gul_S1_pltcalc_P6 ) 2>> log/stderror.err & pid33=$!
+( eltcalc -s < fifo/gul_S2_eltcalc_P6 > work/kat/gul_S2_eltcalc_P6 ) 2>> log/stderror.err & pid34=$!
+( summarycalctocsv -s < fifo/gul_S2_summarycalc_P6 > work/kat/gul_S2_summarycalc_P6 ) 2>> log/stderror.err & pid35=$!
+( pltcalc -s < fifo/gul_S2_pltcalc_P6 > work/kat/gul_S2_pltcalc_P6 ) 2>> log/stderror.err & pid36=$!
+( eltcalc -s < fifo/gul_S1_eltcalc_P7 > work/kat/gul_S1_eltcalc_P7 ) 2>> log/stderror.err & pid37=$!
+( summarycalctocsv -s < fifo/gul_S1_summarycalc_P7 > work/kat/gul_S1_summarycalc_P7 ) 2>> log/stderror.err & pid38=$!
+( pltcalc -s < fifo/gul_S1_pltcalc_P7 > work/kat/gul_S1_pltcalc_P7 ) 2>> log/stderror.err & pid39=$!
+( eltcalc -s < fifo/gul_S2_eltcalc_P7 > work/kat/gul_S2_eltcalc_P7 ) 2>> log/stderror.err & pid40=$!
+( summarycalctocsv -s < fifo/gul_S2_summarycalc_P7 > work/kat/gul_S2_summarycalc_P7 ) 2>> log/stderror.err & pid41=$!
+( pltcalc -s < fifo/gul_S2_pltcalc_P7 > work/kat/gul_S2_pltcalc_P7 ) 2>> log/stderror.err & pid42=$!
+( eltcalc -s < fifo/gul_S1_eltcalc_P8 > work/kat/gul_S1_eltcalc_P8 ) 2>> log/stderror.err & pid43=$!
+( summarycalctocsv -s < fifo/gul_S1_summarycalc_P8 > work/kat/gul_S1_summarycalc_P8 ) 2>> log/stderror.err & pid44=$!
+( pltcalc -s < fifo/gul_S1_pltcalc_P8 > work/kat/gul_S1_pltcalc_P8 ) 2>> log/stderror.err & pid45=$!
+( eltcalc -s < fifo/gul_S2_eltcalc_P8 > work/kat/gul_S2_eltcalc_P8 ) 2>> log/stderror.err & pid46=$!
+( summarycalctocsv -s < fifo/gul_S2_summarycalc_P8 > work/kat/gul_S2_summarycalc_P8 ) 2>> log/stderror.err & pid47=$!
+( pltcalc -s < fifo/gul_S2_pltcalc_P8 > work/kat/gul_S2_pltcalc_P8 ) 2>> log/stderror.err & pid48=$!
+( eltcalc -s < fifo/gul_S1_eltcalc_P9 > work/kat/gul_S1_eltcalc_P9 ) 2>> log/stderror.err & pid49=$!
+( summarycalctocsv -s < fifo/gul_S1_summarycalc_P9 > work/kat/gul_S1_summarycalc_P9 ) 2>> log/stderror.err & pid50=$!
+( pltcalc -s < fifo/gul_S1_pltcalc_P9 > work/kat/gul_S1_pltcalc_P9 ) 2>> log/stderror.err & pid51=$!
+( eltcalc -s < fifo/gul_S2_eltcalc_P9 > work/kat/gul_S2_eltcalc_P9 ) 2>> log/stderror.err & pid52=$!
+( summarycalctocsv -s < fifo/gul_S2_summarycalc_P9 > work/kat/gul_S2_summarycalc_P9 ) 2>> log/stderror.err & pid53=$!
+( pltcalc -s < fifo/gul_S2_pltcalc_P9 > work/kat/gul_S2_pltcalc_P9 ) 2>> log/stderror.err & pid54=$!
+( eltcalc -s < fifo/gul_S1_eltcalc_P10 > work/kat/gul_S1_eltcalc_P10 ) 2>> log/stderror.err & pid55=$!
+( summarycalctocsv -s < fifo/gul_S1_summarycalc_P10 > work/kat/gul_S1_summarycalc_P10 ) 2>> log/stderror.err & pid56=$!
+( pltcalc -s < fifo/gul_S1_pltcalc_P10 > work/kat/gul_S1_pltcalc_P10 ) 2>> log/stderror.err & pid57=$!
+( eltcalc -s < fifo/gul_S2_eltcalc_P10 > work/kat/gul_S2_eltcalc_P10 ) 2>> log/stderror.err & pid58=$!
+( summarycalctocsv -s < fifo/gul_S2_summarycalc_P10 > work/kat/gul_S2_summarycalc_P10 ) 2>> log/stderror.err & pid59=$!
+( pltcalc -s < fifo/gul_S2_pltcalc_P10 > work/kat/gul_S2_pltcalc_P10 ) 2>> log/stderror.err & pid60=$!
+
+tee < fifo/gul_S1_summary_P1 fifo/gul_S1_eltcalc_P1 fifo/gul_S1_summarycalc_P1 fifo/gul_S1_pltcalc_P1 work/gul_S1_summaryaalcalc/P1.bin work/gul_S1_summaryleccalc/P1.bin > /dev/null & pid61=$!
+tee < fifo/gul_S2_summary_P1 fifo/gul_S2_eltcalc_P1 fifo/gul_S2_summarycalc_P1 fifo/gul_S2_pltcalc_P1 work/gul_S2_summaryaalcalc/P1.bin work/gul_S2_summaryleccalc/P1.bin > /dev/null & pid62=$!
+tee < fifo/gul_S1_summary_P2 fifo/gul_S1_eltcalc_P2 fifo/gul_S1_summarycalc_P2 fifo/gul_S1_pltcalc_P2 work/gul_S1_summaryaalcalc/P2.bin work/gul_S1_summaryleccalc/P2.bin > /dev/null & pid63=$!
+tee < fifo/gul_S2_summary_P2 fifo/gul_S2_eltcalc_P2 fifo/gul_S2_summarycalc_P2 fifo/gul_S2_pltcalc_P2 work/gul_S2_summaryaalcalc/P2.bin work/gul_S2_summaryleccalc/P2.bin > /dev/null & pid64=$!
+tee < fifo/gul_S1_summary_P3 fifo/gul_S1_eltcalc_P3 fifo/gul_S1_summarycalc_P3 fifo/gul_S1_pltcalc_P3 work/gul_S1_summaryaalcalc/P3.bin work/gul_S1_summaryleccalc/P3.bin > /dev/null & pid65=$!
+tee < fifo/gul_S2_summary_P3 fifo/gul_S2_eltcalc_P3 fifo/gul_S2_summarycalc_P3 fifo/gul_S2_pltcalc_P3 work/gul_S2_summaryaalcalc/P3.bin work/gul_S2_summaryleccalc/P3.bin > /dev/null & pid66=$!
+tee < fifo/gul_S1_summary_P4 fifo/gul_S1_eltcalc_P4 fifo/gul_S1_summarycalc_P4 fifo/gul_S1_pltcalc_P4 work/gul_S1_summaryaalcalc/P4.bin work/gul_S1_summaryleccalc/P4.bin > /dev/null & pid67=$!
+tee < fifo/gul_S2_summary_P4 fifo/gul_S2_eltcalc_P4 fifo/gul_S2_summarycalc_P4 fifo/gul_S2_pltcalc_P4 work/gul_S2_summaryaalcalc/P4.bin work/gul_S2_summaryleccalc/P4.bin > /dev/null & pid68=$!
+tee < fifo/gul_S1_summary_P5 fifo/gul_S1_eltcalc_P5 fifo/gul_S1_summarycalc_P5 fifo/gul_S1_pltcalc_P5 work/gul_S1_summaryaalcalc/P5.bin work/gul_S1_summaryleccalc/P5.bin > /dev/null & pid69=$!
+tee < fifo/gul_S2_summary_P5 fifo/gul_S2_eltcalc_P5 fifo/gul_S2_summarycalc_P5 fifo/gul_S2_pltcalc_P5 work/gul_S2_summaryaalcalc/P5.bin work/gul_S2_summaryleccalc/P5.bin > /dev/null & pid70=$!
+tee < fifo/gul_S1_summary_P6 fifo/gul_S1_eltcalc_P6 fifo/gul_S1_summarycalc_P6 fifo/gul_S1_pltcalc_P6 work/gul_S1_summaryaalcalc/P6.bin work/gul_S1_summaryleccalc/P6.bin > /dev/null & pid71=$!
+tee < fifo/gul_S2_summary_P6 fifo/gul_S2_eltcalc_P6 fifo/gul_S2_summarycalc_P6 fifo/gul_S2_pltcalc_P6 work/gul_S2_summaryaalcalc/P6.bin work/gul_S2_summaryleccalc/P6.bin > /dev/null & pid72=$!
+tee < fifo/gul_S1_summary_P7 fifo/gul_S1_eltcalc_P7 fifo/gul_S1_summarycalc_P7 fifo/gul_S1_pltcalc_P7 work/gul_S1_summaryaalcalc/P7.bin work/gul_S1_summaryleccalc/P7.bin > /dev/null & pid73=$!
+tee < fifo/gul_S2_summary_P7 fifo/gul_S2_eltcalc_P7 fifo/gul_S2_summarycalc_P7 fifo/gul_S2_pltcalc_P7 work/gul_S2_summaryaalcalc/P7.bin work/gul_S2_summaryleccalc/P7.bin > /dev/null & pid74=$!
+tee < fifo/gul_S1_summary_P8 fifo/gul_S1_eltcalc_P8 fifo/gul_S1_summarycalc_P8 fifo/gul_S1_pltcalc_P8 work/gul_S1_summaryaalcalc/P8.bin work/gul_S1_summaryleccalc/P8.bin > /dev/null & pid75=$!
+tee < fifo/gul_S2_summary_P8 fifo/gul_S2_eltcalc_P8 fifo/gul_S2_summarycalc_P8 fifo/gul_S2_pltcalc_P8 work/gul_S2_summaryaalcalc/P8.bin work/gul_S2_summaryleccalc/P8.bin > /dev/null & pid76=$!
+tee < fifo/gul_S1_summary_P9 fifo/gul_S1_eltcalc_P9 fifo/gul_S1_summarycalc_P9 fifo/gul_S1_pltcalc_P9 work/gul_S1_summaryaalcalc/P9.bin work/gul_S1_summaryleccalc/P9.bin > /dev/null & pid77=$!
+tee < fifo/gul_S2_summary_P9 fifo/gul_S2_eltcalc_P9 fifo/gul_S2_summarycalc_P9 fifo/gul_S2_pltcalc_P9 work/gul_S2_summaryaalcalc/P9.bin work/gul_S2_summaryleccalc/P9.bin > /dev/null & pid78=$!
+tee < fifo/gul_S1_summary_P10 fifo/gul_S1_eltcalc_P10 fifo/gul_S1_summarycalc_P10 fifo/gul_S1_pltcalc_P10 work/gul_S1_summaryaalcalc/P10.bin work/gul_S1_summaryleccalc/P10.bin > /dev/null & pid79=$!
+tee < fifo/gul_S2_summary_P10 fifo/gul_S2_eltcalc_P10 fifo/gul_S2_summarycalc_P10 fifo/gul_S2_pltcalc_P10 work/gul_S2_summaryaalcalc/P10.bin work/gul_S2_summaryleccalc/P10.bin > /dev/null & pid80=$!
+
+( summarycalc -i  -1 fifo/gul_S1_summary_P1 -2 fifo/gul_S2_summary_P1 < fifo/gul_P1 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P2 -2 fifo/gul_S2_summary_P2 < fifo/gul_P2 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P3 -2 fifo/gul_S2_summary_P3 < fifo/gul_P3 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P4 -2 fifo/gul_S2_summary_P4 < fifo/gul_P4 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P5 -2 fifo/gul_S2_summary_P5 < fifo/gul_P5 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P6 -2 fifo/gul_S2_summary_P6 < fifo/gul_P6 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P7 -2 fifo/gul_S2_summary_P7 < fifo/gul_P7 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P8 -2 fifo/gul_S2_summary_P8 < fifo/gul_P8 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P9 -2 fifo/gul_S2_summary_P9 < fifo/gul_P9 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P10 -2 fifo/gul_S2_summary_P10 < fifo/gul_P10 ) 2>> log/stderror.err  &
+
+( eve 1 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P1  ) 2>> log/stderror.err &
+( eve 2 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P2  ) 2>> log/stderror.err &
+( eve 3 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P3  ) 2>> log/stderror.err &
+( eve 4 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P4  ) 2>> log/stderror.err &
+( eve 5 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P5  ) 2>> log/stderror.err &
+( eve 6 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P6  ) 2>> log/stderror.err &
+( eve 7 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P7  ) 2>> log/stderror.err &
+( eve 8 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P8  ) 2>> log/stderror.err &
+( eve 9 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P9  ) 2>> log/stderror.err &
+( eve 10 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P10  ) 2>> log/stderror.err &
+
+wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 $pid13 $pid14 $pid15 $pid16 $pid17 $pid18 $pid19 $pid20 $pid21 $pid22 $pid23 $pid24 $pid25 $pid26 $pid27 $pid28 $pid29 $pid30 $pid31 $pid32 $pid33 $pid34 $pid35 $pid36 $pid37 $pid38 $pid39 $pid40 $pid41 $pid42 $pid43 $pid44 $pid45 $pid46 $pid47 $pid48 $pid49 $pid50 $pid51 $pid52 $pid53 $pid54 $pid55 $pid56 $pid57 $pid58 $pid59 $pid60 $pid61 $pid62 $pid63 $pid64 $pid65 $pid66 $pid67 $pid68 $pid69 $pid70 $pid71 $pid72 $pid73 $pid74 $pid75 $pid76 $pid77 $pid78 $pid79 $pid80
+
+
+# --- Do ground up loss kats ---
+
+kat -s work/kat/gul_S1_eltcalc_P1 work/kat/gul_S1_eltcalc_P2 work/kat/gul_S1_eltcalc_P3 work/kat/gul_S1_eltcalc_P4 work/kat/gul_S1_eltcalc_P5 work/kat/gul_S1_eltcalc_P6 work/kat/gul_S1_eltcalc_P7 work/kat/gul_S1_eltcalc_P8 work/kat/gul_S1_eltcalc_P9 work/kat/gul_S1_eltcalc_P10 > output/gul_S1_eltcalc.csv & kpid1=$!
+kat work/kat/gul_S1_pltcalc_P1 work/kat/gul_S1_pltcalc_P2 work/kat/gul_S1_pltcalc_P3 work/kat/gul_S1_pltcalc_P4 work/kat/gul_S1_pltcalc_P5 work/kat/gul_S1_pltcalc_P6 work/kat/gul_S1_pltcalc_P7 work/kat/gul_S1_pltcalc_P8 work/kat/gul_S1_pltcalc_P9 work/kat/gul_S1_pltcalc_P10 > output/gul_S1_pltcalc.csv & kpid2=$!
+kat work/kat/gul_S1_summarycalc_P1 work/kat/gul_S1_summarycalc_P2 work/kat/gul_S1_summarycalc_P3 work/kat/gul_S1_summarycalc_P4 work/kat/gul_S1_summarycalc_P5 work/kat/gul_S1_summarycalc_P6 work/kat/gul_S1_summarycalc_P7 work/kat/gul_S1_summarycalc_P8 work/kat/gul_S1_summarycalc_P9 work/kat/gul_S1_summarycalc_P10 > output/gul_S1_summarycalc.csv & kpid3=$!
+kat -s work/kat/gul_S2_eltcalc_P1 work/kat/gul_S2_eltcalc_P2 work/kat/gul_S2_eltcalc_P3 work/kat/gul_S2_eltcalc_P4 work/kat/gul_S2_eltcalc_P5 work/kat/gul_S2_eltcalc_P6 work/kat/gul_S2_eltcalc_P7 work/kat/gul_S2_eltcalc_P8 work/kat/gul_S2_eltcalc_P9 work/kat/gul_S2_eltcalc_P10 > output/gul_S2_eltcalc.csv & kpid4=$!
+kat work/kat/gul_S2_pltcalc_P1 work/kat/gul_S2_pltcalc_P2 work/kat/gul_S2_pltcalc_P3 work/kat/gul_S2_pltcalc_P4 work/kat/gul_S2_pltcalc_P5 work/kat/gul_S2_pltcalc_P6 work/kat/gul_S2_pltcalc_P7 work/kat/gul_S2_pltcalc_P8 work/kat/gul_S2_pltcalc_P9 work/kat/gul_S2_pltcalc_P10 > output/gul_S2_pltcalc.csv & kpid5=$!
+kat work/kat/gul_S2_summarycalc_P1 work/kat/gul_S2_summarycalc_P2 work/kat/gul_S2_summarycalc_P3 work/kat/gul_S2_summarycalc_P4 work/kat/gul_S2_summarycalc_P5 work/kat/gul_S2_summarycalc_P6 work/kat/gul_S2_summarycalc_P7 work/kat/gul_S2_summarycalc_P8 work/kat/gul_S2_summarycalc_P9 work/kat/gul_S2_summarycalc_P10 > output/gul_S2_summarycalc.csv & kpid6=$!
+wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
+
+
+( aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv ) 2>> log/stderror.err & lpid1=$!
+( ordleccalc -r -Kgul_S1_summaryleccalc -F -S -s -M -m -W -w -O output/gul_S1_ept.csv -o output/gul_S1_psept.csv ) 2>> log/stderror.err & lpid2=$!
+( leccalc -r -Kgul_S1_summaryleccalc -F output/gul_S1_leccalc_full_uncertainty_aep.csv -f output/gul_S1_leccalc_full_uncertainty_oep.csv -S output/gul_S1_leccalc_sample_mean_aep.csv -s output/gul_S1_leccalc_sample_mean_oep.csv -W output/gul_S1_leccalc_wheatsheaf_aep.csv -M output/gul_S1_leccalc_wheatsheaf_mean_aep.csv -m output/gul_S1_leccalc_wheatsheaf_mean_oep.csv -w output/gul_S1_leccalc_wheatsheaf_oep.csv ) 2>> log/stderror.err & lpid3=$!
+( aalcalc -Kgul_S2_summaryaalcalc > output/gul_S2_aalcalc.csv ) 2>> log/stderror.err & lpid4=$!
+( ordleccalc -r -Kgul_S2_summaryleccalc -F -S -s -M -m -W -w -O output/gul_S2_ept.csv -o output/gul_S2_psept.csv ) 2>> log/stderror.err & lpid5=$!
+( leccalc -r -Kgul_S2_summaryleccalc -F output/gul_S2_leccalc_full_uncertainty_aep.csv -f output/gul_S2_leccalc_full_uncertainty_oep.csv -S output/gul_S2_leccalc_sample_mean_aep.csv -s output/gul_S2_leccalc_sample_mean_oep.csv -W output/gul_S2_leccalc_wheatsheaf_aep.csv -M output/gul_S2_leccalc_wheatsheaf_mean_aep.csv -m output/gul_S2_leccalc_wheatsheaf_mean_oep.csv -w output/gul_S2_leccalc_wheatsheaf_oep.csv ) 2>> log/stderror.err & lpid6=$!
+wait $lpid1 $lpid2 $lpid3 $lpid4 $lpid5 $lpid6
+
+rm -R -f work/*
+rm -R -f fifo/*
+
+check_complete
+exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_ord_ept_psept_lec_2_output_10_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_ord_ept_psept_lec_2_output_10_partition.sh
@@ -29,7 +29,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
    ps f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk -F: '$1>$script_pid' | grep -v celery | grep -v python | grep -v $group_pid | grep -v run_ktools)
+   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | grep -v *.sh)
    echo "$PIDS_KILL" >> log/killout.txt
    kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
    exit $exit_code

--- a/tests/model_execution/err_kparse_reference/gul_ord_psept_2_output_10_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_ord_psept_2_output_10_partition.sh
@@ -1,0 +1,171 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+
+touch log/stderror.err
+ktools_monitor.sh $$ & pid0=$!
+
+exit_handler(){
+   exit_code=$?
+   kill -9 $pid0 2> /dev/null
+   if [ "$exit_code" -gt 0 ]; then
+       echo 'Ktools Run Error - exitcode='$exit_code
+   else
+       echo 'Run Completed'
+   fi
+
+   set +x
+   group_pid=$(ps -p $$ -o pgid --no-headers)
+   sess_pid=$(ps -p $$ -o sess --no-headers)
+   script_pid=$$
+   printf "Script PID:%d, GPID:%s, SPID:%d
+" $script_pid $group_pid $sess_pid >> log/killout.txt
+
+   ps f -g $sess_pid > log/subprocess_list
+   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk -F: '$1>$script_pid' | grep -v celery | grep -v python | grep -v $group_pid | grep -v run_ktools)
+   echo "$PIDS_KILL" >> log/killout.txt
+   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+   exit $exit_code
+}
+trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
+
+check_complete(){
+    set +e
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
+    has_error=0
+    for p in $proc_list; do
+        started=$(find log -name "$p*.log" | wc -l)
+        finished=$(find log -name "$p*.log" -exec grep -l "finish" {} + | wc -l)
+        if [ "$finished" -lt "$started" ]; then
+            echo "[ERROR] $p - $((started-finished)) processes lost"
+            has_error=1
+        elif [ "$started" -gt 0 ]; then
+            echo "[OK] $p"
+        fi
+    done
+    if [ "$has_error" -ne 0 ]; then
+        false # raise non-zero exit code
+    fi
+}
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+
+rm -R -f fifo/*
+rm -R -f work/*
+mkdir work/kat/
+
+mkdir work/gul_S1_summaryleccalc
+mkdir work/gul_S2_summaryleccalc
+
+mkfifo fifo/gul_P1
+mkfifo fifo/gul_P2
+mkfifo fifo/gul_P3
+mkfifo fifo/gul_P4
+mkfifo fifo/gul_P5
+mkfifo fifo/gul_P6
+mkfifo fifo/gul_P7
+mkfifo fifo/gul_P8
+mkfifo fifo/gul_P9
+mkfifo fifo/gul_P10
+
+mkfifo fifo/gul_S1_summary_P1
+mkfifo fifo/gul_S2_summary_P1
+
+mkfifo fifo/gul_S1_summary_P2
+mkfifo fifo/gul_S2_summary_P2
+
+mkfifo fifo/gul_S1_summary_P3
+mkfifo fifo/gul_S2_summary_P3
+
+mkfifo fifo/gul_S1_summary_P4
+mkfifo fifo/gul_S2_summary_P4
+
+mkfifo fifo/gul_S1_summary_P5
+mkfifo fifo/gul_S2_summary_P5
+
+mkfifo fifo/gul_S1_summary_P6
+mkfifo fifo/gul_S2_summary_P6
+
+mkfifo fifo/gul_S1_summary_P7
+mkfifo fifo/gul_S2_summary_P7
+
+mkfifo fifo/gul_S1_summary_P8
+mkfifo fifo/gul_S2_summary_P8
+
+mkfifo fifo/gul_S1_summary_P9
+mkfifo fifo/gul_S2_summary_P9
+
+mkfifo fifo/gul_S1_summary_P10
+mkfifo fifo/gul_S2_summary_P10
+
+
+
+# --- Do ground up loss computes ---
+
+
+tee < fifo/gul_S1_summary_P1 work/gul_S1_summaryleccalc/P1.bin > /dev/null & pid1=$!
+tee < fifo/gul_S2_summary_P1 work/gul_S2_summaryleccalc/P1.bin > /dev/null & pid2=$!
+tee < fifo/gul_S1_summary_P2 work/gul_S1_summaryleccalc/P2.bin > /dev/null & pid3=$!
+tee < fifo/gul_S2_summary_P2 work/gul_S2_summaryleccalc/P2.bin > /dev/null & pid4=$!
+tee < fifo/gul_S1_summary_P3 work/gul_S1_summaryleccalc/P3.bin > /dev/null & pid5=$!
+tee < fifo/gul_S2_summary_P3 work/gul_S2_summaryleccalc/P3.bin > /dev/null & pid6=$!
+tee < fifo/gul_S1_summary_P4 work/gul_S1_summaryleccalc/P4.bin > /dev/null & pid7=$!
+tee < fifo/gul_S2_summary_P4 work/gul_S2_summaryleccalc/P4.bin > /dev/null & pid8=$!
+tee < fifo/gul_S1_summary_P5 work/gul_S1_summaryleccalc/P5.bin > /dev/null & pid9=$!
+tee < fifo/gul_S2_summary_P5 work/gul_S2_summaryleccalc/P5.bin > /dev/null & pid10=$!
+tee < fifo/gul_S1_summary_P6 work/gul_S1_summaryleccalc/P6.bin > /dev/null & pid11=$!
+tee < fifo/gul_S2_summary_P6 work/gul_S2_summaryleccalc/P6.bin > /dev/null & pid12=$!
+tee < fifo/gul_S1_summary_P7 work/gul_S1_summaryleccalc/P7.bin > /dev/null & pid13=$!
+tee < fifo/gul_S2_summary_P7 work/gul_S2_summaryleccalc/P7.bin > /dev/null & pid14=$!
+tee < fifo/gul_S1_summary_P8 work/gul_S1_summaryleccalc/P8.bin > /dev/null & pid15=$!
+tee < fifo/gul_S2_summary_P8 work/gul_S2_summaryleccalc/P8.bin > /dev/null & pid16=$!
+tee < fifo/gul_S1_summary_P9 work/gul_S1_summaryleccalc/P9.bin > /dev/null & pid17=$!
+tee < fifo/gul_S2_summary_P9 work/gul_S2_summaryleccalc/P9.bin > /dev/null & pid18=$!
+tee < fifo/gul_S1_summary_P10 work/gul_S1_summaryleccalc/P10.bin > /dev/null & pid19=$!
+tee < fifo/gul_S2_summary_P10 work/gul_S2_summaryleccalc/P10.bin > /dev/null & pid20=$!
+
+( summarycalc -i  -1 fifo/gul_S1_summary_P1 -2 fifo/gul_S2_summary_P1 < fifo/gul_P1 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P2 -2 fifo/gul_S2_summary_P2 < fifo/gul_P2 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P3 -2 fifo/gul_S2_summary_P3 < fifo/gul_P3 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P4 -2 fifo/gul_S2_summary_P4 < fifo/gul_P4 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P5 -2 fifo/gul_S2_summary_P5 < fifo/gul_P5 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P6 -2 fifo/gul_S2_summary_P6 < fifo/gul_P6 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P7 -2 fifo/gul_S2_summary_P7 < fifo/gul_P7 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P8 -2 fifo/gul_S2_summary_P8 < fifo/gul_P8 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P9 -2 fifo/gul_S2_summary_P9 < fifo/gul_P9 ) 2>> log/stderror.err  &
+( summarycalc -i  -1 fifo/gul_S1_summary_P10 -2 fifo/gul_S2_summary_P10 < fifo/gul_P10 ) 2>> log/stderror.err  &
+
+( eve 1 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P1  ) 2>> log/stderror.err &
+( eve 2 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P2  ) 2>> log/stderror.err &
+( eve 3 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P3  ) 2>> log/stderror.err &
+( eve 4 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P4  ) 2>> log/stderror.err &
+( eve 5 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P5  ) 2>> log/stderror.err &
+( eve 6 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P6  ) 2>> log/stderror.err &
+( eve 7 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P7  ) 2>> log/stderror.err &
+( eve 8 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P8  ) 2>> log/stderror.err &
+( eve 9 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P9  ) 2>> log/stderror.err &
+( eve 10 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P10  ) 2>> log/stderror.err &
+
+wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 $pid13 $pid14 $pid15 $pid16 $pid17 $pid18 $pid19 $pid20
+
+
+# --- Do ground up loss kats ---
+
+
+( ordleccalc  -Kgul_S1_summaryleccalc -W -w -o output/gul_S1_psept.csv ) 2>> log/stderror.err & lpid1=$!
+( ordleccalc -r -Kgul_S2_summaryleccalc -W -w -o output/gul_S2_psept.csv ) 2>> log/stderror.err & lpid2=$!
+wait $lpid1 $lpid2
+
+rm -R -f work/*
+rm -R -f fifo/*
+
+check_complete
+exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_ord_psept_2_output_10_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_ord_psept_2_output_10_partition.sh
@@ -29,7 +29,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
    ps f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk -F: '$1>$script_pid' | grep -v celery | grep -v python | grep -v $group_pid | grep -v run_ktools)
+   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | grep -v *.sh)
    echo "$PIDS_KILL" >> log/killout.txt
    kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
    exit $exit_code

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/il_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_lec_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/il_lec_1_output_2_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_lec_1_output_2_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/il_lec_2_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_lec_2_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/il_lec_2_output_2_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_lec_2_output_2_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/il_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_no_lec_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/il_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_no_lec_1_output_2_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/il_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_no_lec_2_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/il_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_no_lec_2_output_2_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_1_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.sh
@@ -38,7 +38,7 @@ trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
 check_complete(){
     set +e
-    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc"
+    proc_list="eve getmodel gulcalc fmcalc summarycalc eltcalc aalcalc leccalc pltcalc ordleccalc"
     has_error=0
     for p in $proc_list; do
         started=$(find log -name "$p*.log" | wc -l)

--- a/tests/model_execution/eve_kparse_reference/analysis_settings_5_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/analysis_settings_5_1_reins_layer_1_partition.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+
+rm -R -f fifo/*
+rm -R -f work/*
+mkdir work/kat/
+
+mkdir work/gul_S1_summaryaalcalc
+mkdir work/il_S1_summaryleccalc
+mkdir work/ri_S1_summaryleccalc
+
+mkfifo fifo/gul_P1
+mkfifo fifo/gul_P2
+
+mkfifo fifo/gul_S1_summary_P1
+mkfifo fifo/gul_S1_eltcalc_P1
+mkfifo fifo/gul_S1_summarycalc_P1
+mkfifo fifo/gul_S1_pltcalc_P1
+
+mkfifo fifo/gul_S1_summary_P2
+mkfifo fifo/gul_S1_eltcalc_P2
+mkfifo fifo/gul_S1_summarycalc_P2
+mkfifo fifo/gul_S1_pltcalc_P2
+
+mkfifo fifo/il_P1
+mkfifo fifo/il_P2
+
+mkfifo fifo/il_S1_summary_P1
+
+mkfifo fifo/il_S1_summary_P2
+
+mkfifo fifo/ri_P1
+mkfifo fifo/ri_P2
+
+mkfifo fifo/ri_S1_summary_P1
+
+mkfifo fifo/ri_S1_summary_P2
+
+mkfifo fifo/gul_lb_P1
+mkfifo fifo/gul_lb_P2
+
+mkfifo fifo/lb_il_P1
+mkfifo fifo/lb_il_P2
+
+
+
+# --- Do reinsurance loss computes ---
+
+
+tee < fifo/ri_S1_summary_P1 work/ri_S1_summaryleccalc/P1.bin > /dev/null & pid1=$!
+tee < fifo/ri_S1_summary_P2 work/ri_S1_summaryleccalc/P2.bin > /dev/null & pid2=$!
+
+summarycalc -f -p RI_1 -1 fifo/ri_S1_summary_P1 < fifo/ri_P1 &
+summarycalc -f -p RI_1 -1 fifo/ri_S1_summary_P2 < fifo/ri_P2 &
+
+# --- Do insured loss computes ---
+
+
+tee < fifo/il_S1_summary_P1 work/il_S1_summaryleccalc/P1.bin > /dev/null & pid3=$!
+tee < fifo/il_S1_summary_P2 work/il_S1_summaryleccalc/P2.bin > /dev/null & pid4=$!
+
+summarycalc -f  -1 fifo/il_S1_summary_P1 < fifo/il_P1 &
+summarycalc -f  -1 fifo/il_S1_summary_P2 < fifo/il_P2 &
+
+# --- Do ground up loss computes ---
+
+eltcalc < fifo/gul_S1_eltcalc_P1 > work/kat/gul_S1_eltcalc_P1 & pid5=$!
+summarycalctocsv < fifo/gul_S1_summarycalc_P1 > work/kat/gul_S1_summarycalc_P1 & pid6=$!
+pltcalc < fifo/gul_S1_pltcalc_P1 > work/kat/gul_S1_pltcalc_P1 & pid7=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P2 > work/kat/gul_S1_eltcalc_P2 & pid8=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P2 > work/kat/gul_S1_summarycalc_P2 & pid9=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P2 > work/kat/gul_S1_pltcalc_P2 & pid10=$!
+
+tee < fifo/gul_S1_summary_P1 fifo/gul_S1_eltcalc_P1 fifo/gul_S1_summarycalc_P1 fifo/gul_S1_pltcalc_P1 work/gul_S1_summaryaalcalc/P1.bin > /dev/null & pid11=$!
+tee < fifo/gul_S1_summary_P2 fifo/gul_S1_eltcalc_P2 fifo/gul_S1_summarycalc_P2 fifo/gul_S1_pltcalc_P2 work/gul_S1_summaryaalcalc/P2.bin > /dev/null & pid12=$!
+
+summarycalc -i  -1 fifo/gul_S1_summary_P1 < fifo/gul_P1 &
+summarycalc -i  -1 fifo/gul_S1_summary_P2 < fifo/gul_P2 &
+
+eve -R 1 2 | getmodel | gulcalc -S0 -L0 -r -a0 -i - | tee fifo/gul_P1 > fifo/gul_lb_P1  &
+eve -R 2 2 | getmodel | gulcalc -S0 -L0 -r -a0 -i - | tee fifo/gul_P2 > fifo/gul_lb_P2  &
+load_balancer -i fifo/gul_lb_P1 fifo/gul_lb_P2 -o fifo/lb_il_P1 fifo/lb_il_P2 &
+fmcalc -a2 < fifo/lb_il_P1 | tee fifo/il_P1 | fmcalc -a2 -n -p RI_1 > fifo/ri_P1 &
+fmcalc -a2 < fifo/lb_il_P2 | tee fifo/il_P2 | fmcalc -a2 -n -p RI_1 > fifo/ri_P2 &
+
+wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12
+
+
+# --- Do reinsurance loss kats ---
+
+
+# --- Do insured loss kats ---
+
+
+# --- Do ground up loss kats ---
+
+kat work/kat/gul_S1_eltcalc_P1 work/kat/gul_S1_eltcalc_P2 > output/gul_S1_eltcalc.csv & kpid1=$!
+kat work/kat/gul_S1_pltcalc_P1 work/kat/gul_S1_pltcalc_P2 > output/gul_S1_pltcalc.csv & kpid2=$!
+kat work/kat/gul_S1_summarycalc_P1 work/kat/gul_S1_summarycalc_P2 > output/gul_S1_summarycalc.csv & kpid3=$!
+wait $kpid1 $kpid2 $kpid3
+
+
+ordleccalc -r -Kri_S1_summaryleccalc -F -f -S -s -M -m -W -w -O output/ri_S1_ept.csv -o output/ri_S1_psept.csv & lpid1=$!
+ordleccalc  -Kil_S1_summaryleccalc -F -S -s -M -m -O output/il_S1_ept.csv & lpid2=$!
+aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv & lpid3=$!
+wait $lpid1 $lpid2 $lpid3
+
+rm -R -f work/*
+rm -R -f fifo/*

--- a/tests/model_execution/eve_kparse_reference/gul_il_ord_ept_psept_2_output_10_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_il_ord_ept_psept_2_output_10_partition.sh
@@ -1,0 +1,334 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+
+rm -R -f fifo/*
+rm -R -f work/*
+mkdir work/kat/
+
+mkdir work/gul_S1_summaryleccalc
+mkdir work/gul_S1_summaryaalcalc
+mkdir work/gul_S2_summaryleccalc
+mkdir work/gul_S2_summaryaalcalc
+mkdir work/il_S1_summaryleccalc
+mkdir work/il_S1_summaryaalcalc
+mkdir work/il_S2_summaryleccalc
+mkdir work/il_S2_summaryaalcalc
+
+mkfifo fifo/gul_P1
+mkfifo fifo/gul_P2
+mkfifo fifo/gul_P3
+mkfifo fifo/gul_P4
+mkfifo fifo/gul_P5
+mkfifo fifo/gul_P6
+
+mkfifo fifo/gul_S1_summary_P1
+mkfifo fifo/gul_S1_eltcalc_P1
+mkfifo fifo/gul_S1_summarycalc_P1
+mkfifo fifo/gul_S1_pltcalc_P1
+mkfifo fifo/gul_S2_summary_P1
+mkfifo fifo/gul_S2_eltcalc_P1
+mkfifo fifo/gul_S2_summarycalc_P1
+mkfifo fifo/gul_S2_pltcalc_P1
+
+mkfifo fifo/gul_S1_summary_P2
+mkfifo fifo/gul_S1_eltcalc_P2
+mkfifo fifo/gul_S1_summarycalc_P2
+mkfifo fifo/gul_S1_pltcalc_P2
+mkfifo fifo/gul_S2_summary_P2
+mkfifo fifo/gul_S2_eltcalc_P2
+mkfifo fifo/gul_S2_summarycalc_P2
+mkfifo fifo/gul_S2_pltcalc_P2
+
+mkfifo fifo/gul_S1_summary_P3
+mkfifo fifo/gul_S1_eltcalc_P3
+mkfifo fifo/gul_S1_summarycalc_P3
+mkfifo fifo/gul_S1_pltcalc_P3
+mkfifo fifo/gul_S2_summary_P3
+mkfifo fifo/gul_S2_eltcalc_P3
+mkfifo fifo/gul_S2_summarycalc_P3
+mkfifo fifo/gul_S2_pltcalc_P3
+
+mkfifo fifo/gul_S1_summary_P4
+mkfifo fifo/gul_S1_eltcalc_P4
+mkfifo fifo/gul_S1_summarycalc_P4
+mkfifo fifo/gul_S1_pltcalc_P4
+mkfifo fifo/gul_S2_summary_P4
+mkfifo fifo/gul_S2_eltcalc_P4
+mkfifo fifo/gul_S2_summarycalc_P4
+mkfifo fifo/gul_S2_pltcalc_P4
+
+mkfifo fifo/gul_S1_summary_P5
+mkfifo fifo/gul_S1_eltcalc_P5
+mkfifo fifo/gul_S1_summarycalc_P5
+mkfifo fifo/gul_S1_pltcalc_P5
+mkfifo fifo/gul_S2_summary_P5
+mkfifo fifo/gul_S2_eltcalc_P5
+mkfifo fifo/gul_S2_summarycalc_P5
+mkfifo fifo/gul_S2_pltcalc_P5
+
+mkfifo fifo/gul_S1_summary_P6
+mkfifo fifo/gul_S1_eltcalc_P6
+mkfifo fifo/gul_S1_summarycalc_P6
+mkfifo fifo/gul_S1_pltcalc_P6
+mkfifo fifo/gul_S2_summary_P6
+mkfifo fifo/gul_S2_eltcalc_P6
+mkfifo fifo/gul_S2_summarycalc_P6
+mkfifo fifo/gul_S2_pltcalc_P6
+
+mkfifo fifo/il_P1
+mkfifo fifo/il_P2
+mkfifo fifo/il_P3
+mkfifo fifo/il_P4
+mkfifo fifo/il_P5
+mkfifo fifo/il_P6
+
+mkfifo fifo/il_S1_summary_P1
+mkfifo fifo/il_S1_eltcalc_P1
+mkfifo fifo/il_S1_summarycalc_P1
+mkfifo fifo/il_S1_pltcalc_P1
+mkfifo fifo/il_S2_summary_P1
+mkfifo fifo/il_S2_eltcalc_P1
+mkfifo fifo/il_S2_summarycalc_P1
+mkfifo fifo/il_S2_pltcalc_P1
+
+mkfifo fifo/il_S1_summary_P2
+mkfifo fifo/il_S1_eltcalc_P2
+mkfifo fifo/il_S1_summarycalc_P2
+mkfifo fifo/il_S1_pltcalc_P2
+mkfifo fifo/il_S2_summary_P2
+mkfifo fifo/il_S2_eltcalc_P2
+mkfifo fifo/il_S2_summarycalc_P2
+mkfifo fifo/il_S2_pltcalc_P2
+
+mkfifo fifo/il_S1_summary_P3
+mkfifo fifo/il_S1_eltcalc_P3
+mkfifo fifo/il_S1_summarycalc_P3
+mkfifo fifo/il_S1_pltcalc_P3
+mkfifo fifo/il_S2_summary_P3
+mkfifo fifo/il_S2_eltcalc_P3
+mkfifo fifo/il_S2_summarycalc_P3
+mkfifo fifo/il_S2_pltcalc_P3
+
+mkfifo fifo/il_S1_summary_P4
+mkfifo fifo/il_S1_eltcalc_P4
+mkfifo fifo/il_S1_summarycalc_P4
+mkfifo fifo/il_S1_pltcalc_P4
+mkfifo fifo/il_S2_summary_P4
+mkfifo fifo/il_S2_eltcalc_P4
+mkfifo fifo/il_S2_summarycalc_P4
+mkfifo fifo/il_S2_pltcalc_P4
+
+mkfifo fifo/il_S1_summary_P5
+mkfifo fifo/il_S1_eltcalc_P5
+mkfifo fifo/il_S1_summarycalc_P5
+mkfifo fifo/il_S1_pltcalc_P5
+mkfifo fifo/il_S2_summary_P5
+mkfifo fifo/il_S2_eltcalc_P5
+mkfifo fifo/il_S2_summarycalc_P5
+mkfifo fifo/il_S2_pltcalc_P5
+
+mkfifo fifo/il_S1_summary_P6
+mkfifo fifo/il_S1_eltcalc_P6
+mkfifo fifo/il_S1_summarycalc_P6
+mkfifo fifo/il_S1_pltcalc_P6
+mkfifo fifo/il_S2_summary_P6
+mkfifo fifo/il_S2_eltcalc_P6
+mkfifo fifo/il_S2_summarycalc_P6
+mkfifo fifo/il_S2_pltcalc_P6
+
+mkfifo fifo/gul_lb_P1
+mkfifo fifo/gul_lb_P2
+mkfifo fifo/gul_lb_P3
+mkfifo fifo/gul_lb_P4
+mkfifo fifo/gul_lb_P5
+mkfifo fifo/gul_lb_P6
+
+mkfifo fifo/lb_il_P1
+mkfifo fifo/lb_il_P2
+mkfifo fifo/lb_il_P3
+mkfifo fifo/lb_il_P4
+mkfifo fifo/lb_il_P5
+mkfifo fifo/lb_il_P6
+
+
+
+# --- Do insured loss computes ---
+
+eltcalc < fifo/il_S1_eltcalc_P1 > work/kat/il_S1_eltcalc_P1 & pid1=$!
+summarycalctocsv < fifo/il_S1_summarycalc_P1 > work/kat/il_S1_summarycalc_P1 & pid2=$!
+pltcalc < fifo/il_S1_pltcalc_P1 > work/kat/il_S1_pltcalc_P1 & pid3=$!
+eltcalc < fifo/il_S2_eltcalc_P1 > work/kat/il_S2_eltcalc_P1 & pid4=$!
+summarycalctocsv < fifo/il_S2_summarycalc_P1 > work/kat/il_S2_summarycalc_P1 & pid5=$!
+pltcalc < fifo/il_S2_pltcalc_P1 > work/kat/il_S2_pltcalc_P1 & pid6=$!
+eltcalc -s < fifo/il_S1_eltcalc_P2 > work/kat/il_S1_eltcalc_P2 & pid7=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P2 > work/kat/il_S1_summarycalc_P2 & pid8=$!
+pltcalc -s < fifo/il_S1_pltcalc_P2 > work/kat/il_S1_pltcalc_P2 & pid9=$!
+eltcalc -s < fifo/il_S2_eltcalc_P2 > work/kat/il_S2_eltcalc_P2 & pid10=$!
+summarycalctocsv -s < fifo/il_S2_summarycalc_P2 > work/kat/il_S2_summarycalc_P2 & pid11=$!
+pltcalc -s < fifo/il_S2_pltcalc_P2 > work/kat/il_S2_pltcalc_P2 & pid12=$!
+eltcalc -s < fifo/il_S1_eltcalc_P3 > work/kat/il_S1_eltcalc_P3 & pid13=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P3 > work/kat/il_S1_summarycalc_P3 & pid14=$!
+pltcalc -s < fifo/il_S1_pltcalc_P3 > work/kat/il_S1_pltcalc_P3 & pid15=$!
+eltcalc -s < fifo/il_S2_eltcalc_P3 > work/kat/il_S2_eltcalc_P3 & pid16=$!
+summarycalctocsv -s < fifo/il_S2_summarycalc_P3 > work/kat/il_S2_summarycalc_P3 & pid17=$!
+pltcalc -s < fifo/il_S2_pltcalc_P3 > work/kat/il_S2_pltcalc_P3 & pid18=$!
+eltcalc -s < fifo/il_S1_eltcalc_P4 > work/kat/il_S1_eltcalc_P4 & pid19=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P4 > work/kat/il_S1_summarycalc_P4 & pid20=$!
+pltcalc -s < fifo/il_S1_pltcalc_P4 > work/kat/il_S1_pltcalc_P4 & pid21=$!
+eltcalc -s < fifo/il_S2_eltcalc_P4 > work/kat/il_S2_eltcalc_P4 & pid22=$!
+summarycalctocsv -s < fifo/il_S2_summarycalc_P4 > work/kat/il_S2_summarycalc_P4 & pid23=$!
+pltcalc -s < fifo/il_S2_pltcalc_P4 > work/kat/il_S2_pltcalc_P4 & pid24=$!
+eltcalc -s < fifo/il_S1_eltcalc_P5 > work/kat/il_S1_eltcalc_P5 & pid25=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P5 > work/kat/il_S1_summarycalc_P5 & pid26=$!
+pltcalc -s < fifo/il_S1_pltcalc_P5 > work/kat/il_S1_pltcalc_P5 & pid27=$!
+eltcalc -s < fifo/il_S2_eltcalc_P5 > work/kat/il_S2_eltcalc_P5 & pid28=$!
+summarycalctocsv -s < fifo/il_S2_summarycalc_P5 > work/kat/il_S2_summarycalc_P5 & pid29=$!
+pltcalc -s < fifo/il_S2_pltcalc_P5 > work/kat/il_S2_pltcalc_P5 & pid30=$!
+eltcalc -s < fifo/il_S1_eltcalc_P6 > work/kat/il_S1_eltcalc_P6 & pid31=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P6 > work/kat/il_S1_summarycalc_P6 & pid32=$!
+pltcalc -s < fifo/il_S1_pltcalc_P6 > work/kat/il_S1_pltcalc_P6 & pid33=$!
+eltcalc -s < fifo/il_S2_eltcalc_P6 > work/kat/il_S2_eltcalc_P6 & pid34=$!
+summarycalctocsv -s < fifo/il_S2_summarycalc_P6 > work/kat/il_S2_summarycalc_P6 & pid35=$!
+pltcalc -s < fifo/il_S2_pltcalc_P6 > work/kat/il_S2_pltcalc_P6 & pid36=$!
+
+tee < fifo/il_S1_summary_P1 fifo/il_S1_eltcalc_P1 fifo/il_S1_summarycalc_P1 fifo/il_S1_pltcalc_P1 work/il_S1_summaryaalcalc/P1.bin work/il_S1_summaryleccalc/P1.bin > /dev/null & pid37=$!
+tee < fifo/il_S2_summary_P1 fifo/il_S2_eltcalc_P1 fifo/il_S2_summarycalc_P1 fifo/il_S2_pltcalc_P1 work/il_S2_summaryaalcalc/P1.bin work/il_S2_summaryleccalc/P1.bin > /dev/null & pid38=$!
+tee < fifo/il_S1_summary_P2 fifo/il_S1_eltcalc_P2 fifo/il_S1_summarycalc_P2 fifo/il_S1_pltcalc_P2 work/il_S1_summaryaalcalc/P2.bin work/il_S1_summaryleccalc/P2.bin > /dev/null & pid39=$!
+tee < fifo/il_S2_summary_P2 fifo/il_S2_eltcalc_P2 fifo/il_S2_summarycalc_P2 fifo/il_S2_pltcalc_P2 work/il_S2_summaryaalcalc/P2.bin work/il_S2_summaryleccalc/P2.bin > /dev/null & pid40=$!
+tee < fifo/il_S1_summary_P3 fifo/il_S1_eltcalc_P3 fifo/il_S1_summarycalc_P3 fifo/il_S1_pltcalc_P3 work/il_S1_summaryaalcalc/P3.bin work/il_S1_summaryleccalc/P3.bin > /dev/null & pid41=$!
+tee < fifo/il_S2_summary_P3 fifo/il_S2_eltcalc_P3 fifo/il_S2_summarycalc_P3 fifo/il_S2_pltcalc_P3 work/il_S2_summaryaalcalc/P3.bin work/il_S2_summaryleccalc/P3.bin > /dev/null & pid42=$!
+tee < fifo/il_S1_summary_P4 fifo/il_S1_eltcalc_P4 fifo/il_S1_summarycalc_P4 fifo/il_S1_pltcalc_P4 work/il_S1_summaryaalcalc/P4.bin work/il_S1_summaryleccalc/P4.bin > /dev/null & pid43=$!
+tee < fifo/il_S2_summary_P4 fifo/il_S2_eltcalc_P4 fifo/il_S2_summarycalc_P4 fifo/il_S2_pltcalc_P4 work/il_S2_summaryaalcalc/P4.bin work/il_S2_summaryleccalc/P4.bin > /dev/null & pid44=$!
+tee < fifo/il_S1_summary_P5 fifo/il_S1_eltcalc_P5 fifo/il_S1_summarycalc_P5 fifo/il_S1_pltcalc_P5 work/il_S1_summaryaalcalc/P5.bin work/il_S1_summaryleccalc/P5.bin > /dev/null & pid45=$!
+tee < fifo/il_S2_summary_P5 fifo/il_S2_eltcalc_P5 fifo/il_S2_summarycalc_P5 fifo/il_S2_pltcalc_P5 work/il_S2_summaryaalcalc/P5.bin work/il_S2_summaryleccalc/P5.bin > /dev/null & pid46=$!
+tee < fifo/il_S1_summary_P6 fifo/il_S1_eltcalc_P6 fifo/il_S1_summarycalc_P6 fifo/il_S1_pltcalc_P6 work/il_S1_summaryaalcalc/P6.bin work/il_S1_summaryleccalc/P6.bin > /dev/null & pid47=$!
+tee < fifo/il_S2_summary_P6 fifo/il_S2_eltcalc_P6 fifo/il_S2_summarycalc_P6 fifo/il_S2_pltcalc_P6 work/il_S2_summaryaalcalc/P6.bin work/il_S2_summaryleccalc/P6.bin > /dev/null & pid48=$!
+
+summarycalc -f  -1 fifo/il_S1_summary_P1 -2 fifo/il_S2_summary_P1 < fifo/il_P1 &
+summarycalc -f  -1 fifo/il_S1_summary_P2 -2 fifo/il_S2_summary_P2 < fifo/il_P2 &
+summarycalc -f  -1 fifo/il_S1_summary_P3 -2 fifo/il_S2_summary_P3 < fifo/il_P3 &
+summarycalc -f  -1 fifo/il_S1_summary_P4 -2 fifo/il_S2_summary_P4 < fifo/il_P4 &
+summarycalc -f  -1 fifo/il_S1_summary_P5 -2 fifo/il_S2_summary_P5 < fifo/il_P5 &
+summarycalc -f  -1 fifo/il_S1_summary_P6 -2 fifo/il_S2_summary_P6 < fifo/il_P6 &
+
+# --- Do ground up loss computes ---
+
+eltcalc < fifo/gul_S1_eltcalc_P1 > work/kat/gul_S1_eltcalc_P1 & pid49=$!
+summarycalctocsv < fifo/gul_S1_summarycalc_P1 > work/kat/gul_S1_summarycalc_P1 & pid50=$!
+pltcalc < fifo/gul_S1_pltcalc_P1 > work/kat/gul_S1_pltcalc_P1 & pid51=$!
+eltcalc < fifo/gul_S2_eltcalc_P1 > work/kat/gul_S2_eltcalc_P1 & pid52=$!
+summarycalctocsv < fifo/gul_S2_summarycalc_P1 > work/kat/gul_S2_summarycalc_P1 & pid53=$!
+pltcalc < fifo/gul_S2_pltcalc_P1 > work/kat/gul_S2_pltcalc_P1 & pid54=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P2 > work/kat/gul_S1_eltcalc_P2 & pid55=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P2 > work/kat/gul_S1_summarycalc_P2 & pid56=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P2 > work/kat/gul_S1_pltcalc_P2 & pid57=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P2 > work/kat/gul_S2_eltcalc_P2 & pid58=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P2 > work/kat/gul_S2_summarycalc_P2 & pid59=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P2 > work/kat/gul_S2_pltcalc_P2 & pid60=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P3 > work/kat/gul_S1_eltcalc_P3 & pid61=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P3 > work/kat/gul_S1_summarycalc_P3 & pid62=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P3 > work/kat/gul_S1_pltcalc_P3 & pid63=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P3 > work/kat/gul_S2_eltcalc_P3 & pid64=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P3 > work/kat/gul_S2_summarycalc_P3 & pid65=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P3 > work/kat/gul_S2_pltcalc_P3 & pid66=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P4 > work/kat/gul_S1_eltcalc_P4 & pid67=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P4 > work/kat/gul_S1_summarycalc_P4 & pid68=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P4 > work/kat/gul_S1_pltcalc_P4 & pid69=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P4 > work/kat/gul_S2_eltcalc_P4 & pid70=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P4 > work/kat/gul_S2_summarycalc_P4 & pid71=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P4 > work/kat/gul_S2_pltcalc_P4 & pid72=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P5 > work/kat/gul_S1_eltcalc_P5 & pid73=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P5 > work/kat/gul_S1_summarycalc_P5 & pid74=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P5 > work/kat/gul_S1_pltcalc_P5 & pid75=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P5 > work/kat/gul_S2_eltcalc_P5 & pid76=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P5 > work/kat/gul_S2_summarycalc_P5 & pid77=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P5 > work/kat/gul_S2_pltcalc_P5 & pid78=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P6 > work/kat/gul_S1_eltcalc_P6 & pid79=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P6 > work/kat/gul_S1_summarycalc_P6 & pid80=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P6 > work/kat/gul_S1_pltcalc_P6 & pid81=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P6 > work/kat/gul_S2_eltcalc_P6 & pid82=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P6 > work/kat/gul_S2_summarycalc_P6 & pid83=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P6 > work/kat/gul_S2_pltcalc_P6 & pid84=$!
+
+tee < fifo/gul_S1_summary_P1 fifo/gul_S1_eltcalc_P1 fifo/gul_S1_summarycalc_P1 fifo/gul_S1_pltcalc_P1 work/gul_S1_summaryaalcalc/P1.bin work/gul_S1_summaryleccalc/P1.bin > /dev/null & pid85=$!
+tee < fifo/gul_S2_summary_P1 fifo/gul_S2_eltcalc_P1 fifo/gul_S2_summarycalc_P1 fifo/gul_S2_pltcalc_P1 work/gul_S2_summaryaalcalc/P1.bin work/gul_S2_summaryleccalc/P1.bin > /dev/null & pid86=$!
+tee < fifo/gul_S1_summary_P2 fifo/gul_S1_eltcalc_P2 fifo/gul_S1_summarycalc_P2 fifo/gul_S1_pltcalc_P2 work/gul_S1_summaryaalcalc/P2.bin work/gul_S1_summaryleccalc/P2.bin > /dev/null & pid87=$!
+tee < fifo/gul_S2_summary_P2 fifo/gul_S2_eltcalc_P2 fifo/gul_S2_summarycalc_P2 fifo/gul_S2_pltcalc_P2 work/gul_S2_summaryaalcalc/P2.bin work/gul_S2_summaryleccalc/P2.bin > /dev/null & pid88=$!
+tee < fifo/gul_S1_summary_P3 fifo/gul_S1_eltcalc_P3 fifo/gul_S1_summarycalc_P3 fifo/gul_S1_pltcalc_P3 work/gul_S1_summaryaalcalc/P3.bin work/gul_S1_summaryleccalc/P3.bin > /dev/null & pid89=$!
+tee < fifo/gul_S2_summary_P3 fifo/gul_S2_eltcalc_P3 fifo/gul_S2_summarycalc_P3 fifo/gul_S2_pltcalc_P3 work/gul_S2_summaryaalcalc/P3.bin work/gul_S2_summaryleccalc/P3.bin > /dev/null & pid90=$!
+tee < fifo/gul_S1_summary_P4 fifo/gul_S1_eltcalc_P4 fifo/gul_S1_summarycalc_P4 fifo/gul_S1_pltcalc_P4 work/gul_S1_summaryaalcalc/P4.bin work/gul_S1_summaryleccalc/P4.bin > /dev/null & pid91=$!
+tee < fifo/gul_S2_summary_P4 fifo/gul_S2_eltcalc_P4 fifo/gul_S2_summarycalc_P4 fifo/gul_S2_pltcalc_P4 work/gul_S2_summaryaalcalc/P4.bin work/gul_S2_summaryleccalc/P4.bin > /dev/null & pid92=$!
+tee < fifo/gul_S1_summary_P5 fifo/gul_S1_eltcalc_P5 fifo/gul_S1_summarycalc_P5 fifo/gul_S1_pltcalc_P5 work/gul_S1_summaryaalcalc/P5.bin work/gul_S1_summaryleccalc/P5.bin > /dev/null & pid93=$!
+tee < fifo/gul_S2_summary_P5 fifo/gul_S2_eltcalc_P5 fifo/gul_S2_summarycalc_P5 fifo/gul_S2_pltcalc_P5 work/gul_S2_summaryaalcalc/P5.bin work/gul_S2_summaryleccalc/P5.bin > /dev/null & pid94=$!
+tee < fifo/gul_S1_summary_P6 fifo/gul_S1_eltcalc_P6 fifo/gul_S1_summarycalc_P6 fifo/gul_S1_pltcalc_P6 work/gul_S1_summaryaalcalc/P6.bin work/gul_S1_summaryleccalc/P6.bin > /dev/null & pid95=$!
+tee < fifo/gul_S2_summary_P6 fifo/gul_S2_eltcalc_P6 fifo/gul_S2_summarycalc_P6 fifo/gul_S2_pltcalc_P6 work/gul_S2_summaryaalcalc/P6.bin work/gul_S2_summaryleccalc/P6.bin > /dev/null & pid96=$!
+
+summarycalc -i  -1 fifo/gul_S1_summary_P1 -2 fifo/gul_S2_summary_P1 < fifo/gul_P1 &
+summarycalc -i  -1 fifo/gul_S1_summary_P2 -2 fifo/gul_S2_summary_P2 < fifo/gul_P2 &
+summarycalc -i  -1 fifo/gul_S1_summary_P3 -2 fifo/gul_S2_summary_P3 < fifo/gul_P3 &
+summarycalc -i  -1 fifo/gul_S1_summary_P4 -2 fifo/gul_S2_summary_P4 < fifo/gul_P4 &
+summarycalc -i  -1 fifo/gul_S1_summary_P5 -2 fifo/gul_S2_summary_P5 < fifo/gul_P5 &
+summarycalc -i  -1 fifo/gul_S1_summary_P6 -2 fifo/gul_S2_summary_P6 < fifo/gul_P6 &
+
+eve -R 1 6 | getmodel | gulcalc -S0 -L0 -r -a0 -i - | tee fifo/gul_P1 > fifo/gul_lb_P1  &
+eve -R 2 6 | getmodel | gulcalc -S0 -L0 -r -a0 -i - | tee fifo/gul_P2 > fifo/gul_lb_P2  &
+eve -R 3 6 | getmodel | gulcalc -S0 -L0 -r -a0 -i - | tee fifo/gul_P3 > fifo/gul_lb_P3  &
+eve -R 4 6 | getmodel | gulcalc -S0 -L0 -r -a0 -i - | tee fifo/gul_P4 > fifo/gul_lb_P4  &
+eve -R 5 6 | getmodel | gulcalc -S0 -L0 -r -a0 -i - | tee fifo/gul_P5 > fifo/gul_lb_P5  &
+eve -R 6 6 | getmodel | gulcalc -S0 -L0 -r -a0 -i - | tee fifo/gul_P6 > fifo/gul_lb_P6  &
+load_balancer -i fifo/gul_lb_P1 fifo/gul_lb_P2 -o fifo/lb_il_P1 fifo/lb_il_P2 &
+load_balancer -i fifo/gul_lb_P3 fifo/gul_lb_P4 -o fifo/lb_il_P3 fifo/lb_il_P4 &
+load_balancer -i fifo/gul_lb_P5 fifo/gul_lb_P6 -o fifo/lb_il_P5 fifo/lb_il_P6 &
+fmcalc -a2 < fifo/lb_il_P1 > fifo/il_P1 &
+fmcalc -a2 < fifo/lb_il_P2 > fifo/il_P2 &
+fmcalc -a2 < fifo/lb_il_P3 > fifo/il_P3 &
+fmcalc -a2 < fifo/lb_il_P4 > fifo/il_P4 &
+fmcalc -a2 < fifo/lb_il_P5 > fifo/il_P5 &
+fmcalc -a2 < fifo/lb_il_P6 > fifo/il_P6 &
+
+wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 $pid13 $pid14 $pid15 $pid16 $pid17 $pid18 $pid19 $pid20 $pid21 $pid22 $pid23 $pid24 $pid25 $pid26 $pid27 $pid28 $pid29 $pid30 $pid31 $pid32 $pid33 $pid34 $pid35 $pid36 $pid37 $pid38 $pid39 $pid40 $pid41 $pid42 $pid43 $pid44 $pid45 $pid46 $pid47 $pid48 $pid49 $pid50 $pid51 $pid52 $pid53 $pid54 $pid55 $pid56 $pid57 $pid58 $pid59 $pid60 $pid61 $pid62 $pid63 $pid64 $pid65 $pid66 $pid67 $pid68 $pid69 $pid70 $pid71 $pid72 $pid73 $pid74 $pid75 $pid76 $pid77 $pid78 $pid79 $pid80 $pid81 $pid82 $pid83 $pid84 $pid85 $pid86 $pid87 $pid88 $pid89 $pid90 $pid91 $pid92 $pid93 $pid94 $pid95 $pid96
+
+
+# --- Do insured loss kats ---
+
+kat work/kat/il_S1_eltcalc_P1 work/kat/il_S1_eltcalc_P2 work/kat/il_S1_eltcalc_P3 work/kat/il_S1_eltcalc_P4 work/kat/il_S1_eltcalc_P5 work/kat/il_S1_eltcalc_P6 > output/il_S1_eltcalc.csv & kpid1=$!
+kat work/kat/il_S1_pltcalc_P1 work/kat/il_S1_pltcalc_P2 work/kat/il_S1_pltcalc_P3 work/kat/il_S1_pltcalc_P4 work/kat/il_S1_pltcalc_P5 work/kat/il_S1_pltcalc_P6 > output/il_S1_pltcalc.csv & kpid2=$!
+kat work/kat/il_S1_summarycalc_P1 work/kat/il_S1_summarycalc_P2 work/kat/il_S1_summarycalc_P3 work/kat/il_S1_summarycalc_P4 work/kat/il_S1_summarycalc_P5 work/kat/il_S1_summarycalc_P6 > output/il_S1_summarycalc.csv & kpid3=$!
+kat work/kat/il_S2_eltcalc_P1 work/kat/il_S2_eltcalc_P2 work/kat/il_S2_eltcalc_P3 work/kat/il_S2_eltcalc_P4 work/kat/il_S2_eltcalc_P5 work/kat/il_S2_eltcalc_P6 > output/il_S2_eltcalc.csv & kpid4=$!
+kat work/kat/il_S2_pltcalc_P1 work/kat/il_S2_pltcalc_P2 work/kat/il_S2_pltcalc_P3 work/kat/il_S2_pltcalc_P4 work/kat/il_S2_pltcalc_P5 work/kat/il_S2_pltcalc_P6 > output/il_S2_pltcalc.csv & kpid5=$!
+kat work/kat/il_S2_summarycalc_P1 work/kat/il_S2_summarycalc_P2 work/kat/il_S2_summarycalc_P3 work/kat/il_S2_summarycalc_P4 work/kat/il_S2_summarycalc_P5 work/kat/il_S2_summarycalc_P6 > output/il_S2_summarycalc.csv & kpid6=$!
+
+# --- Do ground up loss kats ---
+
+kat work/kat/gul_S1_eltcalc_P1 work/kat/gul_S1_eltcalc_P2 work/kat/gul_S1_eltcalc_P3 work/kat/gul_S1_eltcalc_P4 work/kat/gul_S1_eltcalc_P5 work/kat/gul_S1_eltcalc_P6 > output/gul_S1_eltcalc.csv & kpid7=$!
+kat work/kat/gul_S1_pltcalc_P1 work/kat/gul_S1_pltcalc_P2 work/kat/gul_S1_pltcalc_P3 work/kat/gul_S1_pltcalc_P4 work/kat/gul_S1_pltcalc_P5 work/kat/gul_S1_pltcalc_P6 > output/gul_S1_pltcalc.csv & kpid8=$!
+kat work/kat/gul_S1_summarycalc_P1 work/kat/gul_S1_summarycalc_P2 work/kat/gul_S1_summarycalc_P3 work/kat/gul_S1_summarycalc_P4 work/kat/gul_S1_summarycalc_P5 work/kat/gul_S1_summarycalc_P6 > output/gul_S1_summarycalc.csv & kpid9=$!
+kat work/kat/gul_S2_eltcalc_P1 work/kat/gul_S2_eltcalc_P2 work/kat/gul_S2_eltcalc_P3 work/kat/gul_S2_eltcalc_P4 work/kat/gul_S2_eltcalc_P5 work/kat/gul_S2_eltcalc_P6 > output/gul_S2_eltcalc.csv & kpid10=$!
+kat work/kat/gul_S2_pltcalc_P1 work/kat/gul_S2_pltcalc_P2 work/kat/gul_S2_pltcalc_P3 work/kat/gul_S2_pltcalc_P4 work/kat/gul_S2_pltcalc_P5 work/kat/gul_S2_pltcalc_P6 > output/gul_S2_pltcalc.csv & kpid11=$!
+kat work/kat/gul_S2_summarycalc_P1 work/kat/gul_S2_summarycalc_P2 work/kat/gul_S2_summarycalc_P3 work/kat/gul_S2_summarycalc_P4 work/kat/gul_S2_summarycalc_P5 work/kat/gul_S2_summarycalc_P6 > output/gul_S2_summarycalc.csv & kpid12=$!
+wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpid11 $kpid12
+
+
+aalcalc -Kil_S1_summaryaalcalc > output/il_S1_aalcalc.csv & lpid1=$!
+ordleccalc -r -Kil_S1_summaryleccalc -F -S -s -M -m -W -w -O output/il_S1_ept.csv -o output/il_S1_psept.csv & lpid2=$!
+aalcalc -Kil_S2_summaryaalcalc > output/il_S2_aalcalc.csv & lpid3=$!
+ordleccalc -r -Kil_S2_summaryleccalc -F -S -s -M -m -W -w -O output/il_S2_ept.csv -o output/il_S2_psept.csv & lpid4=$!
+aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv & lpid5=$!
+ordleccalc -r -Kgul_S1_summaryleccalc -F -S -s -M -m -W -w -O output/gul_S1_ept.csv -o output/gul_S1_psept.csv & lpid6=$!
+aalcalc -Kgul_S2_summaryaalcalc > output/gul_S2_aalcalc.csv & lpid7=$!
+ordleccalc -r -Kgul_S2_summaryleccalc -F -S -s -M -m -W -w -O output/gul_S2_ept.csv -o output/gul_S2_psept.csv & lpid8=$!
+wait $lpid1 $lpid2 $lpid3 $lpid4 $lpid5 $lpid6 $lpid7 $lpid8
+
+rm -R -f work/*
+rm -R -f fifo/*

--- a/tests/model_execution/eve_kparse_reference/gul_il_ord_psept_lec_1_output_10_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_il_ord_psept_lec_1_output_10_partition.sh
@@ -1,0 +1,226 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+
+rm -R -f fifo/*
+rm -R -f work/*
+mkdir work/kat/
+
+mkdir work/gul_S1_summaryleccalc
+mkdir work/gul_S1_summaryaalcalc
+mkdir work/il_S1_summaryleccalc
+mkdir work/il_S1_summaryaalcalc
+
+mkfifo fifo/gul_P1
+mkfifo fifo/gul_P2
+mkfifo fifo/gul_P3
+mkfifo fifo/gul_P4
+mkfifo fifo/gul_P5
+mkfifo fifo/gul_P6
+
+mkfifo fifo/gul_S1_summary_P1
+mkfifo fifo/gul_S1_eltcalc_P1
+mkfifo fifo/gul_S1_summarycalc_P1
+mkfifo fifo/gul_S1_pltcalc_P1
+
+mkfifo fifo/gul_S1_summary_P2
+mkfifo fifo/gul_S1_eltcalc_P2
+mkfifo fifo/gul_S1_summarycalc_P2
+mkfifo fifo/gul_S1_pltcalc_P2
+
+mkfifo fifo/gul_S1_summary_P3
+mkfifo fifo/gul_S1_eltcalc_P3
+mkfifo fifo/gul_S1_summarycalc_P3
+mkfifo fifo/gul_S1_pltcalc_P3
+
+mkfifo fifo/gul_S1_summary_P4
+mkfifo fifo/gul_S1_eltcalc_P4
+mkfifo fifo/gul_S1_summarycalc_P4
+mkfifo fifo/gul_S1_pltcalc_P4
+
+mkfifo fifo/gul_S1_summary_P5
+mkfifo fifo/gul_S1_eltcalc_P5
+mkfifo fifo/gul_S1_summarycalc_P5
+mkfifo fifo/gul_S1_pltcalc_P5
+
+mkfifo fifo/gul_S1_summary_P6
+mkfifo fifo/gul_S1_eltcalc_P6
+mkfifo fifo/gul_S1_summarycalc_P6
+mkfifo fifo/gul_S1_pltcalc_P6
+
+mkfifo fifo/il_P1
+mkfifo fifo/il_P2
+mkfifo fifo/il_P3
+mkfifo fifo/il_P4
+mkfifo fifo/il_P5
+mkfifo fifo/il_P6
+
+mkfifo fifo/il_S1_summary_P1
+mkfifo fifo/il_S1_eltcalc_P1
+mkfifo fifo/il_S1_summarycalc_P1
+mkfifo fifo/il_S1_pltcalc_P1
+
+mkfifo fifo/il_S1_summary_P2
+mkfifo fifo/il_S1_eltcalc_P2
+mkfifo fifo/il_S1_summarycalc_P2
+mkfifo fifo/il_S1_pltcalc_P2
+
+mkfifo fifo/il_S1_summary_P3
+mkfifo fifo/il_S1_eltcalc_P3
+mkfifo fifo/il_S1_summarycalc_P3
+mkfifo fifo/il_S1_pltcalc_P3
+
+mkfifo fifo/il_S1_summary_P4
+mkfifo fifo/il_S1_eltcalc_P4
+mkfifo fifo/il_S1_summarycalc_P4
+mkfifo fifo/il_S1_pltcalc_P4
+
+mkfifo fifo/il_S1_summary_P5
+mkfifo fifo/il_S1_eltcalc_P5
+mkfifo fifo/il_S1_summarycalc_P5
+mkfifo fifo/il_S1_pltcalc_P5
+
+mkfifo fifo/il_S1_summary_P6
+mkfifo fifo/il_S1_eltcalc_P6
+mkfifo fifo/il_S1_summarycalc_P6
+mkfifo fifo/il_S1_pltcalc_P6
+
+mkfifo fifo/gul_lb_P1
+mkfifo fifo/gul_lb_P2
+mkfifo fifo/gul_lb_P3
+mkfifo fifo/gul_lb_P4
+mkfifo fifo/gul_lb_P5
+mkfifo fifo/gul_lb_P6
+
+mkfifo fifo/lb_il_P1
+mkfifo fifo/lb_il_P2
+mkfifo fifo/lb_il_P3
+mkfifo fifo/lb_il_P4
+mkfifo fifo/lb_il_P5
+mkfifo fifo/lb_il_P6
+
+
+
+# --- Do insured loss computes ---
+
+eltcalc < fifo/il_S1_eltcalc_P1 > work/kat/il_S1_eltcalc_P1 & pid1=$!
+summarycalctocsv < fifo/il_S1_summarycalc_P1 > work/kat/il_S1_summarycalc_P1 & pid2=$!
+pltcalc < fifo/il_S1_pltcalc_P1 > work/kat/il_S1_pltcalc_P1 & pid3=$!
+eltcalc -s < fifo/il_S1_eltcalc_P2 > work/kat/il_S1_eltcalc_P2 & pid4=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P2 > work/kat/il_S1_summarycalc_P2 & pid5=$!
+pltcalc -s < fifo/il_S1_pltcalc_P2 > work/kat/il_S1_pltcalc_P2 & pid6=$!
+eltcalc -s < fifo/il_S1_eltcalc_P3 > work/kat/il_S1_eltcalc_P3 & pid7=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P3 > work/kat/il_S1_summarycalc_P3 & pid8=$!
+pltcalc -s < fifo/il_S1_pltcalc_P3 > work/kat/il_S1_pltcalc_P3 & pid9=$!
+eltcalc -s < fifo/il_S1_eltcalc_P4 > work/kat/il_S1_eltcalc_P4 & pid10=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P4 > work/kat/il_S1_summarycalc_P4 & pid11=$!
+pltcalc -s < fifo/il_S1_pltcalc_P4 > work/kat/il_S1_pltcalc_P4 & pid12=$!
+eltcalc -s < fifo/il_S1_eltcalc_P5 > work/kat/il_S1_eltcalc_P5 & pid13=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P5 > work/kat/il_S1_summarycalc_P5 & pid14=$!
+pltcalc -s < fifo/il_S1_pltcalc_P5 > work/kat/il_S1_pltcalc_P5 & pid15=$!
+eltcalc -s < fifo/il_S1_eltcalc_P6 > work/kat/il_S1_eltcalc_P6 & pid16=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P6 > work/kat/il_S1_summarycalc_P6 & pid17=$!
+pltcalc -s < fifo/il_S1_pltcalc_P6 > work/kat/il_S1_pltcalc_P6 & pid18=$!
+
+tee < fifo/il_S1_summary_P1 fifo/il_S1_eltcalc_P1 fifo/il_S1_summarycalc_P1 fifo/il_S1_pltcalc_P1 work/il_S1_summaryaalcalc/P1.bin work/il_S1_summaryleccalc/P1.bin > /dev/null & pid19=$!
+tee < fifo/il_S1_summary_P2 fifo/il_S1_eltcalc_P2 fifo/il_S1_summarycalc_P2 fifo/il_S1_pltcalc_P2 work/il_S1_summaryaalcalc/P2.bin work/il_S1_summaryleccalc/P2.bin > /dev/null & pid20=$!
+tee < fifo/il_S1_summary_P3 fifo/il_S1_eltcalc_P3 fifo/il_S1_summarycalc_P3 fifo/il_S1_pltcalc_P3 work/il_S1_summaryaalcalc/P3.bin work/il_S1_summaryleccalc/P3.bin > /dev/null & pid21=$!
+tee < fifo/il_S1_summary_P4 fifo/il_S1_eltcalc_P4 fifo/il_S1_summarycalc_P4 fifo/il_S1_pltcalc_P4 work/il_S1_summaryaalcalc/P4.bin work/il_S1_summaryleccalc/P4.bin > /dev/null & pid22=$!
+tee < fifo/il_S1_summary_P5 fifo/il_S1_eltcalc_P5 fifo/il_S1_summarycalc_P5 fifo/il_S1_pltcalc_P5 work/il_S1_summaryaalcalc/P5.bin work/il_S1_summaryleccalc/P5.bin > /dev/null & pid23=$!
+tee < fifo/il_S1_summary_P6 fifo/il_S1_eltcalc_P6 fifo/il_S1_summarycalc_P6 fifo/il_S1_pltcalc_P6 work/il_S1_summaryaalcalc/P6.bin work/il_S1_summaryleccalc/P6.bin > /dev/null & pid24=$!
+
+summarycalc -f  -1 fifo/il_S1_summary_P1 < fifo/il_P1 &
+summarycalc -f  -1 fifo/il_S1_summary_P2 < fifo/il_P2 &
+summarycalc -f  -1 fifo/il_S1_summary_P3 < fifo/il_P3 &
+summarycalc -f  -1 fifo/il_S1_summary_P4 < fifo/il_P4 &
+summarycalc -f  -1 fifo/il_S1_summary_P5 < fifo/il_P5 &
+summarycalc -f  -1 fifo/il_S1_summary_P6 < fifo/il_P6 &
+
+# --- Do ground up loss computes ---
+
+eltcalc < fifo/gul_S1_eltcalc_P1 > work/kat/gul_S1_eltcalc_P1 & pid25=$!
+summarycalctocsv < fifo/gul_S1_summarycalc_P1 > work/kat/gul_S1_summarycalc_P1 & pid26=$!
+pltcalc < fifo/gul_S1_pltcalc_P1 > work/kat/gul_S1_pltcalc_P1 & pid27=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P2 > work/kat/gul_S1_eltcalc_P2 & pid28=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P2 > work/kat/gul_S1_summarycalc_P2 & pid29=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P2 > work/kat/gul_S1_pltcalc_P2 & pid30=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P3 > work/kat/gul_S1_eltcalc_P3 & pid31=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P3 > work/kat/gul_S1_summarycalc_P3 & pid32=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P3 > work/kat/gul_S1_pltcalc_P3 & pid33=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P4 > work/kat/gul_S1_eltcalc_P4 & pid34=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P4 > work/kat/gul_S1_summarycalc_P4 & pid35=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P4 > work/kat/gul_S1_pltcalc_P4 & pid36=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P5 > work/kat/gul_S1_eltcalc_P5 & pid37=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P5 > work/kat/gul_S1_summarycalc_P5 & pid38=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P5 > work/kat/gul_S1_pltcalc_P5 & pid39=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P6 > work/kat/gul_S1_eltcalc_P6 & pid40=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P6 > work/kat/gul_S1_summarycalc_P6 & pid41=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P6 > work/kat/gul_S1_pltcalc_P6 & pid42=$!
+
+tee < fifo/gul_S1_summary_P1 fifo/gul_S1_eltcalc_P1 fifo/gul_S1_summarycalc_P1 fifo/gul_S1_pltcalc_P1 work/gul_S1_summaryaalcalc/P1.bin work/gul_S1_summaryleccalc/P1.bin > /dev/null & pid43=$!
+tee < fifo/gul_S1_summary_P2 fifo/gul_S1_eltcalc_P2 fifo/gul_S1_summarycalc_P2 fifo/gul_S1_pltcalc_P2 work/gul_S1_summaryaalcalc/P2.bin work/gul_S1_summaryleccalc/P2.bin > /dev/null & pid44=$!
+tee < fifo/gul_S1_summary_P3 fifo/gul_S1_eltcalc_P3 fifo/gul_S1_summarycalc_P3 fifo/gul_S1_pltcalc_P3 work/gul_S1_summaryaalcalc/P3.bin work/gul_S1_summaryleccalc/P3.bin > /dev/null & pid45=$!
+tee < fifo/gul_S1_summary_P4 fifo/gul_S1_eltcalc_P4 fifo/gul_S1_summarycalc_P4 fifo/gul_S1_pltcalc_P4 work/gul_S1_summaryaalcalc/P4.bin work/gul_S1_summaryleccalc/P4.bin > /dev/null & pid46=$!
+tee < fifo/gul_S1_summary_P5 fifo/gul_S1_eltcalc_P5 fifo/gul_S1_summarycalc_P5 fifo/gul_S1_pltcalc_P5 work/gul_S1_summaryaalcalc/P5.bin work/gul_S1_summaryleccalc/P5.bin > /dev/null & pid47=$!
+tee < fifo/gul_S1_summary_P6 fifo/gul_S1_eltcalc_P6 fifo/gul_S1_summarycalc_P6 fifo/gul_S1_pltcalc_P6 work/gul_S1_summaryaalcalc/P6.bin work/gul_S1_summaryleccalc/P6.bin > /dev/null & pid48=$!
+
+summarycalc -i  -1 fifo/gul_S1_summary_P1 < fifo/gul_P1 &
+summarycalc -i  -1 fifo/gul_S1_summary_P2 < fifo/gul_P2 &
+summarycalc -i  -1 fifo/gul_S1_summary_P3 < fifo/gul_P3 &
+summarycalc -i  -1 fifo/gul_S1_summary_P4 < fifo/gul_P4 &
+summarycalc -i  -1 fifo/gul_S1_summary_P5 < fifo/gul_P5 &
+summarycalc -i  -1 fifo/gul_S1_summary_P6 < fifo/gul_P6 &
+
+eve -R 1 6 | getmodel | gulcalc -S0 -L0 -r -a0 -i - | tee fifo/gul_P1 > fifo/gul_lb_P1  &
+eve -R 2 6 | getmodel | gulcalc -S0 -L0 -r -a0 -i - | tee fifo/gul_P2 > fifo/gul_lb_P2  &
+eve -R 3 6 | getmodel | gulcalc -S0 -L0 -r -a0 -i - | tee fifo/gul_P3 > fifo/gul_lb_P3  &
+eve -R 4 6 | getmodel | gulcalc -S0 -L0 -r -a0 -i - | tee fifo/gul_P4 > fifo/gul_lb_P4  &
+eve -R 5 6 | getmodel | gulcalc -S0 -L0 -r -a0 -i - | tee fifo/gul_P5 > fifo/gul_lb_P5  &
+eve -R 6 6 | getmodel | gulcalc -S0 -L0 -r -a0 -i - | tee fifo/gul_P6 > fifo/gul_lb_P6  &
+load_balancer -i fifo/gul_lb_P1 fifo/gul_lb_P2 -o fifo/lb_il_P1 fifo/lb_il_P2 &
+load_balancer -i fifo/gul_lb_P3 fifo/gul_lb_P4 -o fifo/lb_il_P3 fifo/lb_il_P4 &
+load_balancer -i fifo/gul_lb_P5 fifo/gul_lb_P6 -o fifo/lb_il_P5 fifo/lb_il_P6 &
+fmcalc -a2 < fifo/lb_il_P1 > fifo/il_P1 &
+fmcalc -a2 < fifo/lb_il_P2 > fifo/il_P2 &
+fmcalc -a2 < fifo/lb_il_P3 > fifo/il_P3 &
+fmcalc -a2 < fifo/lb_il_P4 > fifo/il_P4 &
+fmcalc -a2 < fifo/lb_il_P5 > fifo/il_P5 &
+fmcalc -a2 < fifo/lb_il_P6 > fifo/il_P6 &
+
+wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 $pid13 $pid14 $pid15 $pid16 $pid17 $pid18 $pid19 $pid20 $pid21 $pid22 $pid23 $pid24 $pid25 $pid26 $pid27 $pid28 $pid29 $pid30 $pid31 $pid32 $pid33 $pid34 $pid35 $pid36 $pid37 $pid38 $pid39 $pid40 $pid41 $pid42 $pid43 $pid44 $pid45 $pid46 $pid47 $pid48
+
+
+# --- Do insured loss kats ---
+
+kat work/kat/il_S1_eltcalc_P1 work/kat/il_S1_eltcalc_P2 work/kat/il_S1_eltcalc_P3 work/kat/il_S1_eltcalc_P4 work/kat/il_S1_eltcalc_P5 work/kat/il_S1_eltcalc_P6 > output/il_S1_eltcalc.csv & kpid1=$!
+kat work/kat/il_S1_pltcalc_P1 work/kat/il_S1_pltcalc_P2 work/kat/il_S1_pltcalc_P3 work/kat/il_S1_pltcalc_P4 work/kat/il_S1_pltcalc_P5 work/kat/il_S1_pltcalc_P6 > output/il_S1_pltcalc.csv & kpid2=$!
+kat work/kat/il_S1_summarycalc_P1 work/kat/il_S1_summarycalc_P2 work/kat/il_S1_summarycalc_P3 work/kat/il_S1_summarycalc_P4 work/kat/il_S1_summarycalc_P5 work/kat/il_S1_summarycalc_P6 > output/il_S1_summarycalc.csv & kpid3=$!
+
+# --- Do ground up loss kats ---
+
+kat work/kat/gul_S1_eltcalc_P1 work/kat/gul_S1_eltcalc_P2 work/kat/gul_S1_eltcalc_P3 work/kat/gul_S1_eltcalc_P4 work/kat/gul_S1_eltcalc_P5 work/kat/gul_S1_eltcalc_P6 > output/gul_S1_eltcalc.csv & kpid4=$!
+kat work/kat/gul_S1_pltcalc_P1 work/kat/gul_S1_pltcalc_P2 work/kat/gul_S1_pltcalc_P3 work/kat/gul_S1_pltcalc_P4 work/kat/gul_S1_pltcalc_P5 work/kat/gul_S1_pltcalc_P6 > output/gul_S1_pltcalc.csv & kpid5=$!
+kat work/kat/gul_S1_summarycalc_P1 work/kat/gul_S1_summarycalc_P2 work/kat/gul_S1_summarycalc_P3 work/kat/gul_S1_summarycalc_P4 work/kat/gul_S1_summarycalc_P5 work/kat/gul_S1_summarycalc_P6 > output/gul_S1_summarycalc.csv & kpid6=$!
+wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
+
+
+aalcalc -Kil_S1_summaryaalcalc > output/il_S1_aalcalc.csv & lpid1=$!
+ordleccalc -r -Kil_S1_summaryleccalc -W -w -o output/il_S1_psept.csv & lpid2=$!
+leccalc -r -Kil_S1_summaryleccalc -F output/il_S1_leccalc_full_uncertainty_aep.csv -f output/il_S1_leccalc_full_uncertainty_oep.csv -S output/il_S1_leccalc_sample_mean_aep.csv -s output/il_S1_leccalc_sample_mean_oep.csv -W output/il_S1_leccalc_wheatsheaf_aep.csv -M output/il_S1_leccalc_wheatsheaf_mean_aep.csv -m output/il_S1_leccalc_wheatsheaf_mean_oep.csv -w output/il_S1_leccalc_wheatsheaf_oep.csv & lpid3=$!
+aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv & lpid4=$!
+ordleccalc  -Kgul_S1_summaryleccalc -W -w -o output/gul_S1_psept.csv & lpid5=$!
+leccalc -r -Kgul_S1_summaryleccalc -F output/gul_S1_leccalc_full_uncertainty_aep.csv -f output/gul_S1_leccalc_full_uncertainty_oep.csv -S output/gul_S1_leccalc_sample_mean_aep.csv -s output/gul_S1_leccalc_sample_mean_oep.csv -W output/gul_S1_leccalc_wheatsheaf_aep.csv -M output/gul_S1_leccalc_wheatsheaf_mean_aep.csv -m output/gul_S1_leccalc_wheatsheaf_mean_oep.csv -w output/gul_S1_leccalc_wheatsheaf_oep.csv & lpid6=$!
+wait $lpid1 $lpid2 $lpid3 $lpid4 $lpid5 $lpid6
+
+rm -R -f work/*
+rm -R -f fifo/*

--- a/tests/model_execution/eve_kparse_reference/gul_ord_ept_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_ord_ept_1_output_1_partition.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+
+rm -R -f fifo/*
+rm -R -f work/*
+mkdir work/kat/
+
+mkdir work/gul_S1_summaryleccalc
+
+mkfifo fifo/gul_P1
+
+mkfifo fifo/gul_S1_summary_P1
+
+
+
+# --- Do ground up loss computes ---
+
+
+tee < fifo/gul_S1_summary_P1 work/gul_S1_summaryleccalc/P1.bin > /dev/null & pid1=$!
+
+summarycalc -i  -1 fifo/gul_S1_summary_P1 < fifo/gul_P1 &
+
+eve -R 1 1 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P1  &
+
+wait $pid1
+
+
+# --- Do ground up loss kats ---
+
+
+ordleccalc -r -Kgul_S1_summaryleccalc -F -f -S -s -M -m -O output/gul_S1_ept.csv & lpid1=$!
+wait $lpid1
+
+rm -R -f work/*
+rm -R -f fifo/*

--- a/tests/model_execution/eve_kparse_reference/gul_ord_ept_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_ord_ept_1_output_20_partition.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+
+rm -R -f fifo/*
+rm -R -f work/*
+mkdir work/kat/
+
+mkdir work/gul_S1_summaryleccalc
+
+mkfifo fifo/gul_P1
+mkfifo fifo/gul_P2
+mkfifo fifo/gul_P3
+mkfifo fifo/gul_P4
+mkfifo fifo/gul_P5
+mkfifo fifo/gul_P6
+mkfifo fifo/gul_P7
+mkfifo fifo/gul_P8
+mkfifo fifo/gul_P9
+mkfifo fifo/gul_P10
+mkfifo fifo/gul_P11
+mkfifo fifo/gul_P12
+mkfifo fifo/gul_P13
+mkfifo fifo/gul_P14
+mkfifo fifo/gul_P15
+mkfifo fifo/gul_P16
+mkfifo fifo/gul_P17
+mkfifo fifo/gul_P18
+mkfifo fifo/gul_P19
+mkfifo fifo/gul_P20
+
+mkfifo fifo/gul_S1_summary_P1
+
+mkfifo fifo/gul_S1_summary_P2
+
+mkfifo fifo/gul_S1_summary_P3
+
+mkfifo fifo/gul_S1_summary_P4
+
+mkfifo fifo/gul_S1_summary_P5
+
+mkfifo fifo/gul_S1_summary_P6
+
+mkfifo fifo/gul_S1_summary_P7
+
+mkfifo fifo/gul_S1_summary_P8
+
+mkfifo fifo/gul_S1_summary_P9
+
+mkfifo fifo/gul_S1_summary_P10
+
+mkfifo fifo/gul_S1_summary_P11
+
+mkfifo fifo/gul_S1_summary_P12
+
+mkfifo fifo/gul_S1_summary_P13
+
+mkfifo fifo/gul_S1_summary_P14
+
+mkfifo fifo/gul_S1_summary_P15
+
+mkfifo fifo/gul_S1_summary_P16
+
+mkfifo fifo/gul_S1_summary_P17
+
+mkfifo fifo/gul_S1_summary_P18
+
+mkfifo fifo/gul_S1_summary_P19
+
+mkfifo fifo/gul_S1_summary_P20
+
+
+
+# --- Do ground up loss computes ---
+
+
+tee < fifo/gul_S1_summary_P1 work/gul_S1_summaryleccalc/P1.bin > /dev/null & pid1=$!
+tee < fifo/gul_S1_summary_P2 work/gul_S1_summaryleccalc/P2.bin > /dev/null & pid2=$!
+tee < fifo/gul_S1_summary_P3 work/gul_S1_summaryleccalc/P3.bin > /dev/null & pid3=$!
+tee < fifo/gul_S1_summary_P4 work/gul_S1_summaryleccalc/P4.bin > /dev/null & pid4=$!
+tee < fifo/gul_S1_summary_P5 work/gul_S1_summaryleccalc/P5.bin > /dev/null & pid5=$!
+tee < fifo/gul_S1_summary_P6 work/gul_S1_summaryleccalc/P6.bin > /dev/null & pid6=$!
+tee < fifo/gul_S1_summary_P7 work/gul_S1_summaryleccalc/P7.bin > /dev/null & pid7=$!
+tee < fifo/gul_S1_summary_P8 work/gul_S1_summaryleccalc/P8.bin > /dev/null & pid8=$!
+tee < fifo/gul_S1_summary_P9 work/gul_S1_summaryleccalc/P9.bin > /dev/null & pid9=$!
+tee < fifo/gul_S1_summary_P10 work/gul_S1_summaryleccalc/P10.bin > /dev/null & pid10=$!
+tee < fifo/gul_S1_summary_P11 work/gul_S1_summaryleccalc/P11.bin > /dev/null & pid11=$!
+tee < fifo/gul_S1_summary_P12 work/gul_S1_summaryleccalc/P12.bin > /dev/null & pid12=$!
+tee < fifo/gul_S1_summary_P13 work/gul_S1_summaryleccalc/P13.bin > /dev/null & pid13=$!
+tee < fifo/gul_S1_summary_P14 work/gul_S1_summaryleccalc/P14.bin > /dev/null & pid14=$!
+tee < fifo/gul_S1_summary_P15 work/gul_S1_summaryleccalc/P15.bin > /dev/null & pid15=$!
+tee < fifo/gul_S1_summary_P16 work/gul_S1_summaryleccalc/P16.bin > /dev/null & pid16=$!
+tee < fifo/gul_S1_summary_P17 work/gul_S1_summaryleccalc/P17.bin > /dev/null & pid17=$!
+tee < fifo/gul_S1_summary_P18 work/gul_S1_summaryleccalc/P18.bin > /dev/null & pid18=$!
+tee < fifo/gul_S1_summary_P19 work/gul_S1_summaryleccalc/P19.bin > /dev/null & pid19=$!
+tee < fifo/gul_S1_summary_P20 work/gul_S1_summaryleccalc/P20.bin > /dev/null & pid20=$!
+
+summarycalc -i  -1 fifo/gul_S1_summary_P1 < fifo/gul_P1 &
+summarycalc -i  -1 fifo/gul_S1_summary_P2 < fifo/gul_P2 &
+summarycalc -i  -1 fifo/gul_S1_summary_P3 < fifo/gul_P3 &
+summarycalc -i  -1 fifo/gul_S1_summary_P4 < fifo/gul_P4 &
+summarycalc -i  -1 fifo/gul_S1_summary_P5 < fifo/gul_P5 &
+summarycalc -i  -1 fifo/gul_S1_summary_P6 < fifo/gul_P6 &
+summarycalc -i  -1 fifo/gul_S1_summary_P7 < fifo/gul_P7 &
+summarycalc -i  -1 fifo/gul_S1_summary_P8 < fifo/gul_P8 &
+summarycalc -i  -1 fifo/gul_S1_summary_P9 < fifo/gul_P9 &
+summarycalc -i  -1 fifo/gul_S1_summary_P10 < fifo/gul_P10 &
+summarycalc -i  -1 fifo/gul_S1_summary_P11 < fifo/gul_P11 &
+summarycalc -i  -1 fifo/gul_S1_summary_P12 < fifo/gul_P12 &
+summarycalc -i  -1 fifo/gul_S1_summary_P13 < fifo/gul_P13 &
+summarycalc -i  -1 fifo/gul_S1_summary_P14 < fifo/gul_P14 &
+summarycalc -i  -1 fifo/gul_S1_summary_P15 < fifo/gul_P15 &
+summarycalc -i  -1 fifo/gul_S1_summary_P16 < fifo/gul_P16 &
+summarycalc -i  -1 fifo/gul_S1_summary_P17 < fifo/gul_P17 &
+summarycalc -i  -1 fifo/gul_S1_summary_P18 < fifo/gul_P18 &
+summarycalc -i  -1 fifo/gul_S1_summary_P19 < fifo/gul_P19 &
+summarycalc -i  -1 fifo/gul_S1_summary_P20 < fifo/gul_P20 &
+
+eve -R 1 20 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P1  &
+eve -R 2 20 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P2  &
+eve -R 3 20 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P3  &
+eve -R 4 20 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P4  &
+eve -R 5 20 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P5  &
+eve -R 6 20 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P6  &
+eve -R 7 20 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P7  &
+eve -R 8 20 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P8  &
+eve -R 9 20 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P9  &
+eve -R 10 20 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P10  &
+eve -R 11 20 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P11  &
+eve -R 12 20 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P12  &
+eve -R 13 20 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P13  &
+eve -R 14 20 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P14  &
+eve -R 15 20 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P15  &
+eve -R 16 20 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P16  &
+eve -R 17 20 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P17  &
+eve -R 18 20 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P18  &
+eve -R 19 20 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P19  &
+eve -R 20 20 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P20  &
+
+wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 $pid13 $pid14 $pid15 $pid16 $pid17 $pid18 $pid19 $pid20
+
+
+# --- Do ground up loss kats ---
+
+
+ordleccalc -r -Kgul_S1_summaryleccalc -F -f -S -s -M -m -O output/gul_S1_ept.csv & lpid1=$!
+wait $lpid1
+
+rm -R -f work/*
+rm -R -f fifo/*

--- a/tests/model_execution/eve_kparse_reference/gul_ord_ept_psept_lec_2_output_10_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_ord_ept_psept_lec_2_output_10_partition.sh
@@ -1,0 +1,256 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+
+rm -R -f fifo/*
+rm -R -f work/*
+mkdir work/kat/
+
+mkdir work/gul_S1_summaryleccalc
+mkdir work/gul_S1_summaryaalcalc
+mkdir work/gul_S2_summaryleccalc
+mkdir work/gul_S2_summaryaalcalc
+
+mkfifo fifo/gul_P1
+mkfifo fifo/gul_P2
+mkfifo fifo/gul_P3
+mkfifo fifo/gul_P4
+mkfifo fifo/gul_P5
+mkfifo fifo/gul_P6
+mkfifo fifo/gul_P7
+mkfifo fifo/gul_P8
+mkfifo fifo/gul_P9
+mkfifo fifo/gul_P10
+
+mkfifo fifo/gul_S1_summary_P1
+mkfifo fifo/gul_S1_eltcalc_P1
+mkfifo fifo/gul_S1_summarycalc_P1
+mkfifo fifo/gul_S1_pltcalc_P1
+mkfifo fifo/gul_S2_summary_P1
+mkfifo fifo/gul_S2_eltcalc_P1
+mkfifo fifo/gul_S2_summarycalc_P1
+mkfifo fifo/gul_S2_pltcalc_P1
+
+mkfifo fifo/gul_S1_summary_P2
+mkfifo fifo/gul_S1_eltcalc_P2
+mkfifo fifo/gul_S1_summarycalc_P2
+mkfifo fifo/gul_S1_pltcalc_P2
+mkfifo fifo/gul_S2_summary_P2
+mkfifo fifo/gul_S2_eltcalc_P2
+mkfifo fifo/gul_S2_summarycalc_P2
+mkfifo fifo/gul_S2_pltcalc_P2
+
+mkfifo fifo/gul_S1_summary_P3
+mkfifo fifo/gul_S1_eltcalc_P3
+mkfifo fifo/gul_S1_summarycalc_P3
+mkfifo fifo/gul_S1_pltcalc_P3
+mkfifo fifo/gul_S2_summary_P3
+mkfifo fifo/gul_S2_eltcalc_P3
+mkfifo fifo/gul_S2_summarycalc_P3
+mkfifo fifo/gul_S2_pltcalc_P3
+
+mkfifo fifo/gul_S1_summary_P4
+mkfifo fifo/gul_S1_eltcalc_P4
+mkfifo fifo/gul_S1_summarycalc_P4
+mkfifo fifo/gul_S1_pltcalc_P4
+mkfifo fifo/gul_S2_summary_P4
+mkfifo fifo/gul_S2_eltcalc_P4
+mkfifo fifo/gul_S2_summarycalc_P4
+mkfifo fifo/gul_S2_pltcalc_P4
+
+mkfifo fifo/gul_S1_summary_P5
+mkfifo fifo/gul_S1_eltcalc_P5
+mkfifo fifo/gul_S1_summarycalc_P5
+mkfifo fifo/gul_S1_pltcalc_P5
+mkfifo fifo/gul_S2_summary_P5
+mkfifo fifo/gul_S2_eltcalc_P5
+mkfifo fifo/gul_S2_summarycalc_P5
+mkfifo fifo/gul_S2_pltcalc_P5
+
+mkfifo fifo/gul_S1_summary_P6
+mkfifo fifo/gul_S1_eltcalc_P6
+mkfifo fifo/gul_S1_summarycalc_P6
+mkfifo fifo/gul_S1_pltcalc_P6
+mkfifo fifo/gul_S2_summary_P6
+mkfifo fifo/gul_S2_eltcalc_P6
+mkfifo fifo/gul_S2_summarycalc_P6
+mkfifo fifo/gul_S2_pltcalc_P6
+
+mkfifo fifo/gul_S1_summary_P7
+mkfifo fifo/gul_S1_eltcalc_P7
+mkfifo fifo/gul_S1_summarycalc_P7
+mkfifo fifo/gul_S1_pltcalc_P7
+mkfifo fifo/gul_S2_summary_P7
+mkfifo fifo/gul_S2_eltcalc_P7
+mkfifo fifo/gul_S2_summarycalc_P7
+mkfifo fifo/gul_S2_pltcalc_P7
+
+mkfifo fifo/gul_S1_summary_P8
+mkfifo fifo/gul_S1_eltcalc_P8
+mkfifo fifo/gul_S1_summarycalc_P8
+mkfifo fifo/gul_S1_pltcalc_P8
+mkfifo fifo/gul_S2_summary_P8
+mkfifo fifo/gul_S2_eltcalc_P8
+mkfifo fifo/gul_S2_summarycalc_P8
+mkfifo fifo/gul_S2_pltcalc_P8
+
+mkfifo fifo/gul_S1_summary_P9
+mkfifo fifo/gul_S1_eltcalc_P9
+mkfifo fifo/gul_S1_summarycalc_P9
+mkfifo fifo/gul_S1_pltcalc_P9
+mkfifo fifo/gul_S2_summary_P9
+mkfifo fifo/gul_S2_eltcalc_P9
+mkfifo fifo/gul_S2_summarycalc_P9
+mkfifo fifo/gul_S2_pltcalc_P9
+
+mkfifo fifo/gul_S1_summary_P10
+mkfifo fifo/gul_S1_eltcalc_P10
+mkfifo fifo/gul_S1_summarycalc_P10
+mkfifo fifo/gul_S1_pltcalc_P10
+mkfifo fifo/gul_S2_summary_P10
+mkfifo fifo/gul_S2_eltcalc_P10
+mkfifo fifo/gul_S2_summarycalc_P10
+mkfifo fifo/gul_S2_pltcalc_P10
+
+
+
+# --- Do ground up loss computes ---
+
+eltcalc < fifo/gul_S1_eltcalc_P1 > work/kat/gul_S1_eltcalc_P1 & pid1=$!
+summarycalctocsv < fifo/gul_S1_summarycalc_P1 > work/kat/gul_S1_summarycalc_P1 & pid2=$!
+pltcalc < fifo/gul_S1_pltcalc_P1 > work/kat/gul_S1_pltcalc_P1 & pid3=$!
+eltcalc < fifo/gul_S2_eltcalc_P1 > work/kat/gul_S2_eltcalc_P1 & pid4=$!
+summarycalctocsv < fifo/gul_S2_summarycalc_P1 > work/kat/gul_S2_summarycalc_P1 & pid5=$!
+pltcalc < fifo/gul_S2_pltcalc_P1 > work/kat/gul_S2_pltcalc_P1 & pid6=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P2 > work/kat/gul_S1_eltcalc_P2 & pid7=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P2 > work/kat/gul_S1_summarycalc_P2 & pid8=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P2 > work/kat/gul_S1_pltcalc_P2 & pid9=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P2 > work/kat/gul_S2_eltcalc_P2 & pid10=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P2 > work/kat/gul_S2_summarycalc_P2 & pid11=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P2 > work/kat/gul_S2_pltcalc_P2 & pid12=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P3 > work/kat/gul_S1_eltcalc_P3 & pid13=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P3 > work/kat/gul_S1_summarycalc_P3 & pid14=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P3 > work/kat/gul_S1_pltcalc_P3 & pid15=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P3 > work/kat/gul_S2_eltcalc_P3 & pid16=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P3 > work/kat/gul_S2_summarycalc_P3 & pid17=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P3 > work/kat/gul_S2_pltcalc_P3 & pid18=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P4 > work/kat/gul_S1_eltcalc_P4 & pid19=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P4 > work/kat/gul_S1_summarycalc_P4 & pid20=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P4 > work/kat/gul_S1_pltcalc_P4 & pid21=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P4 > work/kat/gul_S2_eltcalc_P4 & pid22=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P4 > work/kat/gul_S2_summarycalc_P4 & pid23=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P4 > work/kat/gul_S2_pltcalc_P4 & pid24=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P5 > work/kat/gul_S1_eltcalc_P5 & pid25=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P5 > work/kat/gul_S1_summarycalc_P5 & pid26=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P5 > work/kat/gul_S1_pltcalc_P5 & pid27=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P5 > work/kat/gul_S2_eltcalc_P5 & pid28=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P5 > work/kat/gul_S2_summarycalc_P5 & pid29=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P5 > work/kat/gul_S2_pltcalc_P5 & pid30=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P6 > work/kat/gul_S1_eltcalc_P6 & pid31=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P6 > work/kat/gul_S1_summarycalc_P6 & pid32=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P6 > work/kat/gul_S1_pltcalc_P6 & pid33=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P6 > work/kat/gul_S2_eltcalc_P6 & pid34=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P6 > work/kat/gul_S2_summarycalc_P6 & pid35=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P6 > work/kat/gul_S2_pltcalc_P6 & pid36=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P7 > work/kat/gul_S1_eltcalc_P7 & pid37=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P7 > work/kat/gul_S1_summarycalc_P7 & pid38=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P7 > work/kat/gul_S1_pltcalc_P7 & pid39=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P7 > work/kat/gul_S2_eltcalc_P7 & pid40=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P7 > work/kat/gul_S2_summarycalc_P7 & pid41=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P7 > work/kat/gul_S2_pltcalc_P7 & pid42=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P8 > work/kat/gul_S1_eltcalc_P8 & pid43=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P8 > work/kat/gul_S1_summarycalc_P8 & pid44=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P8 > work/kat/gul_S1_pltcalc_P8 & pid45=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P8 > work/kat/gul_S2_eltcalc_P8 & pid46=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P8 > work/kat/gul_S2_summarycalc_P8 & pid47=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P8 > work/kat/gul_S2_pltcalc_P8 & pid48=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P9 > work/kat/gul_S1_eltcalc_P9 & pid49=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P9 > work/kat/gul_S1_summarycalc_P9 & pid50=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P9 > work/kat/gul_S1_pltcalc_P9 & pid51=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P9 > work/kat/gul_S2_eltcalc_P9 & pid52=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P9 > work/kat/gul_S2_summarycalc_P9 & pid53=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P9 > work/kat/gul_S2_pltcalc_P9 & pid54=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P10 > work/kat/gul_S1_eltcalc_P10 & pid55=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P10 > work/kat/gul_S1_summarycalc_P10 & pid56=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P10 > work/kat/gul_S1_pltcalc_P10 & pid57=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P10 > work/kat/gul_S2_eltcalc_P10 & pid58=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P10 > work/kat/gul_S2_summarycalc_P10 & pid59=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P10 > work/kat/gul_S2_pltcalc_P10 & pid60=$!
+
+tee < fifo/gul_S1_summary_P1 fifo/gul_S1_eltcalc_P1 fifo/gul_S1_summarycalc_P1 fifo/gul_S1_pltcalc_P1 work/gul_S1_summaryaalcalc/P1.bin work/gul_S1_summaryleccalc/P1.bin > /dev/null & pid61=$!
+tee < fifo/gul_S2_summary_P1 fifo/gul_S2_eltcalc_P1 fifo/gul_S2_summarycalc_P1 fifo/gul_S2_pltcalc_P1 work/gul_S2_summaryaalcalc/P1.bin work/gul_S2_summaryleccalc/P1.bin > /dev/null & pid62=$!
+tee < fifo/gul_S1_summary_P2 fifo/gul_S1_eltcalc_P2 fifo/gul_S1_summarycalc_P2 fifo/gul_S1_pltcalc_P2 work/gul_S1_summaryaalcalc/P2.bin work/gul_S1_summaryleccalc/P2.bin > /dev/null & pid63=$!
+tee < fifo/gul_S2_summary_P2 fifo/gul_S2_eltcalc_P2 fifo/gul_S2_summarycalc_P2 fifo/gul_S2_pltcalc_P2 work/gul_S2_summaryaalcalc/P2.bin work/gul_S2_summaryleccalc/P2.bin > /dev/null & pid64=$!
+tee < fifo/gul_S1_summary_P3 fifo/gul_S1_eltcalc_P3 fifo/gul_S1_summarycalc_P3 fifo/gul_S1_pltcalc_P3 work/gul_S1_summaryaalcalc/P3.bin work/gul_S1_summaryleccalc/P3.bin > /dev/null & pid65=$!
+tee < fifo/gul_S2_summary_P3 fifo/gul_S2_eltcalc_P3 fifo/gul_S2_summarycalc_P3 fifo/gul_S2_pltcalc_P3 work/gul_S2_summaryaalcalc/P3.bin work/gul_S2_summaryleccalc/P3.bin > /dev/null & pid66=$!
+tee < fifo/gul_S1_summary_P4 fifo/gul_S1_eltcalc_P4 fifo/gul_S1_summarycalc_P4 fifo/gul_S1_pltcalc_P4 work/gul_S1_summaryaalcalc/P4.bin work/gul_S1_summaryleccalc/P4.bin > /dev/null & pid67=$!
+tee < fifo/gul_S2_summary_P4 fifo/gul_S2_eltcalc_P4 fifo/gul_S2_summarycalc_P4 fifo/gul_S2_pltcalc_P4 work/gul_S2_summaryaalcalc/P4.bin work/gul_S2_summaryleccalc/P4.bin > /dev/null & pid68=$!
+tee < fifo/gul_S1_summary_P5 fifo/gul_S1_eltcalc_P5 fifo/gul_S1_summarycalc_P5 fifo/gul_S1_pltcalc_P5 work/gul_S1_summaryaalcalc/P5.bin work/gul_S1_summaryleccalc/P5.bin > /dev/null & pid69=$!
+tee < fifo/gul_S2_summary_P5 fifo/gul_S2_eltcalc_P5 fifo/gul_S2_summarycalc_P5 fifo/gul_S2_pltcalc_P5 work/gul_S2_summaryaalcalc/P5.bin work/gul_S2_summaryleccalc/P5.bin > /dev/null & pid70=$!
+tee < fifo/gul_S1_summary_P6 fifo/gul_S1_eltcalc_P6 fifo/gul_S1_summarycalc_P6 fifo/gul_S1_pltcalc_P6 work/gul_S1_summaryaalcalc/P6.bin work/gul_S1_summaryleccalc/P6.bin > /dev/null & pid71=$!
+tee < fifo/gul_S2_summary_P6 fifo/gul_S2_eltcalc_P6 fifo/gul_S2_summarycalc_P6 fifo/gul_S2_pltcalc_P6 work/gul_S2_summaryaalcalc/P6.bin work/gul_S2_summaryleccalc/P6.bin > /dev/null & pid72=$!
+tee < fifo/gul_S1_summary_P7 fifo/gul_S1_eltcalc_P7 fifo/gul_S1_summarycalc_P7 fifo/gul_S1_pltcalc_P7 work/gul_S1_summaryaalcalc/P7.bin work/gul_S1_summaryleccalc/P7.bin > /dev/null & pid73=$!
+tee < fifo/gul_S2_summary_P7 fifo/gul_S2_eltcalc_P7 fifo/gul_S2_summarycalc_P7 fifo/gul_S2_pltcalc_P7 work/gul_S2_summaryaalcalc/P7.bin work/gul_S2_summaryleccalc/P7.bin > /dev/null & pid74=$!
+tee < fifo/gul_S1_summary_P8 fifo/gul_S1_eltcalc_P8 fifo/gul_S1_summarycalc_P8 fifo/gul_S1_pltcalc_P8 work/gul_S1_summaryaalcalc/P8.bin work/gul_S1_summaryleccalc/P8.bin > /dev/null & pid75=$!
+tee < fifo/gul_S2_summary_P8 fifo/gul_S2_eltcalc_P8 fifo/gul_S2_summarycalc_P8 fifo/gul_S2_pltcalc_P8 work/gul_S2_summaryaalcalc/P8.bin work/gul_S2_summaryleccalc/P8.bin > /dev/null & pid76=$!
+tee < fifo/gul_S1_summary_P9 fifo/gul_S1_eltcalc_P9 fifo/gul_S1_summarycalc_P9 fifo/gul_S1_pltcalc_P9 work/gul_S1_summaryaalcalc/P9.bin work/gul_S1_summaryleccalc/P9.bin > /dev/null & pid77=$!
+tee < fifo/gul_S2_summary_P9 fifo/gul_S2_eltcalc_P9 fifo/gul_S2_summarycalc_P9 fifo/gul_S2_pltcalc_P9 work/gul_S2_summaryaalcalc/P9.bin work/gul_S2_summaryleccalc/P9.bin > /dev/null & pid78=$!
+tee < fifo/gul_S1_summary_P10 fifo/gul_S1_eltcalc_P10 fifo/gul_S1_summarycalc_P10 fifo/gul_S1_pltcalc_P10 work/gul_S1_summaryaalcalc/P10.bin work/gul_S1_summaryleccalc/P10.bin > /dev/null & pid79=$!
+tee < fifo/gul_S2_summary_P10 fifo/gul_S2_eltcalc_P10 fifo/gul_S2_summarycalc_P10 fifo/gul_S2_pltcalc_P10 work/gul_S2_summaryaalcalc/P10.bin work/gul_S2_summaryleccalc/P10.bin > /dev/null & pid80=$!
+
+summarycalc -i  -1 fifo/gul_S1_summary_P1 -2 fifo/gul_S2_summary_P1 < fifo/gul_P1 &
+summarycalc -i  -1 fifo/gul_S1_summary_P2 -2 fifo/gul_S2_summary_P2 < fifo/gul_P2 &
+summarycalc -i  -1 fifo/gul_S1_summary_P3 -2 fifo/gul_S2_summary_P3 < fifo/gul_P3 &
+summarycalc -i  -1 fifo/gul_S1_summary_P4 -2 fifo/gul_S2_summary_P4 < fifo/gul_P4 &
+summarycalc -i  -1 fifo/gul_S1_summary_P5 -2 fifo/gul_S2_summary_P5 < fifo/gul_P5 &
+summarycalc -i  -1 fifo/gul_S1_summary_P6 -2 fifo/gul_S2_summary_P6 < fifo/gul_P6 &
+summarycalc -i  -1 fifo/gul_S1_summary_P7 -2 fifo/gul_S2_summary_P7 < fifo/gul_P7 &
+summarycalc -i  -1 fifo/gul_S1_summary_P8 -2 fifo/gul_S2_summary_P8 < fifo/gul_P8 &
+summarycalc -i  -1 fifo/gul_S1_summary_P9 -2 fifo/gul_S2_summary_P9 < fifo/gul_P9 &
+summarycalc -i  -1 fifo/gul_S1_summary_P10 -2 fifo/gul_S2_summary_P10 < fifo/gul_P10 &
+
+eve -R 1 10 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P1  &
+eve -R 2 10 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P2  &
+eve -R 3 10 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P3  &
+eve -R 4 10 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P4  &
+eve -R 5 10 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P5  &
+eve -R 6 10 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P6  &
+eve -R 7 10 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P7  &
+eve -R 8 10 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P8  &
+eve -R 9 10 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P9  &
+eve -R 10 10 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P10  &
+
+wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 $pid13 $pid14 $pid15 $pid16 $pid17 $pid18 $pid19 $pid20 $pid21 $pid22 $pid23 $pid24 $pid25 $pid26 $pid27 $pid28 $pid29 $pid30 $pid31 $pid32 $pid33 $pid34 $pid35 $pid36 $pid37 $pid38 $pid39 $pid40 $pid41 $pid42 $pid43 $pid44 $pid45 $pid46 $pid47 $pid48 $pid49 $pid50 $pid51 $pid52 $pid53 $pid54 $pid55 $pid56 $pid57 $pid58 $pid59 $pid60 $pid61 $pid62 $pid63 $pid64 $pid65 $pid66 $pid67 $pid68 $pid69 $pid70 $pid71 $pid72 $pid73 $pid74 $pid75 $pid76 $pid77 $pid78 $pid79 $pid80
+
+
+# --- Do ground up loss kats ---
+
+kat work/kat/gul_S1_eltcalc_P1 work/kat/gul_S1_eltcalc_P2 work/kat/gul_S1_eltcalc_P3 work/kat/gul_S1_eltcalc_P4 work/kat/gul_S1_eltcalc_P5 work/kat/gul_S1_eltcalc_P6 work/kat/gul_S1_eltcalc_P7 work/kat/gul_S1_eltcalc_P8 work/kat/gul_S1_eltcalc_P9 work/kat/gul_S1_eltcalc_P10 > output/gul_S1_eltcalc.csv & kpid1=$!
+kat work/kat/gul_S1_pltcalc_P1 work/kat/gul_S1_pltcalc_P2 work/kat/gul_S1_pltcalc_P3 work/kat/gul_S1_pltcalc_P4 work/kat/gul_S1_pltcalc_P5 work/kat/gul_S1_pltcalc_P6 work/kat/gul_S1_pltcalc_P7 work/kat/gul_S1_pltcalc_P8 work/kat/gul_S1_pltcalc_P9 work/kat/gul_S1_pltcalc_P10 > output/gul_S1_pltcalc.csv & kpid2=$!
+kat work/kat/gul_S1_summarycalc_P1 work/kat/gul_S1_summarycalc_P2 work/kat/gul_S1_summarycalc_P3 work/kat/gul_S1_summarycalc_P4 work/kat/gul_S1_summarycalc_P5 work/kat/gul_S1_summarycalc_P6 work/kat/gul_S1_summarycalc_P7 work/kat/gul_S1_summarycalc_P8 work/kat/gul_S1_summarycalc_P9 work/kat/gul_S1_summarycalc_P10 > output/gul_S1_summarycalc.csv & kpid3=$!
+kat work/kat/gul_S2_eltcalc_P1 work/kat/gul_S2_eltcalc_P2 work/kat/gul_S2_eltcalc_P3 work/kat/gul_S2_eltcalc_P4 work/kat/gul_S2_eltcalc_P5 work/kat/gul_S2_eltcalc_P6 work/kat/gul_S2_eltcalc_P7 work/kat/gul_S2_eltcalc_P8 work/kat/gul_S2_eltcalc_P9 work/kat/gul_S2_eltcalc_P10 > output/gul_S2_eltcalc.csv & kpid4=$!
+kat work/kat/gul_S2_pltcalc_P1 work/kat/gul_S2_pltcalc_P2 work/kat/gul_S2_pltcalc_P3 work/kat/gul_S2_pltcalc_P4 work/kat/gul_S2_pltcalc_P5 work/kat/gul_S2_pltcalc_P6 work/kat/gul_S2_pltcalc_P7 work/kat/gul_S2_pltcalc_P8 work/kat/gul_S2_pltcalc_P9 work/kat/gul_S2_pltcalc_P10 > output/gul_S2_pltcalc.csv & kpid5=$!
+kat work/kat/gul_S2_summarycalc_P1 work/kat/gul_S2_summarycalc_P2 work/kat/gul_S2_summarycalc_P3 work/kat/gul_S2_summarycalc_P4 work/kat/gul_S2_summarycalc_P5 work/kat/gul_S2_summarycalc_P6 work/kat/gul_S2_summarycalc_P7 work/kat/gul_S2_summarycalc_P8 work/kat/gul_S2_summarycalc_P9 work/kat/gul_S2_summarycalc_P10 > output/gul_S2_summarycalc.csv & kpid6=$!
+wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
+
+
+aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv & lpid1=$!
+ordleccalc -r -Kgul_S1_summaryleccalc -F -S -s -M -m -W -w -O output/gul_S1_ept.csv -o output/gul_S1_psept.csv & lpid2=$!
+leccalc -r -Kgul_S1_summaryleccalc -F output/gul_S1_leccalc_full_uncertainty_aep.csv -f output/gul_S1_leccalc_full_uncertainty_oep.csv -S output/gul_S1_leccalc_sample_mean_aep.csv -s output/gul_S1_leccalc_sample_mean_oep.csv -W output/gul_S1_leccalc_wheatsheaf_aep.csv -M output/gul_S1_leccalc_wheatsheaf_mean_aep.csv -m output/gul_S1_leccalc_wheatsheaf_mean_oep.csv -w output/gul_S1_leccalc_wheatsheaf_oep.csv & lpid3=$!
+aalcalc -Kgul_S2_summaryaalcalc > output/gul_S2_aalcalc.csv & lpid4=$!
+ordleccalc -r -Kgul_S2_summaryleccalc -F -S -s -M -m -W -w -O output/gul_S2_ept.csv -o output/gul_S2_psept.csv & lpid5=$!
+leccalc -r -Kgul_S2_summaryleccalc -F output/gul_S2_leccalc_full_uncertainty_aep.csv -f output/gul_S2_leccalc_full_uncertainty_oep.csv -S output/gul_S2_leccalc_sample_mean_aep.csv -s output/gul_S2_leccalc_sample_mean_oep.csv -W output/gul_S2_leccalc_wheatsheaf_aep.csv -M output/gul_S2_leccalc_wheatsheaf_mean_aep.csv -m output/gul_S2_leccalc_wheatsheaf_mean_oep.csv -w output/gul_S2_leccalc_wheatsheaf_oep.csv & lpid6=$!
+wait $lpid1 $lpid2 $lpid3 $lpid4 $lpid5 $lpid6
+
+rm -R -f work/*
+rm -R -f fifo/*

--- a/tests/model_execution/eve_kparse_reference/gul_ord_psept_2_output_10_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_ord_psept_2_output_10_partition.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+
+rm -R -f fifo/*
+rm -R -f work/*
+mkdir work/kat/
+
+mkdir work/gul_S1_summaryleccalc
+mkdir work/gul_S2_summaryleccalc
+
+mkfifo fifo/gul_P1
+mkfifo fifo/gul_P2
+mkfifo fifo/gul_P3
+mkfifo fifo/gul_P4
+mkfifo fifo/gul_P5
+mkfifo fifo/gul_P6
+mkfifo fifo/gul_P7
+mkfifo fifo/gul_P8
+mkfifo fifo/gul_P9
+mkfifo fifo/gul_P10
+
+mkfifo fifo/gul_S1_summary_P1
+mkfifo fifo/gul_S2_summary_P1
+
+mkfifo fifo/gul_S1_summary_P2
+mkfifo fifo/gul_S2_summary_P2
+
+mkfifo fifo/gul_S1_summary_P3
+mkfifo fifo/gul_S2_summary_P3
+
+mkfifo fifo/gul_S1_summary_P4
+mkfifo fifo/gul_S2_summary_P4
+
+mkfifo fifo/gul_S1_summary_P5
+mkfifo fifo/gul_S2_summary_P5
+
+mkfifo fifo/gul_S1_summary_P6
+mkfifo fifo/gul_S2_summary_P6
+
+mkfifo fifo/gul_S1_summary_P7
+mkfifo fifo/gul_S2_summary_P7
+
+mkfifo fifo/gul_S1_summary_P8
+mkfifo fifo/gul_S2_summary_P8
+
+mkfifo fifo/gul_S1_summary_P9
+mkfifo fifo/gul_S2_summary_P9
+
+mkfifo fifo/gul_S1_summary_P10
+mkfifo fifo/gul_S2_summary_P10
+
+
+
+# --- Do ground up loss computes ---
+
+
+tee < fifo/gul_S1_summary_P1 work/gul_S1_summaryleccalc/P1.bin > /dev/null & pid1=$!
+tee < fifo/gul_S2_summary_P1 work/gul_S2_summaryleccalc/P1.bin > /dev/null & pid2=$!
+tee < fifo/gul_S1_summary_P2 work/gul_S1_summaryleccalc/P2.bin > /dev/null & pid3=$!
+tee < fifo/gul_S2_summary_P2 work/gul_S2_summaryleccalc/P2.bin > /dev/null & pid4=$!
+tee < fifo/gul_S1_summary_P3 work/gul_S1_summaryleccalc/P3.bin > /dev/null & pid5=$!
+tee < fifo/gul_S2_summary_P3 work/gul_S2_summaryleccalc/P3.bin > /dev/null & pid6=$!
+tee < fifo/gul_S1_summary_P4 work/gul_S1_summaryleccalc/P4.bin > /dev/null & pid7=$!
+tee < fifo/gul_S2_summary_P4 work/gul_S2_summaryleccalc/P4.bin > /dev/null & pid8=$!
+tee < fifo/gul_S1_summary_P5 work/gul_S1_summaryleccalc/P5.bin > /dev/null & pid9=$!
+tee < fifo/gul_S2_summary_P5 work/gul_S2_summaryleccalc/P5.bin > /dev/null & pid10=$!
+tee < fifo/gul_S1_summary_P6 work/gul_S1_summaryleccalc/P6.bin > /dev/null & pid11=$!
+tee < fifo/gul_S2_summary_P6 work/gul_S2_summaryleccalc/P6.bin > /dev/null & pid12=$!
+tee < fifo/gul_S1_summary_P7 work/gul_S1_summaryleccalc/P7.bin > /dev/null & pid13=$!
+tee < fifo/gul_S2_summary_P7 work/gul_S2_summaryleccalc/P7.bin > /dev/null & pid14=$!
+tee < fifo/gul_S1_summary_P8 work/gul_S1_summaryleccalc/P8.bin > /dev/null & pid15=$!
+tee < fifo/gul_S2_summary_P8 work/gul_S2_summaryleccalc/P8.bin > /dev/null & pid16=$!
+tee < fifo/gul_S1_summary_P9 work/gul_S1_summaryleccalc/P9.bin > /dev/null & pid17=$!
+tee < fifo/gul_S2_summary_P9 work/gul_S2_summaryleccalc/P9.bin > /dev/null & pid18=$!
+tee < fifo/gul_S1_summary_P10 work/gul_S1_summaryleccalc/P10.bin > /dev/null & pid19=$!
+tee < fifo/gul_S2_summary_P10 work/gul_S2_summaryleccalc/P10.bin > /dev/null & pid20=$!
+
+summarycalc -i  -1 fifo/gul_S1_summary_P1 -2 fifo/gul_S2_summary_P1 < fifo/gul_P1 &
+summarycalc -i  -1 fifo/gul_S1_summary_P2 -2 fifo/gul_S2_summary_P2 < fifo/gul_P2 &
+summarycalc -i  -1 fifo/gul_S1_summary_P3 -2 fifo/gul_S2_summary_P3 < fifo/gul_P3 &
+summarycalc -i  -1 fifo/gul_S1_summary_P4 -2 fifo/gul_S2_summary_P4 < fifo/gul_P4 &
+summarycalc -i  -1 fifo/gul_S1_summary_P5 -2 fifo/gul_S2_summary_P5 < fifo/gul_P5 &
+summarycalc -i  -1 fifo/gul_S1_summary_P6 -2 fifo/gul_S2_summary_P6 < fifo/gul_P6 &
+summarycalc -i  -1 fifo/gul_S1_summary_P7 -2 fifo/gul_S2_summary_P7 < fifo/gul_P7 &
+summarycalc -i  -1 fifo/gul_S1_summary_P8 -2 fifo/gul_S2_summary_P8 < fifo/gul_P8 &
+summarycalc -i  -1 fifo/gul_S1_summary_P9 -2 fifo/gul_S2_summary_P9 < fifo/gul_P9 &
+summarycalc -i  -1 fifo/gul_S1_summary_P10 -2 fifo/gul_S2_summary_P10 < fifo/gul_P10 &
+
+eve -R 1 10 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P1  &
+eve -R 2 10 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P2  &
+eve -R 3 10 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P3  &
+eve -R 4 10 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P4  &
+eve -R 5 10 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P5  &
+eve -R 6 10 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P6  &
+eve -R 7 10 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P7  &
+eve -R 8 10 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P8  &
+eve -R 9 10 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P9  &
+eve -R 10 10 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P10  &
+
+wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 $pid13 $pid14 $pid15 $pid16 $pid17 $pid18 $pid19 $pid20
+
+
+# --- Do ground up loss kats ---
+
+
+ordleccalc  -Kgul_S1_summaryleccalc -W -w -o output/gul_S1_psept.csv & lpid1=$!
+ordleccalc -r -Kgul_S2_summaryleccalc -W -w -o output/gul_S2_psept.csv & lpid2=$!
+wait $lpid1 $lpid2
+
+rm -R -f work/*
+rm -R -f fifo/*

--- a/tests/model_execution/fc_kparse_input/analysis_settings_5.json
+++ b/tests/model_execution/fc_kparse_input/analysis_settings_5.json
@@ -1,0 +1,59 @@
+{
+  "analysis_settings": {
+    "source_tag": "test_source",
+    "analysis_tag": "test_analysis",
+    "module_supplier_id": "OasisIM",
+    "model_version_id": "1",
+    "number_of_samples": 0,
+    "gul_threshold": 0,
+    "model_settings": {
+      "use_random_number_file": true,
+      "event_occurrence_file_id": 1
+    },
+    "gul_output": true,
+    "gul_summaries": [
+      {
+        "id": 1,
+        "summarycalc": true,
+        "eltcalc": true,
+        "aalcalc": true,
+        "pltcalc": true
+      }
+    ],
+    "il_output": true,    
+    "il_summaries": [
+      {
+        "id": 1,
+        "ord_output": {
+          "ept_full_uncertainty_aep": true,
+          "ept_full_uncertainty_oep": false,
+          "ept_mean_sample_aep": true,
+          "ept_mean_sample_oep": true,
+          "ept_per_sample_mean_aep": true,
+          "ept_per_sample_mean_oep": true,
+          "psept_aep": false,
+          "psept_oep": false,
+          "return_period_file": false
+        }
+      }
+    ],
+    "ri_output": true,    
+    "ri_summaries": [
+      {
+        "id": 1,
+        "ord_output": {
+          "ept_full_uncertainty_aep": true,
+          "ept_full_uncertainty_oep": true,
+          "ept_mean_sample_aep": true,
+          "ept_mean_sample_oep": true,
+          "ept_per_sample_mean_aep": true,
+          "ept_per_sample_mean_oep": true,
+          "psept_aep": true,
+          "psept_oep": true,
+          "return_period_file": true
+        }
+      }
+    ],
+    "full_correlation": true
+  }
+}

--- a/tests/model_execution/fc_kparse_input/gul_il_ord_ept_psept_2_output.json
+++ b/tests/model_execution/fc_kparse_input/gul_il_ord_ept_psept_2_output.json
@@ -1,0 +1,93 @@
+{
+  "analysis_settings": {
+    "source_tag": "test_source",
+    "analysis_tag": "test_analysis",
+    "module_supplier_id": "OasisIM",
+    "model_version_id": "1",
+    "number_of_samples": 0,
+    "gul_threshold": 0,
+    "model_settings": {
+      "use_random_number_file": true,
+      "event_occurrence_file_id": 1
+    },
+    "gul_output": true,
+    "gul_summaries": [
+      {
+        "id": 1,
+        "summarycalc": true,
+        "eltcalc": true,
+        "aalcalc": true,
+        "pltcalc": true,
+        "ord_output": {
+          "ept_full_uncertainty_aep": true,
+          "ept_full_uncertainty_oep": false,
+          "ept_mean_sample_aep": true,
+          "ept_mean_sample_oep": true,
+          "ept_per_sample_mean_aep": true,
+          "ept_per_sample_mean_oep": true,
+          "psept_aep": true,
+          "psept_oep": true,
+          "return_period_file": true
+        }
+      },
+      {
+        "id": 2,
+        "summarycalc": true,
+        "eltcalc": true,
+        "aalcalc": true,
+        "pltcalc": true,
+        "ord_output": {
+          "ept_full_uncertainty_aep": true,
+          "ept_full_uncertainty_oep": false,
+          "ept_mean_sample_aep": true,
+          "ept_mean_sample_oep": true,
+          "ept_per_sample_mean_aep": true,
+          "ept_per_sample_mean_oep": true,
+          "psept_aep": true,
+          "psept_oep": true,
+          "return_period_file": true
+        }
+      }
+    ],
+    "il_output": true,
+    "il_summaries": [
+      {
+        "id": 1,
+        "summarycalc": true,
+        "eltcalc": true,
+        "aalcalc": true,
+        "pltcalc": true,
+        "ord_output": {
+          "ept_full_uncertainty_aep": true,
+          "ept_full_uncertainty_oep": false,
+          "ept_mean_sample_aep": true,
+          "ept_mean_sample_oep": true,
+          "ept_per_sample_mean_aep": true,
+          "ept_per_sample_mean_oep": true,
+          "psept_aep": true,
+          "psept_oep": true,
+          "return_period_file": true
+        }
+      },
+      {
+        "id": 2,
+        "summarycalc": true,
+        "eltcalc": true,
+        "aalcalc": true,
+        "pltcalc": true,
+        "ord_output": {
+          "ept_full_uncertainty_aep": true,
+          "ept_full_uncertainty_oep": false,
+          "ept_mean_sample_aep": true,
+          "ept_mean_sample_oep": true,
+          "ept_per_sample_mean_aep": true,
+          "ept_per_sample_mean_oep": true,
+          "psept_aep": true,
+          "psept_oep": true,
+          "return_period_file": true
+        }
+      }
+    ],
+    "full_correlation": true
+  }
+}

--- a/tests/model_execution/fc_kparse_input/gul_il_ord_psept_lec_1_output.json
+++ b/tests/model_execution/fc_kparse_input/gul_il_ord_psept_lec_1_output.json
@@ -1,0 +1,81 @@
+{
+  "analysis_settings": {
+    "source_tag": "test_source",
+    "analysis_tag": "test_analysis",
+    "module_supplier_id": "OasisIM",
+    "model_version_id": "1",
+    "number_of_samples": 0,
+    "gul_threshold": 0,
+    "model_settings": {
+      "use_random_number_file": true,
+      "event_occurrence_file_id": 1
+    },
+    "gul_output": true,
+    "gul_summaries": [
+      {
+        "id": 1,
+        "summarycalc": true,
+        "eltcalc": true,
+        "aalcalc": true,
+        "pltcalc": true,
+        "lec_output":true,
+        "leccalc": {
+            "return_period_file": true,
+            "full_uncertainty_aep": true,
+            "full_uncertainty_oep": true,
+            "wheatsheaf_aep": true,
+            "wheatsheaf_oep": true,
+            "wheatsheaf_mean_aep": true,
+            "wheatsheaf_mean_oep": true,
+            "sample_mean_aep": true,
+            "sample_mean_oep": true
+        },        
+        "ord_output": {
+          "ept_full_uncertainty_aep": false,
+          "ept_full_uncertainty_oep": false,
+          "ept_mean_sample_aep": false,
+          "ept_mean_sample_oep": false,
+          "ept_per_sample_mean_aep": false,
+          "ept_per_sample_mean_oep": false,
+          "psept_aep": true,
+          "psept_oep": true,
+          "return_period_file": false
+        }
+      }
+    ],
+    "il_output": true,
+    "il_summaries": [
+      {
+        "id": 1,
+        "summarycalc": true,
+        "eltcalc": true,
+        "aalcalc": true,
+        "pltcalc": true,
+        "lec_output":true,
+        "leccalc": {
+            "return_period_file": true,
+            "full_uncertainty_aep": true,
+            "full_uncertainty_oep": true,
+            "wheatsheaf_aep": true,
+            "wheatsheaf_oep": true,
+            "wheatsheaf_mean_aep": true,
+            "wheatsheaf_mean_oep": true,
+            "sample_mean_aep": true,
+            "sample_mean_oep": true
+        },        
+        "ord_output": {
+          "ept_full_uncertainty_aep": false,
+          "ept_full_uncertainty_oep": false,
+          "ept_mean_sample_aep": false,
+          "ept_mean_sample_oep": false,
+          "ept_per_sample_mean_aep": false,
+          "ept_per_sample_mean_oep": false,
+          "psept_aep": true,
+          "psept_oep": true,
+          "return_period_file": true
+        }
+      }
+    ],    
+    "full_correlation": true
+  }
+}

--- a/tests/model_execution/fc_kparse_input/gul_ord_ept_1_output.json
+++ b/tests/model_execution/fc_kparse_input/gul_ord_ept_1_output.json
@@ -1,0 +1,31 @@
+{
+  "analysis_settings": {
+    "source_tag": "test_source",
+    "analysis_tag": "test_analysis",
+    "module_supplier_id": "OasisIM",
+    "model_version_id": "1",
+    "number_of_samples": 0,
+    "gul_threshold": 0,
+    "model_settings": {
+      "use_random_number_file": true,
+      "event_occurrence_file_id": 1
+    },
+    "gul_output": true,
+    "gul_summaries": [
+      {
+        "id": 1,
+        "ord_output": {
+          "ept_full_uncertainty_aep": true,
+          "ept_full_uncertainty_oep": true,
+          "ept_mean_sample_aep": true,
+          "ept_mean_sample_oep": true,
+          "ept_per_sample_mean_aep": true,
+          "ept_per_sample_mean_oep": true,
+          "return_period_file": true
+        }
+      }  
+    ],
+    "il_output": false,
+    "full_correlation": true
+  }
+}

--- a/tests/model_execution/fc_kparse_input/gul_ord_ept_psept_lec_2_output.json
+++ b/tests/model_execution/fc_kparse_input/gul_ord_ept_psept_lec_2_output.json
@@ -1,0 +1,79 @@
+{
+  "analysis_settings": {
+    "source_tag": "test_source",
+    "analysis_tag": "test_analysis",
+    "module_supplier_id": "OasisIM",
+    "model_version_id": "1",
+    "number_of_samples": 0,
+    "gul_threshold": 0,
+    "model_settings": {
+      "use_random_number_file": true,
+      "event_occurrence_file_id": 1
+    },
+    "gul_output": true,
+    "gul_summaries": [
+      {
+        "id": 1,
+        "summarycalc": true,
+        "eltcalc": true,
+        "aalcalc": true,
+        "pltcalc": true,
+        "lec_output":true,
+        "leccalc": {
+          "return_period_file": true,
+          "full_uncertainty_aep": true,
+          "full_uncertainty_oep": true,
+          "wheatsheaf_aep": true,
+          "wheatsheaf_oep": true,
+          "wheatsheaf_mean_aep": true,
+          "wheatsheaf_mean_oep": true,
+          "sample_mean_aep": true,
+          "sample_mean_oep": true
+        },
+        "ord_output": {
+          "ept_full_uncertainty_aep": true,
+          "ept_full_uncertainty_oep": false,
+          "ept_mean_sample_aep": true,
+          "ept_mean_sample_oep": true,
+          "ept_per_sample_mean_aep": true,
+          "ept_per_sample_mean_oep": true,
+          "psept_aep": true,
+          "psept_oep": true,
+          "return_period_file": true
+        }
+      },
+      {
+        "id": 2,
+        "summarycalc": true,
+        "eltcalc": true,
+        "aalcalc": true,
+        "pltcalc": true,
+        "lec_output":true,
+        "leccalc": {
+          "return_period_file": true,
+          "full_uncertainty_aep": true,
+          "full_uncertainty_oep": true,
+          "wheatsheaf_aep": true,
+          "wheatsheaf_oep": true,
+          "wheatsheaf_mean_aep": true,
+          "wheatsheaf_mean_oep": true,
+          "sample_mean_aep": true,
+          "sample_mean_oep": true
+        },        
+        "ord_output": {
+          "ept_full_uncertainty_aep": true,
+          "ept_full_uncertainty_oep": false,
+          "ept_mean_sample_aep": true,
+          "ept_mean_sample_oep": true,
+          "ept_per_sample_mean_aep": true,
+          "ept_per_sample_mean_oep": true,
+          "psept_aep": true,
+          "psept_oep": true,
+          "return_period_file": true
+        }
+      }
+    ],
+    "il_output": false,
+    "full_correlation": true
+  }
+}

--- a/tests/model_execution/fc_kparse_input/gul_ord_psept_2_output.json
+++ b/tests/model_execution/fc_kparse_input/gul_ord_psept_2_output.json
@@ -1,0 +1,35 @@
+{
+  "analysis_settings": {
+    "source_tag": "test_source",
+    "analysis_tag": "test_analysis",
+    "module_supplier_id": "OasisIM",
+    "model_version_id": "1",
+    "number_of_samples": 0,
+    "gul_threshold": 0,
+    "model_settings": {
+      "use_random_number_file": true,
+      "event_occurrence_file_id": 1
+    },
+    "gul_output": true,
+    "gul_summaries": [
+      {
+        "id": 1,
+        "ord_output": {
+          "psept_aep": true,
+          "psept_oep": true,
+          "return_period_file": false
+        }
+      },
+      {
+        "id": 2,
+        "ord_output": {
+          "psept_aep": true,
+          "psept_oep": true,
+          "return_period_file": true
+        }
+      } 
+    ],
+    "il_output": false,
+    "full_correlation": true
+  }
+}

--- a/tests/model_execution/itm_fc_kparse_reference/analysis_settings_5_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/analysis_settings_5_1_reins_layer_1_partition.sh
@@ -1,0 +1,153 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+mkdir output/full_correlation/
+
+rm -R -f fifo/*
+mkdir fifo/full_correlation/
+rm -R -f work/*
+mkdir work/kat/
+mkdir work/full_correlation/
+mkdir work/full_correlation/kat/
+
+mkdir work/gul_S1_summaryaalcalc
+mkdir work/full_correlation/gul_S1_summaryaalcalc
+mkdir work/il_S1_summaryleccalc
+mkdir work/full_correlation/il_S1_summaryleccalc
+mkdir work/ri_S1_summaryleccalc
+mkdir work/full_correlation/ri_S1_summaryleccalc
+
+mkfifo fifo/full_correlation/gul_fc_P1
+
+mkfifo fifo/gul_P1
+
+mkfifo fifo/gul_S1_summary_P1
+mkfifo fifo/gul_S1_eltcalc_P1
+mkfifo fifo/gul_S1_summarycalc_P1
+mkfifo fifo/gul_S1_pltcalc_P1
+
+mkfifo fifo/il_P1
+
+mkfifo fifo/il_S1_summary_P1
+
+mkfifo fifo/ri_P1
+
+mkfifo fifo/ri_S1_summary_P1
+
+mkfifo fifo/full_correlation/gul_P1
+
+mkfifo fifo/full_correlation/gul_S1_summary_P1
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P1
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P1
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P1
+
+mkfifo fifo/full_correlation/il_P1
+
+mkfifo fifo/full_correlation/il_S1_summary_P1
+
+mkfifo fifo/full_correlation/ri_P1
+
+mkfifo fifo/full_correlation/ri_S1_summary_P1
+
+
+
+# --- Do reinsurance loss computes ---
+
+
+tee < fifo/ri_S1_summary_P1 work/ri_S1_summaryleccalc/P1.bin > /dev/null & pid1=$!
+
+summarycalc -f -p RI_1 -1 fifo/ri_S1_summary_P1 < fifo/ri_P1 &
+
+# --- Do insured loss computes ---
+
+
+tee < fifo/il_S1_summary_P1 work/il_S1_summaryleccalc/P1.bin > /dev/null & pid2=$!
+
+summarycalc -f  -1 fifo/il_S1_summary_P1 < fifo/il_P1 &
+
+# --- Do ground up loss computes ---
+
+eltcalc < fifo/gul_S1_eltcalc_P1 > work/kat/gul_S1_eltcalc_P1 & pid3=$!
+summarycalctocsv < fifo/gul_S1_summarycalc_P1 > work/kat/gul_S1_summarycalc_P1 & pid4=$!
+pltcalc < fifo/gul_S1_pltcalc_P1 > work/kat/gul_S1_pltcalc_P1 & pid5=$!
+
+tee < fifo/gul_S1_summary_P1 fifo/gul_S1_eltcalc_P1 fifo/gul_S1_summarycalc_P1 fifo/gul_S1_pltcalc_P1 work/gul_S1_summaryaalcalc/P1.bin > /dev/null & pid6=$!
+
+summarycalc -i  -1 fifo/gul_S1_summary_P1 < fifo/gul_P1 &
+
+# --- Do reinsurance loss computes ---
+
+
+tee < fifo/full_correlation/ri_S1_summary_P1 work/full_correlation/ri_S1_summaryleccalc/P1.bin > /dev/null & pid7=$!
+
+summarycalc -f -p RI_1 -1 fifo/full_correlation/ri_S1_summary_P1 < fifo/full_correlation/ri_P1 &
+
+# --- Do insured loss computes ---
+
+
+tee < fifo/full_correlation/il_S1_summary_P1 work/full_correlation/il_S1_summaryleccalc/P1.bin > /dev/null & pid8=$!
+
+summarycalc -f  -1 fifo/full_correlation/il_S1_summary_P1 < fifo/full_correlation/il_P1 &
+
+# --- Do ground up loss computes ---
+
+eltcalc < fifo/full_correlation/gul_S1_eltcalc_P1 > work/full_correlation/kat/gul_S1_eltcalc_P1 & pid9=$!
+summarycalctocsv < fifo/full_correlation/gul_S1_summarycalc_P1 > work/full_correlation/kat/gul_S1_summarycalc_P1 & pid10=$!
+pltcalc < fifo/full_correlation/gul_S1_pltcalc_P1 > work/full_correlation/kat/gul_S1_pltcalc_P1 & pid11=$!
+
+tee < fifo/full_correlation/gul_S1_summary_P1 fifo/full_correlation/gul_S1_eltcalc_P1 fifo/full_correlation/gul_S1_summarycalc_P1 fifo/full_correlation/gul_S1_pltcalc_P1 work/full_correlation/gul_S1_summaryaalcalc/P1.bin > /dev/null & pid12=$!
+
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P1 < fifo/full_correlation/gul_P1 &
+
+tee < fifo/full_correlation/gul_fc_P1 fifo/full_correlation/gul_P1  | fmcalc -a2 | tee fifo/full_correlation/il_P1 | fmcalc -a3 -n -p RI_1 > fifo/full_correlation/ri_P1 &
+eve 1 1 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_fc_P1 -a1 -i - | tee fifo/gul_P1 | fmcalc -a2 | tee fifo/il_P1 | fmcalc -a3 -n -p RI_1 > fifo/ri_P1 &
+
+wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12
+
+
+# --- Do reinsurance loss kats ---
+
+
+# --- Do reinsurance loss kats for fully correlated output ---
+
+
+# --- Do insured loss kats ---
+
+
+# --- Do insured loss kats for fully correlated output ---
+
+
+# --- Do ground up loss kats ---
+
+kat -s work/kat/gul_S1_eltcalc_P1 > output/gul_S1_eltcalc.csv & kpid1=$!
+kat work/kat/gul_S1_pltcalc_P1 > output/gul_S1_pltcalc.csv & kpid2=$!
+kat work/kat/gul_S1_summarycalc_P1 > output/gul_S1_summarycalc.csv & kpid3=$!
+
+# --- Do ground up loss kats for fully correlated output ---
+
+kat -s work/full_correlation/kat/gul_S1_eltcalc_P1 > output/full_correlation/gul_S1_eltcalc.csv & kpid4=$!
+kat work/full_correlation/kat/gul_S1_pltcalc_P1 > output/full_correlation/gul_S1_pltcalc.csv & kpid5=$!
+kat work/full_correlation/kat/gul_S1_summarycalc_P1 > output/full_correlation/gul_S1_summarycalc.csv & kpid6=$!
+wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
+
+
+ordleccalc -r -Kri_S1_summaryleccalc -F -f -S -s -M -m -W -w -O output/ri_S1_ept.csv -o output/ri_S1_psept.csv & lpid1=$!
+ordleccalc  -Kil_S1_summaryleccalc -F -S -s -M -m -O output/il_S1_ept.csv & lpid2=$!
+aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv & lpid3=$!
+ordleccalc -r -Kfull_correlation/ri_S1_summaryleccalc -F -f -S -s -M -m -W -w -O output/full_correlation/ri_S1_ept.csv -o output/full_correlation/ri_S1_psept.csv & lpid4=$!
+ordleccalc  -Kfull_correlation/il_S1_summaryleccalc -F -S -s -M -m -O output/full_correlation/il_S1_ept.csv & lpid5=$!
+aalcalc -Kfull_correlation/gul_S1_summaryaalcalc > output/full_correlation/gul_S1_aalcalc.csv & lpid6=$!
+wait $lpid1 $lpid2 $lpid3 $lpid4 $lpid5 $lpid6
+
+rm -R -f work/*
+rm -R -f fifo/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_il_ord_ept_psept_2_output_10_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_il_ord_ept_psept_2_output_10_partition.sh
@@ -1,0 +1,918 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+mkdir output/full_correlation/
+
+rm -R -f fifo/*
+mkdir fifo/full_correlation/
+rm -R -f work/*
+mkdir work/kat/
+mkdir work/full_correlation/
+mkdir work/full_correlation/kat/
+
+mkdir work/gul_S1_summaryleccalc
+mkdir work/gul_S1_summaryaalcalc
+mkdir work/gul_S2_summaryleccalc
+mkdir work/gul_S2_summaryaalcalc
+mkdir work/full_correlation/gul_S1_summaryleccalc
+mkdir work/full_correlation/gul_S1_summaryaalcalc
+mkdir work/full_correlation/gul_S2_summaryleccalc
+mkdir work/full_correlation/gul_S2_summaryaalcalc
+mkdir work/il_S1_summaryleccalc
+mkdir work/il_S1_summaryaalcalc
+mkdir work/il_S2_summaryleccalc
+mkdir work/il_S2_summaryaalcalc
+mkdir work/full_correlation/il_S1_summaryleccalc
+mkdir work/full_correlation/il_S1_summaryaalcalc
+mkdir work/full_correlation/il_S2_summaryleccalc
+mkdir work/full_correlation/il_S2_summaryaalcalc
+
+mkfifo fifo/full_correlation/gul_fc_P1
+mkfifo fifo/full_correlation/gul_fc_P2
+mkfifo fifo/full_correlation/gul_fc_P3
+mkfifo fifo/full_correlation/gul_fc_P4
+mkfifo fifo/full_correlation/gul_fc_P5
+mkfifo fifo/full_correlation/gul_fc_P6
+mkfifo fifo/full_correlation/gul_fc_P7
+mkfifo fifo/full_correlation/gul_fc_P8
+mkfifo fifo/full_correlation/gul_fc_P9
+mkfifo fifo/full_correlation/gul_fc_P10
+
+mkfifo fifo/gul_P1
+mkfifo fifo/gul_P2
+mkfifo fifo/gul_P3
+mkfifo fifo/gul_P4
+mkfifo fifo/gul_P5
+mkfifo fifo/gul_P6
+mkfifo fifo/gul_P7
+mkfifo fifo/gul_P8
+mkfifo fifo/gul_P9
+mkfifo fifo/gul_P10
+
+mkfifo fifo/gul_S1_summary_P1
+mkfifo fifo/gul_S1_eltcalc_P1
+mkfifo fifo/gul_S1_summarycalc_P1
+mkfifo fifo/gul_S1_pltcalc_P1
+mkfifo fifo/gul_S2_summary_P1
+mkfifo fifo/gul_S2_eltcalc_P1
+mkfifo fifo/gul_S2_summarycalc_P1
+mkfifo fifo/gul_S2_pltcalc_P1
+
+mkfifo fifo/gul_S1_summary_P2
+mkfifo fifo/gul_S1_eltcalc_P2
+mkfifo fifo/gul_S1_summarycalc_P2
+mkfifo fifo/gul_S1_pltcalc_P2
+mkfifo fifo/gul_S2_summary_P2
+mkfifo fifo/gul_S2_eltcalc_P2
+mkfifo fifo/gul_S2_summarycalc_P2
+mkfifo fifo/gul_S2_pltcalc_P2
+
+mkfifo fifo/gul_S1_summary_P3
+mkfifo fifo/gul_S1_eltcalc_P3
+mkfifo fifo/gul_S1_summarycalc_P3
+mkfifo fifo/gul_S1_pltcalc_P3
+mkfifo fifo/gul_S2_summary_P3
+mkfifo fifo/gul_S2_eltcalc_P3
+mkfifo fifo/gul_S2_summarycalc_P3
+mkfifo fifo/gul_S2_pltcalc_P3
+
+mkfifo fifo/gul_S1_summary_P4
+mkfifo fifo/gul_S1_eltcalc_P4
+mkfifo fifo/gul_S1_summarycalc_P4
+mkfifo fifo/gul_S1_pltcalc_P4
+mkfifo fifo/gul_S2_summary_P4
+mkfifo fifo/gul_S2_eltcalc_P4
+mkfifo fifo/gul_S2_summarycalc_P4
+mkfifo fifo/gul_S2_pltcalc_P4
+
+mkfifo fifo/gul_S1_summary_P5
+mkfifo fifo/gul_S1_eltcalc_P5
+mkfifo fifo/gul_S1_summarycalc_P5
+mkfifo fifo/gul_S1_pltcalc_P5
+mkfifo fifo/gul_S2_summary_P5
+mkfifo fifo/gul_S2_eltcalc_P5
+mkfifo fifo/gul_S2_summarycalc_P5
+mkfifo fifo/gul_S2_pltcalc_P5
+
+mkfifo fifo/gul_S1_summary_P6
+mkfifo fifo/gul_S1_eltcalc_P6
+mkfifo fifo/gul_S1_summarycalc_P6
+mkfifo fifo/gul_S1_pltcalc_P6
+mkfifo fifo/gul_S2_summary_P6
+mkfifo fifo/gul_S2_eltcalc_P6
+mkfifo fifo/gul_S2_summarycalc_P6
+mkfifo fifo/gul_S2_pltcalc_P6
+
+mkfifo fifo/gul_S1_summary_P7
+mkfifo fifo/gul_S1_eltcalc_P7
+mkfifo fifo/gul_S1_summarycalc_P7
+mkfifo fifo/gul_S1_pltcalc_P7
+mkfifo fifo/gul_S2_summary_P7
+mkfifo fifo/gul_S2_eltcalc_P7
+mkfifo fifo/gul_S2_summarycalc_P7
+mkfifo fifo/gul_S2_pltcalc_P7
+
+mkfifo fifo/gul_S1_summary_P8
+mkfifo fifo/gul_S1_eltcalc_P8
+mkfifo fifo/gul_S1_summarycalc_P8
+mkfifo fifo/gul_S1_pltcalc_P8
+mkfifo fifo/gul_S2_summary_P8
+mkfifo fifo/gul_S2_eltcalc_P8
+mkfifo fifo/gul_S2_summarycalc_P8
+mkfifo fifo/gul_S2_pltcalc_P8
+
+mkfifo fifo/gul_S1_summary_P9
+mkfifo fifo/gul_S1_eltcalc_P9
+mkfifo fifo/gul_S1_summarycalc_P9
+mkfifo fifo/gul_S1_pltcalc_P9
+mkfifo fifo/gul_S2_summary_P9
+mkfifo fifo/gul_S2_eltcalc_P9
+mkfifo fifo/gul_S2_summarycalc_P9
+mkfifo fifo/gul_S2_pltcalc_P9
+
+mkfifo fifo/gul_S1_summary_P10
+mkfifo fifo/gul_S1_eltcalc_P10
+mkfifo fifo/gul_S1_summarycalc_P10
+mkfifo fifo/gul_S1_pltcalc_P10
+mkfifo fifo/gul_S2_summary_P10
+mkfifo fifo/gul_S2_eltcalc_P10
+mkfifo fifo/gul_S2_summarycalc_P10
+mkfifo fifo/gul_S2_pltcalc_P10
+
+mkfifo fifo/il_P1
+mkfifo fifo/il_P2
+mkfifo fifo/il_P3
+mkfifo fifo/il_P4
+mkfifo fifo/il_P5
+mkfifo fifo/il_P6
+mkfifo fifo/il_P7
+mkfifo fifo/il_P8
+mkfifo fifo/il_P9
+mkfifo fifo/il_P10
+
+mkfifo fifo/il_S1_summary_P1
+mkfifo fifo/il_S1_eltcalc_P1
+mkfifo fifo/il_S1_summarycalc_P1
+mkfifo fifo/il_S1_pltcalc_P1
+mkfifo fifo/il_S2_summary_P1
+mkfifo fifo/il_S2_eltcalc_P1
+mkfifo fifo/il_S2_summarycalc_P1
+mkfifo fifo/il_S2_pltcalc_P1
+
+mkfifo fifo/il_S1_summary_P2
+mkfifo fifo/il_S1_eltcalc_P2
+mkfifo fifo/il_S1_summarycalc_P2
+mkfifo fifo/il_S1_pltcalc_P2
+mkfifo fifo/il_S2_summary_P2
+mkfifo fifo/il_S2_eltcalc_P2
+mkfifo fifo/il_S2_summarycalc_P2
+mkfifo fifo/il_S2_pltcalc_P2
+
+mkfifo fifo/il_S1_summary_P3
+mkfifo fifo/il_S1_eltcalc_P3
+mkfifo fifo/il_S1_summarycalc_P3
+mkfifo fifo/il_S1_pltcalc_P3
+mkfifo fifo/il_S2_summary_P3
+mkfifo fifo/il_S2_eltcalc_P3
+mkfifo fifo/il_S2_summarycalc_P3
+mkfifo fifo/il_S2_pltcalc_P3
+
+mkfifo fifo/il_S1_summary_P4
+mkfifo fifo/il_S1_eltcalc_P4
+mkfifo fifo/il_S1_summarycalc_P4
+mkfifo fifo/il_S1_pltcalc_P4
+mkfifo fifo/il_S2_summary_P4
+mkfifo fifo/il_S2_eltcalc_P4
+mkfifo fifo/il_S2_summarycalc_P4
+mkfifo fifo/il_S2_pltcalc_P4
+
+mkfifo fifo/il_S1_summary_P5
+mkfifo fifo/il_S1_eltcalc_P5
+mkfifo fifo/il_S1_summarycalc_P5
+mkfifo fifo/il_S1_pltcalc_P5
+mkfifo fifo/il_S2_summary_P5
+mkfifo fifo/il_S2_eltcalc_P5
+mkfifo fifo/il_S2_summarycalc_P5
+mkfifo fifo/il_S2_pltcalc_P5
+
+mkfifo fifo/il_S1_summary_P6
+mkfifo fifo/il_S1_eltcalc_P6
+mkfifo fifo/il_S1_summarycalc_P6
+mkfifo fifo/il_S1_pltcalc_P6
+mkfifo fifo/il_S2_summary_P6
+mkfifo fifo/il_S2_eltcalc_P6
+mkfifo fifo/il_S2_summarycalc_P6
+mkfifo fifo/il_S2_pltcalc_P6
+
+mkfifo fifo/il_S1_summary_P7
+mkfifo fifo/il_S1_eltcalc_P7
+mkfifo fifo/il_S1_summarycalc_P7
+mkfifo fifo/il_S1_pltcalc_P7
+mkfifo fifo/il_S2_summary_P7
+mkfifo fifo/il_S2_eltcalc_P7
+mkfifo fifo/il_S2_summarycalc_P7
+mkfifo fifo/il_S2_pltcalc_P7
+
+mkfifo fifo/il_S1_summary_P8
+mkfifo fifo/il_S1_eltcalc_P8
+mkfifo fifo/il_S1_summarycalc_P8
+mkfifo fifo/il_S1_pltcalc_P8
+mkfifo fifo/il_S2_summary_P8
+mkfifo fifo/il_S2_eltcalc_P8
+mkfifo fifo/il_S2_summarycalc_P8
+mkfifo fifo/il_S2_pltcalc_P8
+
+mkfifo fifo/il_S1_summary_P9
+mkfifo fifo/il_S1_eltcalc_P9
+mkfifo fifo/il_S1_summarycalc_P9
+mkfifo fifo/il_S1_pltcalc_P9
+mkfifo fifo/il_S2_summary_P9
+mkfifo fifo/il_S2_eltcalc_P9
+mkfifo fifo/il_S2_summarycalc_P9
+mkfifo fifo/il_S2_pltcalc_P9
+
+mkfifo fifo/il_S1_summary_P10
+mkfifo fifo/il_S1_eltcalc_P10
+mkfifo fifo/il_S1_summarycalc_P10
+mkfifo fifo/il_S1_pltcalc_P10
+mkfifo fifo/il_S2_summary_P10
+mkfifo fifo/il_S2_eltcalc_P10
+mkfifo fifo/il_S2_summarycalc_P10
+mkfifo fifo/il_S2_pltcalc_P10
+
+mkfifo fifo/full_correlation/gul_P1
+mkfifo fifo/full_correlation/gul_P2
+mkfifo fifo/full_correlation/gul_P3
+mkfifo fifo/full_correlation/gul_P4
+mkfifo fifo/full_correlation/gul_P5
+mkfifo fifo/full_correlation/gul_P6
+mkfifo fifo/full_correlation/gul_P7
+mkfifo fifo/full_correlation/gul_P8
+mkfifo fifo/full_correlation/gul_P9
+mkfifo fifo/full_correlation/gul_P10
+
+mkfifo fifo/full_correlation/gul_S1_summary_P1
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P1
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P1
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P1
+mkfifo fifo/full_correlation/gul_S2_summary_P1
+mkfifo fifo/full_correlation/gul_S2_eltcalc_P1
+mkfifo fifo/full_correlation/gul_S2_summarycalc_P1
+mkfifo fifo/full_correlation/gul_S2_pltcalc_P1
+
+mkfifo fifo/full_correlation/gul_S1_summary_P2
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P2
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P2
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P2
+mkfifo fifo/full_correlation/gul_S2_summary_P2
+mkfifo fifo/full_correlation/gul_S2_eltcalc_P2
+mkfifo fifo/full_correlation/gul_S2_summarycalc_P2
+mkfifo fifo/full_correlation/gul_S2_pltcalc_P2
+
+mkfifo fifo/full_correlation/gul_S1_summary_P3
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P3
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P3
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P3
+mkfifo fifo/full_correlation/gul_S2_summary_P3
+mkfifo fifo/full_correlation/gul_S2_eltcalc_P3
+mkfifo fifo/full_correlation/gul_S2_summarycalc_P3
+mkfifo fifo/full_correlation/gul_S2_pltcalc_P3
+
+mkfifo fifo/full_correlation/gul_S1_summary_P4
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P4
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P4
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P4
+mkfifo fifo/full_correlation/gul_S2_summary_P4
+mkfifo fifo/full_correlation/gul_S2_eltcalc_P4
+mkfifo fifo/full_correlation/gul_S2_summarycalc_P4
+mkfifo fifo/full_correlation/gul_S2_pltcalc_P4
+
+mkfifo fifo/full_correlation/gul_S1_summary_P5
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P5
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P5
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P5
+mkfifo fifo/full_correlation/gul_S2_summary_P5
+mkfifo fifo/full_correlation/gul_S2_eltcalc_P5
+mkfifo fifo/full_correlation/gul_S2_summarycalc_P5
+mkfifo fifo/full_correlation/gul_S2_pltcalc_P5
+
+mkfifo fifo/full_correlation/gul_S1_summary_P6
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P6
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P6
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P6
+mkfifo fifo/full_correlation/gul_S2_summary_P6
+mkfifo fifo/full_correlation/gul_S2_eltcalc_P6
+mkfifo fifo/full_correlation/gul_S2_summarycalc_P6
+mkfifo fifo/full_correlation/gul_S2_pltcalc_P6
+
+mkfifo fifo/full_correlation/gul_S1_summary_P7
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P7
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P7
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P7
+mkfifo fifo/full_correlation/gul_S2_summary_P7
+mkfifo fifo/full_correlation/gul_S2_eltcalc_P7
+mkfifo fifo/full_correlation/gul_S2_summarycalc_P7
+mkfifo fifo/full_correlation/gul_S2_pltcalc_P7
+
+mkfifo fifo/full_correlation/gul_S1_summary_P8
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P8
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P8
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P8
+mkfifo fifo/full_correlation/gul_S2_summary_P8
+mkfifo fifo/full_correlation/gul_S2_eltcalc_P8
+mkfifo fifo/full_correlation/gul_S2_summarycalc_P8
+mkfifo fifo/full_correlation/gul_S2_pltcalc_P8
+
+mkfifo fifo/full_correlation/gul_S1_summary_P9
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P9
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P9
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P9
+mkfifo fifo/full_correlation/gul_S2_summary_P9
+mkfifo fifo/full_correlation/gul_S2_eltcalc_P9
+mkfifo fifo/full_correlation/gul_S2_summarycalc_P9
+mkfifo fifo/full_correlation/gul_S2_pltcalc_P9
+
+mkfifo fifo/full_correlation/gul_S1_summary_P10
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P10
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P10
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P10
+mkfifo fifo/full_correlation/gul_S2_summary_P10
+mkfifo fifo/full_correlation/gul_S2_eltcalc_P10
+mkfifo fifo/full_correlation/gul_S2_summarycalc_P10
+mkfifo fifo/full_correlation/gul_S2_pltcalc_P10
+
+mkfifo fifo/full_correlation/il_P1
+mkfifo fifo/full_correlation/il_P2
+mkfifo fifo/full_correlation/il_P3
+mkfifo fifo/full_correlation/il_P4
+mkfifo fifo/full_correlation/il_P5
+mkfifo fifo/full_correlation/il_P6
+mkfifo fifo/full_correlation/il_P7
+mkfifo fifo/full_correlation/il_P8
+mkfifo fifo/full_correlation/il_P9
+mkfifo fifo/full_correlation/il_P10
+
+mkfifo fifo/full_correlation/il_S1_summary_P1
+mkfifo fifo/full_correlation/il_S1_eltcalc_P1
+mkfifo fifo/full_correlation/il_S1_summarycalc_P1
+mkfifo fifo/full_correlation/il_S1_pltcalc_P1
+mkfifo fifo/full_correlation/il_S2_summary_P1
+mkfifo fifo/full_correlation/il_S2_eltcalc_P1
+mkfifo fifo/full_correlation/il_S2_summarycalc_P1
+mkfifo fifo/full_correlation/il_S2_pltcalc_P1
+
+mkfifo fifo/full_correlation/il_S1_summary_P2
+mkfifo fifo/full_correlation/il_S1_eltcalc_P2
+mkfifo fifo/full_correlation/il_S1_summarycalc_P2
+mkfifo fifo/full_correlation/il_S1_pltcalc_P2
+mkfifo fifo/full_correlation/il_S2_summary_P2
+mkfifo fifo/full_correlation/il_S2_eltcalc_P2
+mkfifo fifo/full_correlation/il_S2_summarycalc_P2
+mkfifo fifo/full_correlation/il_S2_pltcalc_P2
+
+mkfifo fifo/full_correlation/il_S1_summary_P3
+mkfifo fifo/full_correlation/il_S1_eltcalc_P3
+mkfifo fifo/full_correlation/il_S1_summarycalc_P3
+mkfifo fifo/full_correlation/il_S1_pltcalc_P3
+mkfifo fifo/full_correlation/il_S2_summary_P3
+mkfifo fifo/full_correlation/il_S2_eltcalc_P3
+mkfifo fifo/full_correlation/il_S2_summarycalc_P3
+mkfifo fifo/full_correlation/il_S2_pltcalc_P3
+
+mkfifo fifo/full_correlation/il_S1_summary_P4
+mkfifo fifo/full_correlation/il_S1_eltcalc_P4
+mkfifo fifo/full_correlation/il_S1_summarycalc_P4
+mkfifo fifo/full_correlation/il_S1_pltcalc_P4
+mkfifo fifo/full_correlation/il_S2_summary_P4
+mkfifo fifo/full_correlation/il_S2_eltcalc_P4
+mkfifo fifo/full_correlation/il_S2_summarycalc_P4
+mkfifo fifo/full_correlation/il_S2_pltcalc_P4
+
+mkfifo fifo/full_correlation/il_S1_summary_P5
+mkfifo fifo/full_correlation/il_S1_eltcalc_P5
+mkfifo fifo/full_correlation/il_S1_summarycalc_P5
+mkfifo fifo/full_correlation/il_S1_pltcalc_P5
+mkfifo fifo/full_correlation/il_S2_summary_P5
+mkfifo fifo/full_correlation/il_S2_eltcalc_P5
+mkfifo fifo/full_correlation/il_S2_summarycalc_P5
+mkfifo fifo/full_correlation/il_S2_pltcalc_P5
+
+mkfifo fifo/full_correlation/il_S1_summary_P6
+mkfifo fifo/full_correlation/il_S1_eltcalc_P6
+mkfifo fifo/full_correlation/il_S1_summarycalc_P6
+mkfifo fifo/full_correlation/il_S1_pltcalc_P6
+mkfifo fifo/full_correlation/il_S2_summary_P6
+mkfifo fifo/full_correlation/il_S2_eltcalc_P6
+mkfifo fifo/full_correlation/il_S2_summarycalc_P6
+mkfifo fifo/full_correlation/il_S2_pltcalc_P6
+
+mkfifo fifo/full_correlation/il_S1_summary_P7
+mkfifo fifo/full_correlation/il_S1_eltcalc_P7
+mkfifo fifo/full_correlation/il_S1_summarycalc_P7
+mkfifo fifo/full_correlation/il_S1_pltcalc_P7
+mkfifo fifo/full_correlation/il_S2_summary_P7
+mkfifo fifo/full_correlation/il_S2_eltcalc_P7
+mkfifo fifo/full_correlation/il_S2_summarycalc_P7
+mkfifo fifo/full_correlation/il_S2_pltcalc_P7
+
+mkfifo fifo/full_correlation/il_S1_summary_P8
+mkfifo fifo/full_correlation/il_S1_eltcalc_P8
+mkfifo fifo/full_correlation/il_S1_summarycalc_P8
+mkfifo fifo/full_correlation/il_S1_pltcalc_P8
+mkfifo fifo/full_correlation/il_S2_summary_P8
+mkfifo fifo/full_correlation/il_S2_eltcalc_P8
+mkfifo fifo/full_correlation/il_S2_summarycalc_P8
+mkfifo fifo/full_correlation/il_S2_pltcalc_P8
+
+mkfifo fifo/full_correlation/il_S1_summary_P9
+mkfifo fifo/full_correlation/il_S1_eltcalc_P9
+mkfifo fifo/full_correlation/il_S1_summarycalc_P9
+mkfifo fifo/full_correlation/il_S1_pltcalc_P9
+mkfifo fifo/full_correlation/il_S2_summary_P9
+mkfifo fifo/full_correlation/il_S2_eltcalc_P9
+mkfifo fifo/full_correlation/il_S2_summarycalc_P9
+mkfifo fifo/full_correlation/il_S2_pltcalc_P9
+
+mkfifo fifo/full_correlation/il_S1_summary_P10
+mkfifo fifo/full_correlation/il_S1_eltcalc_P10
+mkfifo fifo/full_correlation/il_S1_summarycalc_P10
+mkfifo fifo/full_correlation/il_S1_pltcalc_P10
+mkfifo fifo/full_correlation/il_S2_summary_P10
+mkfifo fifo/full_correlation/il_S2_eltcalc_P10
+mkfifo fifo/full_correlation/il_S2_summarycalc_P10
+mkfifo fifo/full_correlation/il_S2_pltcalc_P10
+
+
+
+# --- Do insured loss computes ---
+
+eltcalc < fifo/il_S1_eltcalc_P1 > work/kat/il_S1_eltcalc_P1 & pid1=$!
+summarycalctocsv < fifo/il_S1_summarycalc_P1 > work/kat/il_S1_summarycalc_P1 & pid2=$!
+pltcalc < fifo/il_S1_pltcalc_P1 > work/kat/il_S1_pltcalc_P1 & pid3=$!
+eltcalc < fifo/il_S2_eltcalc_P1 > work/kat/il_S2_eltcalc_P1 & pid4=$!
+summarycalctocsv < fifo/il_S2_summarycalc_P1 > work/kat/il_S2_summarycalc_P1 & pid5=$!
+pltcalc < fifo/il_S2_pltcalc_P1 > work/kat/il_S2_pltcalc_P1 & pid6=$!
+eltcalc -s < fifo/il_S1_eltcalc_P2 > work/kat/il_S1_eltcalc_P2 & pid7=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P2 > work/kat/il_S1_summarycalc_P2 & pid8=$!
+pltcalc -s < fifo/il_S1_pltcalc_P2 > work/kat/il_S1_pltcalc_P2 & pid9=$!
+eltcalc -s < fifo/il_S2_eltcalc_P2 > work/kat/il_S2_eltcalc_P2 & pid10=$!
+summarycalctocsv -s < fifo/il_S2_summarycalc_P2 > work/kat/il_S2_summarycalc_P2 & pid11=$!
+pltcalc -s < fifo/il_S2_pltcalc_P2 > work/kat/il_S2_pltcalc_P2 & pid12=$!
+eltcalc -s < fifo/il_S1_eltcalc_P3 > work/kat/il_S1_eltcalc_P3 & pid13=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P3 > work/kat/il_S1_summarycalc_P3 & pid14=$!
+pltcalc -s < fifo/il_S1_pltcalc_P3 > work/kat/il_S1_pltcalc_P3 & pid15=$!
+eltcalc -s < fifo/il_S2_eltcalc_P3 > work/kat/il_S2_eltcalc_P3 & pid16=$!
+summarycalctocsv -s < fifo/il_S2_summarycalc_P3 > work/kat/il_S2_summarycalc_P3 & pid17=$!
+pltcalc -s < fifo/il_S2_pltcalc_P3 > work/kat/il_S2_pltcalc_P3 & pid18=$!
+eltcalc -s < fifo/il_S1_eltcalc_P4 > work/kat/il_S1_eltcalc_P4 & pid19=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P4 > work/kat/il_S1_summarycalc_P4 & pid20=$!
+pltcalc -s < fifo/il_S1_pltcalc_P4 > work/kat/il_S1_pltcalc_P4 & pid21=$!
+eltcalc -s < fifo/il_S2_eltcalc_P4 > work/kat/il_S2_eltcalc_P4 & pid22=$!
+summarycalctocsv -s < fifo/il_S2_summarycalc_P4 > work/kat/il_S2_summarycalc_P4 & pid23=$!
+pltcalc -s < fifo/il_S2_pltcalc_P4 > work/kat/il_S2_pltcalc_P4 & pid24=$!
+eltcalc -s < fifo/il_S1_eltcalc_P5 > work/kat/il_S1_eltcalc_P5 & pid25=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P5 > work/kat/il_S1_summarycalc_P5 & pid26=$!
+pltcalc -s < fifo/il_S1_pltcalc_P5 > work/kat/il_S1_pltcalc_P5 & pid27=$!
+eltcalc -s < fifo/il_S2_eltcalc_P5 > work/kat/il_S2_eltcalc_P5 & pid28=$!
+summarycalctocsv -s < fifo/il_S2_summarycalc_P5 > work/kat/il_S2_summarycalc_P5 & pid29=$!
+pltcalc -s < fifo/il_S2_pltcalc_P5 > work/kat/il_S2_pltcalc_P5 & pid30=$!
+eltcalc -s < fifo/il_S1_eltcalc_P6 > work/kat/il_S1_eltcalc_P6 & pid31=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P6 > work/kat/il_S1_summarycalc_P6 & pid32=$!
+pltcalc -s < fifo/il_S1_pltcalc_P6 > work/kat/il_S1_pltcalc_P6 & pid33=$!
+eltcalc -s < fifo/il_S2_eltcalc_P6 > work/kat/il_S2_eltcalc_P6 & pid34=$!
+summarycalctocsv -s < fifo/il_S2_summarycalc_P6 > work/kat/il_S2_summarycalc_P6 & pid35=$!
+pltcalc -s < fifo/il_S2_pltcalc_P6 > work/kat/il_S2_pltcalc_P6 & pid36=$!
+eltcalc -s < fifo/il_S1_eltcalc_P7 > work/kat/il_S1_eltcalc_P7 & pid37=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P7 > work/kat/il_S1_summarycalc_P7 & pid38=$!
+pltcalc -s < fifo/il_S1_pltcalc_P7 > work/kat/il_S1_pltcalc_P7 & pid39=$!
+eltcalc -s < fifo/il_S2_eltcalc_P7 > work/kat/il_S2_eltcalc_P7 & pid40=$!
+summarycalctocsv -s < fifo/il_S2_summarycalc_P7 > work/kat/il_S2_summarycalc_P7 & pid41=$!
+pltcalc -s < fifo/il_S2_pltcalc_P7 > work/kat/il_S2_pltcalc_P7 & pid42=$!
+eltcalc -s < fifo/il_S1_eltcalc_P8 > work/kat/il_S1_eltcalc_P8 & pid43=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P8 > work/kat/il_S1_summarycalc_P8 & pid44=$!
+pltcalc -s < fifo/il_S1_pltcalc_P8 > work/kat/il_S1_pltcalc_P8 & pid45=$!
+eltcalc -s < fifo/il_S2_eltcalc_P8 > work/kat/il_S2_eltcalc_P8 & pid46=$!
+summarycalctocsv -s < fifo/il_S2_summarycalc_P8 > work/kat/il_S2_summarycalc_P8 & pid47=$!
+pltcalc -s < fifo/il_S2_pltcalc_P8 > work/kat/il_S2_pltcalc_P8 & pid48=$!
+eltcalc -s < fifo/il_S1_eltcalc_P9 > work/kat/il_S1_eltcalc_P9 & pid49=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P9 > work/kat/il_S1_summarycalc_P9 & pid50=$!
+pltcalc -s < fifo/il_S1_pltcalc_P9 > work/kat/il_S1_pltcalc_P9 & pid51=$!
+eltcalc -s < fifo/il_S2_eltcalc_P9 > work/kat/il_S2_eltcalc_P9 & pid52=$!
+summarycalctocsv -s < fifo/il_S2_summarycalc_P9 > work/kat/il_S2_summarycalc_P9 & pid53=$!
+pltcalc -s < fifo/il_S2_pltcalc_P9 > work/kat/il_S2_pltcalc_P9 & pid54=$!
+eltcalc -s < fifo/il_S1_eltcalc_P10 > work/kat/il_S1_eltcalc_P10 & pid55=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P10 > work/kat/il_S1_summarycalc_P10 & pid56=$!
+pltcalc -s < fifo/il_S1_pltcalc_P10 > work/kat/il_S1_pltcalc_P10 & pid57=$!
+eltcalc -s < fifo/il_S2_eltcalc_P10 > work/kat/il_S2_eltcalc_P10 & pid58=$!
+summarycalctocsv -s < fifo/il_S2_summarycalc_P10 > work/kat/il_S2_summarycalc_P10 & pid59=$!
+pltcalc -s < fifo/il_S2_pltcalc_P10 > work/kat/il_S2_pltcalc_P10 & pid60=$!
+
+tee < fifo/il_S1_summary_P1 fifo/il_S1_eltcalc_P1 fifo/il_S1_summarycalc_P1 fifo/il_S1_pltcalc_P1 work/il_S1_summaryaalcalc/P1.bin work/il_S1_summaryleccalc/P1.bin > /dev/null & pid61=$!
+tee < fifo/il_S2_summary_P1 fifo/il_S2_eltcalc_P1 fifo/il_S2_summarycalc_P1 fifo/il_S2_pltcalc_P1 work/il_S2_summaryaalcalc/P1.bin work/il_S2_summaryleccalc/P1.bin > /dev/null & pid62=$!
+tee < fifo/il_S1_summary_P2 fifo/il_S1_eltcalc_P2 fifo/il_S1_summarycalc_P2 fifo/il_S1_pltcalc_P2 work/il_S1_summaryaalcalc/P2.bin work/il_S1_summaryleccalc/P2.bin > /dev/null & pid63=$!
+tee < fifo/il_S2_summary_P2 fifo/il_S2_eltcalc_P2 fifo/il_S2_summarycalc_P2 fifo/il_S2_pltcalc_P2 work/il_S2_summaryaalcalc/P2.bin work/il_S2_summaryleccalc/P2.bin > /dev/null & pid64=$!
+tee < fifo/il_S1_summary_P3 fifo/il_S1_eltcalc_P3 fifo/il_S1_summarycalc_P3 fifo/il_S1_pltcalc_P3 work/il_S1_summaryaalcalc/P3.bin work/il_S1_summaryleccalc/P3.bin > /dev/null & pid65=$!
+tee < fifo/il_S2_summary_P3 fifo/il_S2_eltcalc_P3 fifo/il_S2_summarycalc_P3 fifo/il_S2_pltcalc_P3 work/il_S2_summaryaalcalc/P3.bin work/il_S2_summaryleccalc/P3.bin > /dev/null & pid66=$!
+tee < fifo/il_S1_summary_P4 fifo/il_S1_eltcalc_P4 fifo/il_S1_summarycalc_P4 fifo/il_S1_pltcalc_P4 work/il_S1_summaryaalcalc/P4.bin work/il_S1_summaryleccalc/P4.bin > /dev/null & pid67=$!
+tee < fifo/il_S2_summary_P4 fifo/il_S2_eltcalc_P4 fifo/il_S2_summarycalc_P4 fifo/il_S2_pltcalc_P4 work/il_S2_summaryaalcalc/P4.bin work/il_S2_summaryleccalc/P4.bin > /dev/null & pid68=$!
+tee < fifo/il_S1_summary_P5 fifo/il_S1_eltcalc_P5 fifo/il_S1_summarycalc_P5 fifo/il_S1_pltcalc_P5 work/il_S1_summaryaalcalc/P5.bin work/il_S1_summaryleccalc/P5.bin > /dev/null & pid69=$!
+tee < fifo/il_S2_summary_P5 fifo/il_S2_eltcalc_P5 fifo/il_S2_summarycalc_P5 fifo/il_S2_pltcalc_P5 work/il_S2_summaryaalcalc/P5.bin work/il_S2_summaryleccalc/P5.bin > /dev/null & pid70=$!
+tee < fifo/il_S1_summary_P6 fifo/il_S1_eltcalc_P6 fifo/il_S1_summarycalc_P6 fifo/il_S1_pltcalc_P6 work/il_S1_summaryaalcalc/P6.bin work/il_S1_summaryleccalc/P6.bin > /dev/null & pid71=$!
+tee < fifo/il_S2_summary_P6 fifo/il_S2_eltcalc_P6 fifo/il_S2_summarycalc_P6 fifo/il_S2_pltcalc_P6 work/il_S2_summaryaalcalc/P6.bin work/il_S2_summaryleccalc/P6.bin > /dev/null & pid72=$!
+tee < fifo/il_S1_summary_P7 fifo/il_S1_eltcalc_P7 fifo/il_S1_summarycalc_P7 fifo/il_S1_pltcalc_P7 work/il_S1_summaryaalcalc/P7.bin work/il_S1_summaryleccalc/P7.bin > /dev/null & pid73=$!
+tee < fifo/il_S2_summary_P7 fifo/il_S2_eltcalc_P7 fifo/il_S2_summarycalc_P7 fifo/il_S2_pltcalc_P7 work/il_S2_summaryaalcalc/P7.bin work/il_S2_summaryleccalc/P7.bin > /dev/null & pid74=$!
+tee < fifo/il_S1_summary_P8 fifo/il_S1_eltcalc_P8 fifo/il_S1_summarycalc_P8 fifo/il_S1_pltcalc_P8 work/il_S1_summaryaalcalc/P8.bin work/il_S1_summaryleccalc/P8.bin > /dev/null & pid75=$!
+tee < fifo/il_S2_summary_P8 fifo/il_S2_eltcalc_P8 fifo/il_S2_summarycalc_P8 fifo/il_S2_pltcalc_P8 work/il_S2_summaryaalcalc/P8.bin work/il_S2_summaryleccalc/P8.bin > /dev/null & pid76=$!
+tee < fifo/il_S1_summary_P9 fifo/il_S1_eltcalc_P9 fifo/il_S1_summarycalc_P9 fifo/il_S1_pltcalc_P9 work/il_S1_summaryaalcalc/P9.bin work/il_S1_summaryleccalc/P9.bin > /dev/null & pid77=$!
+tee < fifo/il_S2_summary_P9 fifo/il_S2_eltcalc_P9 fifo/il_S2_summarycalc_P9 fifo/il_S2_pltcalc_P9 work/il_S2_summaryaalcalc/P9.bin work/il_S2_summaryleccalc/P9.bin > /dev/null & pid78=$!
+tee < fifo/il_S1_summary_P10 fifo/il_S1_eltcalc_P10 fifo/il_S1_summarycalc_P10 fifo/il_S1_pltcalc_P10 work/il_S1_summaryaalcalc/P10.bin work/il_S1_summaryleccalc/P10.bin > /dev/null & pid79=$!
+tee < fifo/il_S2_summary_P10 fifo/il_S2_eltcalc_P10 fifo/il_S2_summarycalc_P10 fifo/il_S2_pltcalc_P10 work/il_S2_summaryaalcalc/P10.bin work/il_S2_summaryleccalc/P10.bin > /dev/null & pid80=$!
+
+summarycalc -f  -1 fifo/il_S1_summary_P1 -2 fifo/il_S2_summary_P1 < fifo/il_P1 &
+summarycalc -f  -1 fifo/il_S1_summary_P2 -2 fifo/il_S2_summary_P2 < fifo/il_P2 &
+summarycalc -f  -1 fifo/il_S1_summary_P3 -2 fifo/il_S2_summary_P3 < fifo/il_P3 &
+summarycalc -f  -1 fifo/il_S1_summary_P4 -2 fifo/il_S2_summary_P4 < fifo/il_P4 &
+summarycalc -f  -1 fifo/il_S1_summary_P5 -2 fifo/il_S2_summary_P5 < fifo/il_P5 &
+summarycalc -f  -1 fifo/il_S1_summary_P6 -2 fifo/il_S2_summary_P6 < fifo/il_P6 &
+summarycalc -f  -1 fifo/il_S1_summary_P7 -2 fifo/il_S2_summary_P7 < fifo/il_P7 &
+summarycalc -f  -1 fifo/il_S1_summary_P8 -2 fifo/il_S2_summary_P8 < fifo/il_P8 &
+summarycalc -f  -1 fifo/il_S1_summary_P9 -2 fifo/il_S2_summary_P9 < fifo/il_P9 &
+summarycalc -f  -1 fifo/il_S1_summary_P10 -2 fifo/il_S2_summary_P10 < fifo/il_P10 &
+
+# --- Do ground up loss computes ---
+
+eltcalc < fifo/gul_S1_eltcalc_P1 > work/kat/gul_S1_eltcalc_P1 & pid81=$!
+summarycalctocsv < fifo/gul_S1_summarycalc_P1 > work/kat/gul_S1_summarycalc_P1 & pid82=$!
+pltcalc < fifo/gul_S1_pltcalc_P1 > work/kat/gul_S1_pltcalc_P1 & pid83=$!
+eltcalc < fifo/gul_S2_eltcalc_P1 > work/kat/gul_S2_eltcalc_P1 & pid84=$!
+summarycalctocsv < fifo/gul_S2_summarycalc_P1 > work/kat/gul_S2_summarycalc_P1 & pid85=$!
+pltcalc < fifo/gul_S2_pltcalc_P1 > work/kat/gul_S2_pltcalc_P1 & pid86=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P2 > work/kat/gul_S1_eltcalc_P2 & pid87=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P2 > work/kat/gul_S1_summarycalc_P2 & pid88=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P2 > work/kat/gul_S1_pltcalc_P2 & pid89=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P2 > work/kat/gul_S2_eltcalc_P2 & pid90=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P2 > work/kat/gul_S2_summarycalc_P2 & pid91=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P2 > work/kat/gul_S2_pltcalc_P2 & pid92=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P3 > work/kat/gul_S1_eltcalc_P3 & pid93=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P3 > work/kat/gul_S1_summarycalc_P3 & pid94=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P3 > work/kat/gul_S1_pltcalc_P3 & pid95=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P3 > work/kat/gul_S2_eltcalc_P3 & pid96=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P3 > work/kat/gul_S2_summarycalc_P3 & pid97=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P3 > work/kat/gul_S2_pltcalc_P3 & pid98=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P4 > work/kat/gul_S1_eltcalc_P4 & pid99=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P4 > work/kat/gul_S1_summarycalc_P4 & pid100=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P4 > work/kat/gul_S1_pltcalc_P4 & pid101=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P4 > work/kat/gul_S2_eltcalc_P4 & pid102=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P4 > work/kat/gul_S2_summarycalc_P4 & pid103=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P4 > work/kat/gul_S2_pltcalc_P4 & pid104=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P5 > work/kat/gul_S1_eltcalc_P5 & pid105=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P5 > work/kat/gul_S1_summarycalc_P5 & pid106=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P5 > work/kat/gul_S1_pltcalc_P5 & pid107=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P5 > work/kat/gul_S2_eltcalc_P5 & pid108=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P5 > work/kat/gul_S2_summarycalc_P5 & pid109=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P5 > work/kat/gul_S2_pltcalc_P5 & pid110=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P6 > work/kat/gul_S1_eltcalc_P6 & pid111=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P6 > work/kat/gul_S1_summarycalc_P6 & pid112=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P6 > work/kat/gul_S1_pltcalc_P6 & pid113=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P6 > work/kat/gul_S2_eltcalc_P6 & pid114=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P6 > work/kat/gul_S2_summarycalc_P6 & pid115=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P6 > work/kat/gul_S2_pltcalc_P6 & pid116=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P7 > work/kat/gul_S1_eltcalc_P7 & pid117=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P7 > work/kat/gul_S1_summarycalc_P7 & pid118=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P7 > work/kat/gul_S1_pltcalc_P7 & pid119=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P7 > work/kat/gul_S2_eltcalc_P7 & pid120=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P7 > work/kat/gul_S2_summarycalc_P7 & pid121=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P7 > work/kat/gul_S2_pltcalc_P7 & pid122=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P8 > work/kat/gul_S1_eltcalc_P8 & pid123=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P8 > work/kat/gul_S1_summarycalc_P8 & pid124=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P8 > work/kat/gul_S1_pltcalc_P8 & pid125=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P8 > work/kat/gul_S2_eltcalc_P8 & pid126=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P8 > work/kat/gul_S2_summarycalc_P8 & pid127=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P8 > work/kat/gul_S2_pltcalc_P8 & pid128=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P9 > work/kat/gul_S1_eltcalc_P9 & pid129=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P9 > work/kat/gul_S1_summarycalc_P9 & pid130=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P9 > work/kat/gul_S1_pltcalc_P9 & pid131=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P9 > work/kat/gul_S2_eltcalc_P9 & pid132=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P9 > work/kat/gul_S2_summarycalc_P9 & pid133=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P9 > work/kat/gul_S2_pltcalc_P9 & pid134=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P10 > work/kat/gul_S1_eltcalc_P10 & pid135=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P10 > work/kat/gul_S1_summarycalc_P10 & pid136=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P10 > work/kat/gul_S1_pltcalc_P10 & pid137=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P10 > work/kat/gul_S2_eltcalc_P10 & pid138=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P10 > work/kat/gul_S2_summarycalc_P10 & pid139=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P10 > work/kat/gul_S2_pltcalc_P10 & pid140=$!
+
+tee < fifo/gul_S1_summary_P1 fifo/gul_S1_eltcalc_P1 fifo/gul_S1_summarycalc_P1 fifo/gul_S1_pltcalc_P1 work/gul_S1_summaryaalcalc/P1.bin work/gul_S1_summaryleccalc/P1.bin > /dev/null & pid141=$!
+tee < fifo/gul_S2_summary_P1 fifo/gul_S2_eltcalc_P1 fifo/gul_S2_summarycalc_P1 fifo/gul_S2_pltcalc_P1 work/gul_S2_summaryaalcalc/P1.bin work/gul_S2_summaryleccalc/P1.bin > /dev/null & pid142=$!
+tee < fifo/gul_S1_summary_P2 fifo/gul_S1_eltcalc_P2 fifo/gul_S1_summarycalc_P2 fifo/gul_S1_pltcalc_P2 work/gul_S1_summaryaalcalc/P2.bin work/gul_S1_summaryleccalc/P2.bin > /dev/null & pid143=$!
+tee < fifo/gul_S2_summary_P2 fifo/gul_S2_eltcalc_P2 fifo/gul_S2_summarycalc_P2 fifo/gul_S2_pltcalc_P2 work/gul_S2_summaryaalcalc/P2.bin work/gul_S2_summaryleccalc/P2.bin > /dev/null & pid144=$!
+tee < fifo/gul_S1_summary_P3 fifo/gul_S1_eltcalc_P3 fifo/gul_S1_summarycalc_P3 fifo/gul_S1_pltcalc_P3 work/gul_S1_summaryaalcalc/P3.bin work/gul_S1_summaryleccalc/P3.bin > /dev/null & pid145=$!
+tee < fifo/gul_S2_summary_P3 fifo/gul_S2_eltcalc_P3 fifo/gul_S2_summarycalc_P3 fifo/gul_S2_pltcalc_P3 work/gul_S2_summaryaalcalc/P3.bin work/gul_S2_summaryleccalc/P3.bin > /dev/null & pid146=$!
+tee < fifo/gul_S1_summary_P4 fifo/gul_S1_eltcalc_P4 fifo/gul_S1_summarycalc_P4 fifo/gul_S1_pltcalc_P4 work/gul_S1_summaryaalcalc/P4.bin work/gul_S1_summaryleccalc/P4.bin > /dev/null & pid147=$!
+tee < fifo/gul_S2_summary_P4 fifo/gul_S2_eltcalc_P4 fifo/gul_S2_summarycalc_P4 fifo/gul_S2_pltcalc_P4 work/gul_S2_summaryaalcalc/P4.bin work/gul_S2_summaryleccalc/P4.bin > /dev/null & pid148=$!
+tee < fifo/gul_S1_summary_P5 fifo/gul_S1_eltcalc_P5 fifo/gul_S1_summarycalc_P5 fifo/gul_S1_pltcalc_P5 work/gul_S1_summaryaalcalc/P5.bin work/gul_S1_summaryleccalc/P5.bin > /dev/null & pid149=$!
+tee < fifo/gul_S2_summary_P5 fifo/gul_S2_eltcalc_P5 fifo/gul_S2_summarycalc_P5 fifo/gul_S2_pltcalc_P5 work/gul_S2_summaryaalcalc/P5.bin work/gul_S2_summaryleccalc/P5.bin > /dev/null & pid150=$!
+tee < fifo/gul_S1_summary_P6 fifo/gul_S1_eltcalc_P6 fifo/gul_S1_summarycalc_P6 fifo/gul_S1_pltcalc_P6 work/gul_S1_summaryaalcalc/P6.bin work/gul_S1_summaryleccalc/P6.bin > /dev/null & pid151=$!
+tee < fifo/gul_S2_summary_P6 fifo/gul_S2_eltcalc_P6 fifo/gul_S2_summarycalc_P6 fifo/gul_S2_pltcalc_P6 work/gul_S2_summaryaalcalc/P6.bin work/gul_S2_summaryleccalc/P6.bin > /dev/null & pid152=$!
+tee < fifo/gul_S1_summary_P7 fifo/gul_S1_eltcalc_P7 fifo/gul_S1_summarycalc_P7 fifo/gul_S1_pltcalc_P7 work/gul_S1_summaryaalcalc/P7.bin work/gul_S1_summaryleccalc/P7.bin > /dev/null & pid153=$!
+tee < fifo/gul_S2_summary_P7 fifo/gul_S2_eltcalc_P7 fifo/gul_S2_summarycalc_P7 fifo/gul_S2_pltcalc_P7 work/gul_S2_summaryaalcalc/P7.bin work/gul_S2_summaryleccalc/P7.bin > /dev/null & pid154=$!
+tee < fifo/gul_S1_summary_P8 fifo/gul_S1_eltcalc_P8 fifo/gul_S1_summarycalc_P8 fifo/gul_S1_pltcalc_P8 work/gul_S1_summaryaalcalc/P8.bin work/gul_S1_summaryleccalc/P8.bin > /dev/null & pid155=$!
+tee < fifo/gul_S2_summary_P8 fifo/gul_S2_eltcalc_P8 fifo/gul_S2_summarycalc_P8 fifo/gul_S2_pltcalc_P8 work/gul_S2_summaryaalcalc/P8.bin work/gul_S2_summaryleccalc/P8.bin > /dev/null & pid156=$!
+tee < fifo/gul_S1_summary_P9 fifo/gul_S1_eltcalc_P9 fifo/gul_S1_summarycalc_P9 fifo/gul_S1_pltcalc_P9 work/gul_S1_summaryaalcalc/P9.bin work/gul_S1_summaryleccalc/P9.bin > /dev/null & pid157=$!
+tee < fifo/gul_S2_summary_P9 fifo/gul_S2_eltcalc_P9 fifo/gul_S2_summarycalc_P9 fifo/gul_S2_pltcalc_P9 work/gul_S2_summaryaalcalc/P9.bin work/gul_S2_summaryleccalc/P9.bin > /dev/null & pid158=$!
+tee < fifo/gul_S1_summary_P10 fifo/gul_S1_eltcalc_P10 fifo/gul_S1_summarycalc_P10 fifo/gul_S1_pltcalc_P10 work/gul_S1_summaryaalcalc/P10.bin work/gul_S1_summaryleccalc/P10.bin > /dev/null & pid159=$!
+tee < fifo/gul_S2_summary_P10 fifo/gul_S2_eltcalc_P10 fifo/gul_S2_summarycalc_P10 fifo/gul_S2_pltcalc_P10 work/gul_S2_summaryaalcalc/P10.bin work/gul_S2_summaryleccalc/P10.bin > /dev/null & pid160=$!
+
+summarycalc -i  -1 fifo/gul_S1_summary_P1 -2 fifo/gul_S2_summary_P1 < fifo/gul_P1 &
+summarycalc -i  -1 fifo/gul_S1_summary_P2 -2 fifo/gul_S2_summary_P2 < fifo/gul_P2 &
+summarycalc -i  -1 fifo/gul_S1_summary_P3 -2 fifo/gul_S2_summary_P3 < fifo/gul_P3 &
+summarycalc -i  -1 fifo/gul_S1_summary_P4 -2 fifo/gul_S2_summary_P4 < fifo/gul_P4 &
+summarycalc -i  -1 fifo/gul_S1_summary_P5 -2 fifo/gul_S2_summary_P5 < fifo/gul_P5 &
+summarycalc -i  -1 fifo/gul_S1_summary_P6 -2 fifo/gul_S2_summary_P6 < fifo/gul_P6 &
+summarycalc -i  -1 fifo/gul_S1_summary_P7 -2 fifo/gul_S2_summary_P7 < fifo/gul_P7 &
+summarycalc -i  -1 fifo/gul_S1_summary_P8 -2 fifo/gul_S2_summary_P8 < fifo/gul_P8 &
+summarycalc -i  -1 fifo/gul_S1_summary_P9 -2 fifo/gul_S2_summary_P9 < fifo/gul_P9 &
+summarycalc -i  -1 fifo/gul_S1_summary_P10 -2 fifo/gul_S2_summary_P10 < fifo/gul_P10 &
+
+# --- Do insured loss computes ---
+
+eltcalc < fifo/full_correlation/il_S1_eltcalc_P1 > work/full_correlation/kat/il_S1_eltcalc_P1 & pid161=$!
+summarycalctocsv < fifo/full_correlation/il_S1_summarycalc_P1 > work/full_correlation/kat/il_S1_summarycalc_P1 & pid162=$!
+pltcalc < fifo/full_correlation/il_S1_pltcalc_P1 > work/full_correlation/kat/il_S1_pltcalc_P1 & pid163=$!
+eltcalc < fifo/full_correlation/il_S2_eltcalc_P1 > work/full_correlation/kat/il_S2_eltcalc_P1 & pid164=$!
+summarycalctocsv < fifo/full_correlation/il_S2_summarycalc_P1 > work/full_correlation/kat/il_S2_summarycalc_P1 & pid165=$!
+pltcalc < fifo/full_correlation/il_S2_pltcalc_P1 > work/full_correlation/kat/il_S2_pltcalc_P1 & pid166=$!
+eltcalc -s < fifo/full_correlation/il_S1_eltcalc_P2 > work/full_correlation/kat/il_S1_eltcalc_P2 & pid167=$!
+summarycalctocsv -s < fifo/full_correlation/il_S1_summarycalc_P2 > work/full_correlation/kat/il_S1_summarycalc_P2 & pid168=$!
+pltcalc -s < fifo/full_correlation/il_S1_pltcalc_P2 > work/full_correlation/kat/il_S1_pltcalc_P2 & pid169=$!
+eltcalc -s < fifo/full_correlation/il_S2_eltcalc_P2 > work/full_correlation/kat/il_S2_eltcalc_P2 & pid170=$!
+summarycalctocsv -s < fifo/full_correlation/il_S2_summarycalc_P2 > work/full_correlation/kat/il_S2_summarycalc_P2 & pid171=$!
+pltcalc -s < fifo/full_correlation/il_S2_pltcalc_P2 > work/full_correlation/kat/il_S2_pltcalc_P2 & pid172=$!
+eltcalc -s < fifo/full_correlation/il_S1_eltcalc_P3 > work/full_correlation/kat/il_S1_eltcalc_P3 & pid173=$!
+summarycalctocsv -s < fifo/full_correlation/il_S1_summarycalc_P3 > work/full_correlation/kat/il_S1_summarycalc_P3 & pid174=$!
+pltcalc -s < fifo/full_correlation/il_S1_pltcalc_P3 > work/full_correlation/kat/il_S1_pltcalc_P3 & pid175=$!
+eltcalc -s < fifo/full_correlation/il_S2_eltcalc_P3 > work/full_correlation/kat/il_S2_eltcalc_P3 & pid176=$!
+summarycalctocsv -s < fifo/full_correlation/il_S2_summarycalc_P3 > work/full_correlation/kat/il_S2_summarycalc_P3 & pid177=$!
+pltcalc -s < fifo/full_correlation/il_S2_pltcalc_P3 > work/full_correlation/kat/il_S2_pltcalc_P3 & pid178=$!
+eltcalc -s < fifo/full_correlation/il_S1_eltcalc_P4 > work/full_correlation/kat/il_S1_eltcalc_P4 & pid179=$!
+summarycalctocsv -s < fifo/full_correlation/il_S1_summarycalc_P4 > work/full_correlation/kat/il_S1_summarycalc_P4 & pid180=$!
+pltcalc -s < fifo/full_correlation/il_S1_pltcalc_P4 > work/full_correlation/kat/il_S1_pltcalc_P4 & pid181=$!
+eltcalc -s < fifo/full_correlation/il_S2_eltcalc_P4 > work/full_correlation/kat/il_S2_eltcalc_P4 & pid182=$!
+summarycalctocsv -s < fifo/full_correlation/il_S2_summarycalc_P4 > work/full_correlation/kat/il_S2_summarycalc_P4 & pid183=$!
+pltcalc -s < fifo/full_correlation/il_S2_pltcalc_P4 > work/full_correlation/kat/il_S2_pltcalc_P4 & pid184=$!
+eltcalc -s < fifo/full_correlation/il_S1_eltcalc_P5 > work/full_correlation/kat/il_S1_eltcalc_P5 & pid185=$!
+summarycalctocsv -s < fifo/full_correlation/il_S1_summarycalc_P5 > work/full_correlation/kat/il_S1_summarycalc_P5 & pid186=$!
+pltcalc -s < fifo/full_correlation/il_S1_pltcalc_P5 > work/full_correlation/kat/il_S1_pltcalc_P5 & pid187=$!
+eltcalc -s < fifo/full_correlation/il_S2_eltcalc_P5 > work/full_correlation/kat/il_S2_eltcalc_P5 & pid188=$!
+summarycalctocsv -s < fifo/full_correlation/il_S2_summarycalc_P5 > work/full_correlation/kat/il_S2_summarycalc_P5 & pid189=$!
+pltcalc -s < fifo/full_correlation/il_S2_pltcalc_P5 > work/full_correlation/kat/il_S2_pltcalc_P5 & pid190=$!
+eltcalc -s < fifo/full_correlation/il_S1_eltcalc_P6 > work/full_correlation/kat/il_S1_eltcalc_P6 & pid191=$!
+summarycalctocsv -s < fifo/full_correlation/il_S1_summarycalc_P6 > work/full_correlation/kat/il_S1_summarycalc_P6 & pid192=$!
+pltcalc -s < fifo/full_correlation/il_S1_pltcalc_P6 > work/full_correlation/kat/il_S1_pltcalc_P6 & pid193=$!
+eltcalc -s < fifo/full_correlation/il_S2_eltcalc_P6 > work/full_correlation/kat/il_S2_eltcalc_P6 & pid194=$!
+summarycalctocsv -s < fifo/full_correlation/il_S2_summarycalc_P6 > work/full_correlation/kat/il_S2_summarycalc_P6 & pid195=$!
+pltcalc -s < fifo/full_correlation/il_S2_pltcalc_P6 > work/full_correlation/kat/il_S2_pltcalc_P6 & pid196=$!
+eltcalc -s < fifo/full_correlation/il_S1_eltcalc_P7 > work/full_correlation/kat/il_S1_eltcalc_P7 & pid197=$!
+summarycalctocsv -s < fifo/full_correlation/il_S1_summarycalc_P7 > work/full_correlation/kat/il_S1_summarycalc_P7 & pid198=$!
+pltcalc -s < fifo/full_correlation/il_S1_pltcalc_P7 > work/full_correlation/kat/il_S1_pltcalc_P7 & pid199=$!
+eltcalc -s < fifo/full_correlation/il_S2_eltcalc_P7 > work/full_correlation/kat/il_S2_eltcalc_P7 & pid200=$!
+summarycalctocsv -s < fifo/full_correlation/il_S2_summarycalc_P7 > work/full_correlation/kat/il_S2_summarycalc_P7 & pid201=$!
+pltcalc -s < fifo/full_correlation/il_S2_pltcalc_P7 > work/full_correlation/kat/il_S2_pltcalc_P7 & pid202=$!
+eltcalc -s < fifo/full_correlation/il_S1_eltcalc_P8 > work/full_correlation/kat/il_S1_eltcalc_P8 & pid203=$!
+summarycalctocsv -s < fifo/full_correlation/il_S1_summarycalc_P8 > work/full_correlation/kat/il_S1_summarycalc_P8 & pid204=$!
+pltcalc -s < fifo/full_correlation/il_S1_pltcalc_P8 > work/full_correlation/kat/il_S1_pltcalc_P8 & pid205=$!
+eltcalc -s < fifo/full_correlation/il_S2_eltcalc_P8 > work/full_correlation/kat/il_S2_eltcalc_P8 & pid206=$!
+summarycalctocsv -s < fifo/full_correlation/il_S2_summarycalc_P8 > work/full_correlation/kat/il_S2_summarycalc_P8 & pid207=$!
+pltcalc -s < fifo/full_correlation/il_S2_pltcalc_P8 > work/full_correlation/kat/il_S2_pltcalc_P8 & pid208=$!
+eltcalc -s < fifo/full_correlation/il_S1_eltcalc_P9 > work/full_correlation/kat/il_S1_eltcalc_P9 & pid209=$!
+summarycalctocsv -s < fifo/full_correlation/il_S1_summarycalc_P9 > work/full_correlation/kat/il_S1_summarycalc_P9 & pid210=$!
+pltcalc -s < fifo/full_correlation/il_S1_pltcalc_P9 > work/full_correlation/kat/il_S1_pltcalc_P9 & pid211=$!
+eltcalc -s < fifo/full_correlation/il_S2_eltcalc_P9 > work/full_correlation/kat/il_S2_eltcalc_P9 & pid212=$!
+summarycalctocsv -s < fifo/full_correlation/il_S2_summarycalc_P9 > work/full_correlation/kat/il_S2_summarycalc_P9 & pid213=$!
+pltcalc -s < fifo/full_correlation/il_S2_pltcalc_P9 > work/full_correlation/kat/il_S2_pltcalc_P9 & pid214=$!
+eltcalc -s < fifo/full_correlation/il_S1_eltcalc_P10 > work/full_correlation/kat/il_S1_eltcalc_P10 & pid215=$!
+summarycalctocsv -s < fifo/full_correlation/il_S1_summarycalc_P10 > work/full_correlation/kat/il_S1_summarycalc_P10 & pid216=$!
+pltcalc -s < fifo/full_correlation/il_S1_pltcalc_P10 > work/full_correlation/kat/il_S1_pltcalc_P10 & pid217=$!
+eltcalc -s < fifo/full_correlation/il_S2_eltcalc_P10 > work/full_correlation/kat/il_S2_eltcalc_P10 & pid218=$!
+summarycalctocsv -s < fifo/full_correlation/il_S2_summarycalc_P10 > work/full_correlation/kat/il_S2_summarycalc_P10 & pid219=$!
+pltcalc -s < fifo/full_correlation/il_S2_pltcalc_P10 > work/full_correlation/kat/il_S2_pltcalc_P10 & pid220=$!
+
+tee < fifo/full_correlation/il_S1_summary_P1 fifo/full_correlation/il_S1_eltcalc_P1 fifo/full_correlation/il_S1_summarycalc_P1 fifo/full_correlation/il_S1_pltcalc_P1 work/full_correlation/il_S1_summaryaalcalc/P1.bin work/full_correlation/il_S1_summaryleccalc/P1.bin > /dev/null & pid221=$!
+tee < fifo/full_correlation/il_S2_summary_P1 fifo/full_correlation/il_S2_eltcalc_P1 fifo/full_correlation/il_S2_summarycalc_P1 fifo/full_correlation/il_S2_pltcalc_P1 work/full_correlation/il_S2_summaryaalcalc/P1.bin work/full_correlation/il_S2_summaryleccalc/P1.bin > /dev/null & pid222=$!
+tee < fifo/full_correlation/il_S1_summary_P2 fifo/full_correlation/il_S1_eltcalc_P2 fifo/full_correlation/il_S1_summarycalc_P2 fifo/full_correlation/il_S1_pltcalc_P2 work/full_correlation/il_S1_summaryaalcalc/P2.bin work/full_correlation/il_S1_summaryleccalc/P2.bin > /dev/null & pid223=$!
+tee < fifo/full_correlation/il_S2_summary_P2 fifo/full_correlation/il_S2_eltcalc_P2 fifo/full_correlation/il_S2_summarycalc_P2 fifo/full_correlation/il_S2_pltcalc_P2 work/full_correlation/il_S2_summaryaalcalc/P2.bin work/full_correlation/il_S2_summaryleccalc/P2.bin > /dev/null & pid224=$!
+tee < fifo/full_correlation/il_S1_summary_P3 fifo/full_correlation/il_S1_eltcalc_P3 fifo/full_correlation/il_S1_summarycalc_P3 fifo/full_correlation/il_S1_pltcalc_P3 work/full_correlation/il_S1_summaryaalcalc/P3.bin work/full_correlation/il_S1_summaryleccalc/P3.bin > /dev/null & pid225=$!
+tee < fifo/full_correlation/il_S2_summary_P3 fifo/full_correlation/il_S2_eltcalc_P3 fifo/full_correlation/il_S2_summarycalc_P3 fifo/full_correlation/il_S2_pltcalc_P3 work/full_correlation/il_S2_summaryaalcalc/P3.bin work/full_correlation/il_S2_summaryleccalc/P3.bin > /dev/null & pid226=$!
+tee < fifo/full_correlation/il_S1_summary_P4 fifo/full_correlation/il_S1_eltcalc_P4 fifo/full_correlation/il_S1_summarycalc_P4 fifo/full_correlation/il_S1_pltcalc_P4 work/full_correlation/il_S1_summaryaalcalc/P4.bin work/full_correlation/il_S1_summaryleccalc/P4.bin > /dev/null & pid227=$!
+tee < fifo/full_correlation/il_S2_summary_P4 fifo/full_correlation/il_S2_eltcalc_P4 fifo/full_correlation/il_S2_summarycalc_P4 fifo/full_correlation/il_S2_pltcalc_P4 work/full_correlation/il_S2_summaryaalcalc/P4.bin work/full_correlation/il_S2_summaryleccalc/P4.bin > /dev/null & pid228=$!
+tee < fifo/full_correlation/il_S1_summary_P5 fifo/full_correlation/il_S1_eltcalc_P5 fifo/full_correlation/il_S1_summarycalc_P5 fifo/full_correlation/il_S1_pltcalc_P5 work/full_correlation/il_S1_summaryaalcalc/P5.bin work/full_correlation/il_S1_summaryleccalc/P5.bin > /dev/null & pid229=$!
+tee < fifo/full_correlation/il_S2_summary_P5 fifo/full_correlation/il_S2_eltcalc_P5 fifo/full_correlation/il_S2_summarycalc_P5 fifo/full_correlation/il_S2_pltcalc_P5 work/full_correlation/il_S2_summaryaalcalc/P5.bin work/full_correlation/il_S2_summaryleccalc/P5.bin > /dev/null & pid230=$!
+tee < fifo/full_correlation/il_S1_summary_P6 fifo/full_correlation/il_S1_eltcalc_P6 fifo/full_correlation/il_S1_summarycalc_P6 fifo/full_correlation/il_S1_pltcalc_P6 work/full_correlation/il_S1_summaryaalcalc/P6.bin work/full_correlation/il_S1_summaryleccalc/P6.bin > /dev/null & pid231=$!
+tee < fifo/full_correlation/il_S2_summary_P6 fifo/full_correlation/il_S2_eltcalc_P6 fifo/full_correlation/il_S2_summarycalc_P6 fifo/full_correlation/il_S2_pltcalc_P6 work/full_correlation/il_S2_summaryaalcalc/P6.bin work/full_correlation/il_S2_summaryleccalc/P6.bin > /dev/null & pid232=$!
+tee < fifo/full_correlation/il_S1_summary_P7 fifo/full_correlation/il_S1_eltcalc_P7 fifo/full_correlation/il_S1_summarycalc_P7 fifo/full_correlation/il_S1_pltcalc_P7 work/full_correlation/il_S1_summaryaalcalc/P7.bin work/full_correlation/il_S1_summaryleccalc/P7.bin > /dev/null & pid233=$!
+tee < fifo/full_correlation/il_S2_summary_P7 fifo/full_correlation/il_S2_eltcalc_P7 fifo/full_correlation/il_S2_summarycalc_P7 fifo/full_correlation/il_S2_pltcalc_P7 work/full_correlation/il_S2_summaryaalcalc/P7.bin work/full_correlation/il_S2_summaryleccalc/P7.bin > /dev/null & pid234=$!
+tee < fifo/full_correlation/il_S1_summary_P8 fifo/full_correlation/il_S1_eltcalc_P8 fifo/full_correlation/il_S1_summarycalc_P8 fifo/full_correlation/il_S1_pltcalc_P8 work/full_correlation/il_S1_summaryaalcalc/P8.bin work/full_correlation/il_S1_summaryleccalc/P8.bin > /dev/null & pid235=$!
+tee < fifo/full_correlation/il_S2_summary_P8 fifo/full_correlation/il_S2_eltcalc_P8 fifo/full_correlation/il_S2_summarycalc_P8 fifo/full_correlation/il_S2_pltcalc_P8 work/full_correlation/il_S2_summaryaalcalc/P8.bin work/full_correlation/il_S2_summaryleccalc/P8.bin > /dev/null & pid236=$!
+tee < fifo/full_correlation/il_S1_summary_P9 fifo/full_correlation/il_S1_eltcalc_P9 fifo/full_correlation/il_S1_summarycalc_P9 fifo/full_correlation/il_S1_pltcalc_P9 work/full_correlation/il_S1_summaryaalcalc/P9.bin work/full_correlation/il_S1_summaryleccalc/P9.bin > /dev/null & pid237=$!
+tee < fifo/full_correlation/il_S2_summary_P9 fifo/full_correlation/il_S2_eltcalc_P9 fifo/full_correlation/il_S2_summarycalc_P9 fifo/full_correlation/il_S2_pltcalc_P9 work/full_correlation/il_S2_summaryaalcalc/P9.bin work/full_correlation/il_S2_summaryleccalc/P9.bin > /dev/null & pid238=$!
+tee < fifo/full_correlation/il_S1_summary_P10 fifo/full_correlation/il_S1_eltcalc_P10 fifo/full_correlation/il_S1_summarycalc_P10 fifo/full_correlation/il_S1_pltcalc_P10 work/full_correlation/il_S1_summaryaalcalc/P10.bin work/full_correlation/il_S1_summaryleccalc/P10.bin > /dev/null & pid239=$!
+tee < fifo/full_correlation/il_S2_summary_P10 fifo/full_correlation/il_S2_eltcalc_P10 fifo/full_correlation/il_S2_summarycalc_P10 fifo/full_correlation/il_S2_pltcalc_P10 work/full_correlation/il_S2_summaryaalcalc/P10.bin work/full_correlation/il_S2_summaryleccalc/P10.bin > /dev/null & pid240=$!
+
+summarycalc -f  -1 fifo/full_correlation/il_S1_summary_P1 -2 fifo/full_correlation/il_S2_summary_P1 < fifo/full_correlation/il_P1 &
+summarycalc -f  -1 fifo/full_correlation/il_S1_summary_P2 -2 fifo/full_correlation/il_S2_summary_P2 < fifo/full_correlation/il_P2 &
+summarycalc -f  -1 fifo/full_correlation/il_S1_summary_P3 -2 fifo/full_correlation/il_S2_summary_P3 < fifo/full_correlation/il_P3 &
+summarycalc -f  -1 fifo/full_correlation/il_S1_summary_P4 -2 fifo/full_correlation/il_S2_summary_P4 < fifo/full_correlation/il_P4 &
+summarycalc -f  -1 fifo/full_correlation/il_S1_summary_P5 -2 fifo/full_correlation/il_S2_summary_P5 < fifo/full_correlation/il_P5 &
+summarycalc -f  -1 fifo/full_correlation/il_S1_summary_P6 -2 fifo/full_correlation/il_S2_summary_P6 < fifo/full_correlation/il_P6 &
+summarycalc -f  -1 fifo/full_correlation/il_S1_summary_P7 -2 fifo/full_correlation/il_S2_summary_P7 < fifo/full_correlation/il_P7 &
+summarycalc -f  -1 fifo/full_correlation/il_S1_summary_P8 -2 fifo/full_correlation/il_S2_summary_P8 < fifo/full_correlation/il_P8 &
+summarycalc -f  -1 fifo/full_correlation/il_S1_summary_P9 -2 fifo/full_correlation/il_S2_summary_P9 < fifo/full_correlation/il_P9 &
+summarycalc -f  -1 fifo/full_correlation/il_S1_summary_P10 -2 fifo/full_correlation/il_S2_summary_P10 < fifo/full_correlation/il_P10 &
+
+# --- Do ground up loss computes ---
+
+eltcalc < fifo/full_correlation/gul_S1_eltcalc_P1 > work/full_correlation/kat/gul_S1_eltcalc_P1 & pid241=$!
+summarycalctocsv < fifo/full_correlation/gul_S1_summarycalc_P1 > work/full_correlation/kat/gul_S1_summarycalc_P1 & pid242=$!
+pltcalc < fifo/full_correlation/gul_S1_pltcalc_P1 > work/full_correlation/kat/gul_S1_pltcalc_P1 & pid243=$!
+eltcalc < fifo/full_correlation/gul_S2_eltcalc_P1 > work/full_correlation/kat/gul_S2_eltcalc_P1 & pid244=$!
+summarycalctocsv < fifo/full_correlation/gul_S2_summarycalc_P1 > work/full_correlation/kat/gul_S2_summarycalc_P1 & pid245=$!
+pltcalc < fifo/full_correlation/gul_S2_pltcalc_P1 > work/full_correlation/kat/gul_S2_pltcalc_P1 & pid246=$!
+eltcalc -s < fifo/full_correlation/gul_S1_eltcalc_P2 > work/full_correlation/kat/gul_S1_eltcalc_P2 & pid247=$!
+summarycalctocsv -s < fifo/full_correlation/gul_S1_summarycalc_P2 > work/full_correlation/kat/gul_S1_summarycalc_P2 & pid248=$!
+pltcalc -s < fifo/full_correlation/gul_S1_pltcalc_P2 > work/full_correlation/kat/gul_S1_pltcalc_P2 & pid249=$!
+eltcalc -s < fifo/full_correlation/gul_S2_eltcalc_P2 > work/full_correlation/kat/gul_S2_eltcalc_P2 & pid250=$!
+summarycalctocsv -s < fifo/full_correlation/gul_S2_summarycalc_P2 > work/full_correlation/kat/gul_S2_summarycalc_P2 & pid251=$!
+pltcalc -s < fifo/full_correlation/gul_S2_pltcalc_P2 > work/full_correlation/kat/gul_S2_pltcalc_P2 & pid252=$!
+eltcalc -s < fifo/full_correlation/gul_S1_eltcalc_P3 > work/full_correlation/kat/gul_S1_eltcalc_P3 & pid253=$!
+summarycalctocsv -s < fifo/full_correlation/gul_S1_summarycalc_P3 > work/full_correlation/kat/gul_S1_summarycalc_P3 & pid254=$!
+pltcalc -s < fifo/full_correlation/gul_S1_pltcalc_P3 > work/full_correlation/kat/gul_S1_pltcalc_P3 & pid255=$!
+eltcalc -s < fifo/full_correlation/gul_S2_eltcalc_P3 > work/full_correlation/kat/gul_S2_eltcalc_P3 & pid256=$!
+summarycalctocsv -s < fifo/full_correlation/gul_S2_summarycalc_P3 > work/full_correlation/kat/gul_S2_summarycalc_P3 & pid257=$!
+pltcalc -s < fifo/full_correlation/gul_S2_pltcalc_P3 > work/full_correlation/kat/gul_S2_pltcalc_P3 & pid258=$!
+eltcalc -s < fifo/full_correlation/gul_S1_eltcalc_P4 > work/full_correlation/kat/gul_S1_eltcalc_P4 & pid259=$!
+summarycalctocsv -s < fifo/full_correlation/gul_S1_summarycalc_P4 > work/full_correlation/kat/gul_S1_summarycalc_P4 & pid260=$!
+pltcalc -s < fifo/full_correlation/gul_S1_pltcalc_P4 > work/full_correlation/kat/gul_S1_pltcalc_P4 & pid261=$!
+eltcalc -s < fifo/full_correlation/gul_S2_eltcalc_P4 > work/full_correlation/kat/gul_S2_eltcalc_P4 & pid262=$!
+summarycalctocsv -s < fifo/full_correlation/gul_S2_summarycalc_P4 > work/full_correlation/kat/gul_S2_summarycalc_P4 & pid263=$!
+pltcalc -s < fifo/full_correlation/gul_S2_pltcalc_P4 > work/full_correlation/kat/gul_S2_pltcalc_P4 & pid264=$!
+eltcalc -s < fifo/full_correlation/gul_S1_eltcalc_P5 > work/full_correlation/kat/gul_S1_eltcalc_P5 & pid265=$!
+summarycalctocsv -s < fifo/full_correlation/gul_S1_summarycalc_P5 > work/full_correlation/kat/gul_S1_summarycalc_P5 & pid266=$!
+pltcalc -s < fifo/full_correlation/gul_S1_pltcalc_P5 > work/full_correlation/kat/gul_S1_pltcalc_P5 & pid267=$!
+eltcalc -s < fifo/full_correlation/gul_S2_eltcalc_P5 > work/full_correlation/kat/gul_S2_eltcalc_P5 & pid268=$!
+summarycalctocsv -s < fifo/full_correlation/gul_S2_summarycalc_P5 > work/full_correlation/kat/gul_S2_summarycalc_P5 & pid269=$!
+pltcalc -s < fifo/full_correlation/gul_S2_pltcalc_P5 > work/full_correlation/kat/gul_S2_pltcalc_P5 & pid270=$!
+eltcalc -s < fifo/full_correlation/gul_S1_eltcalc_P6 > work/full_correlation/kat/gul_S1_eltcalc_P6 & pid271=$!
+summarycalctocsv -s < fifo/full_correlation/gul_S1_summarycalc_P6 > work/full_correlation/kat/gul_S1_summarycalc_P6 & pid272=$!
+pltcalc -s < fifo/full_correlation/gul_S1_pltcalc_P6 > work/full_correlation/kat/gul_S1_pltcalc_P6 & pid273=$!
+eltcalc -s < fifo/full_correlation/gul_S2_eltcalc_P6 > work/full_correlation/kat/gul_S2_eltcalc_P6 & pid274=$!
+summarycalctocsv -s < fifo/full_correlation/gul_S2_summarycalc_P6 > work/full_correlation/kat/gul_S2_summarycalc_P6 & pid275=$!
+pltcalc -s < fifo/full_correlation/gul_S2_pltcalc_P6 > work/full_correlation/kat/gul_S2_pltcalc_P6 & pid276=$!
+eltcalc -s < fifo/full_correlation/gul_S1_eltcalc_P7 > work/full_correlation/kat/gul_S1_eltcalc_P7 & pid277=$!
+summarycalctocsv -s < fifo/full_correlation/gul_S1_summarycalc_P7 > work/full_correlation/kat/gul_S1_summarycalc_P7 & pid278=$!
+pltcalc -s < fifo/full_correlation/gul_S1_pltcalc_P7 > work/full_correlation/kat/gul_S1_pltcalc_P7 & pid279=$!
+eltcalc -s < fifo/full_correlation/gul_S2_eltcalc_P7 > work/full_correlation/kat/gul_S2_eltcalc_P7 & pid280=$!
+summarycalctocsv -s < fifo/full_correlation/gul_S2_summarycalc_P7 > work/full_correlation/kat/gul_S2_summarycalc_P7 & pid281=$!
+pltcalc -s < fifo/full_correlation/gul_S2_pltcalc_P7 > work/full_correlation/kat/gul_S2_pltcalc_P7 & pid282=$!
+eltcalc -s < fifo/full_correlation/gul_S1_eltcalc_P8 > work/full_correlation/kat/gul_S1_eltcalc_P8 & pid283=$!
+summarycalctocsv -s < fifo/full_correlation/gul_S1_summarycalc_P8 > work/full_correlation/kat/gul_S1_summarycalc_P8 & pid284=$!
+pltcalc -s < fifo/full_correlation/gul_S1_pltcalc_P8 > work/full_correlation/kat/gul_S1_pltcalc_P8 & pid285=$!
+eltcalc -s < fifo/full_correlation/gul_S2_eltcalc_P8 > work/full_correlation/kat/gul_S2_eltcalc_P8 & pid286=$!
+summarycalctocsv -s < fifo/full_correlation/gul_S2_summarycalc_P8 > work/full_correlation/kat/gul_S2_summarycalc_P8 & pid287=$!
+pltcalc -s < fifo/full_correlation/gul_S2_pltcalc_P8 > work/full_correlation/kat/gul_S2_pltcalc_P8 & pid288=$!
+eltcalc -s < fifo/full_correlation/gul_S1_eltcalc_P9 > work/full_correlation/kat/gul_S1_eltcalc_P9 & pid289=$!
+summarycalctocsv -s < fifo/full_correlation/gul_S1_summarycalc_P9 > work/full_correlation/kat/gul_S1_summarycalc_P9 & pid290=$!
+pltcalc -s < fifo/full_correlation/gul_S1_pltcalc_P9 > work/full_correlation/kat/gul_S1_pltcalc_P9 & pid291=$!
+eltcalc -s < fifo/full_correlation/gul_S2_eltcalc_P9 > work/full_correlation/kat/gul_S2_eltcalc_P9 & pid292=$!
+summarycalctocsv -s < fifo/full_correlation/gul_S2_summarycalc_P9 > work/full_correlation/kat/gul_S2_summarycalc_P9 & pid293=$!
+pltcalc -s < fifo/full_correlation/gul_S2_pltcalc_P9 > work/full_correlation/kat/gul_S2_pltcalc_P9 & pid294=$!
+eltcalc -s < fifo/full_correlation/gul_S1_eltcalc_P10 > work/full_correlation/kat/gul_S1_eltcalc_P10 & pid295=$!
+summarycalctocsv -s < fifo/full_correlation/gul_S1_summarycalc_P10 > work/full_correlation/kat/gul_S1_summarycalc_P10 & pid296=$!
+pltcalc -s < fifo/full_correlation/gul_S1_pltcalc_P10 > work/full_correlation/kat/gul_S1_pltcalc_P10 & pid297=$!
+eltcalc -s < fifo/full_correlation/gul_S2_eltcalc_P10 > work/full_correlation/kat/gul_S2_eltcalc_P10 & pid298=$!
+summarycalctocsv -s < fifo/full_correlation/gul_S2_summarycalc_P10 > work/full_correlation/kat/gul_S2_summarycalc_P10 & pid299=$!
+pltcalc -s < fifo/full_correlation/gul_S2_pltcalc_P10 > work/full_correlation/kat/gul_S2_pltcalc_P10 & pid300=$!
+
+tee < fifo/full_correlation/gul_S1_summary_P1 fifo/full_correlation/gul_S1_eltcalc_P1 fifo/full_correlation/gul_S1_summarycalc_P1 fifo/full_correlation/gul_S1_pltcalc_P1 work/full_correlation/gul_S1_summaryaalcalc/P1.bin work/full_correlation/gul_S1_summaryleccalc/P1.bin > /dev/null & pid301=$!
+tee < fifo/full_correlation/gul_S2_summary_P1 fifo/full_correlation/gul_S2_eltcalc_P1 fifo/full_correlation/gul_S2_summarycalc_P1 fifo/full_correlation/gul_S2_pltcalc_P1 work/full_correlation/gul_S2_summaryaalcalc/P1.bin work/full_correlation/gul_S2_summaryleccalc/P1.bin > /dev/null & pid302=$!
+tee < fifo/full_correlation/gul_S1_summary_P2 fifo/full_correlation/gul_S1_eltcalc_P2 fifo/full_correlation/gul_S1_summarycalc_P2 fifo/full_correlation/gul_S1_pltcalc_P2 work/full_correlation/gul_S1_summaryaalcalc/P2.bin work/full_correlation/gul_S1_summaryleccalc/P2.bin > /dev/null & pid303=$!
+tee < fifo/full_correlation/gul_S2_summary_P2 fifo/full_correlation/gul_S2_eltcalc_P2 fifo/full_correlation/gul_S2_summarycalc_P2 fifo/full_correlation/gul_S2_pltcalc_P2 work/full_correlation/gul_S2_summaryaalcalc/P2.bin work/full_correlation/gul_S2_summaryleccalc/P2.bin > /dev/null & pid304=$!
+tee < fifo/full_correlation/gul_S1_summary_P3 fifo/full_correlation/gul_S1_eltcalc_P3 fifo/full_correlation/gul_S1_summarycalc_P3 fifo/full_correlation/gul_S1_pltcalc_P3 work/full_correlation/gul_S1_summaryaalcalc/P3.bin work/full_correlation/gul_S1_summaryleccalc/P3.bin > /dev/null & pid305=$!
+tee < fifo/full_correlation/gul_S2_summary_P3 fifo/full_correlation/gul_S2_eltcalc_P3 fifo/full_correlation/gul_S2_summarycalc_P3 fifo/full_correlation/gul_S2_pltcalc_P3 work/full_correlation/gul_S2_summaryaalcalc/P3.bin work/full_correlation/gul_S2_summaryleccalc/P3.bin > /dev/null & pid306=$!
+tee < fifo/full_correlation/gul_S1_summary_P4 fifo/full_correlation/gul_S1_eltcalc_P4 fifo/full_correlation/gul_S1_summarycalc_P4 fifo/full_correlation/gul_S1_pltcalc_P4 work/full_correlation/gul_S1_summaryaalcalc/P4.bin work/full_correlation/gul_S1_summaryleccalc/P4.bin > /dev/null & pid307=$!
+tee < fifo/full_correlation/gul_S2_summary_P4 fifo/full_correlation/gul_S2_eltcalc_P4 fifo/full_correlation/gul_S2_summarycalc_P4 fifo/full_correlation/gul_S2_pltcalc_P4 work/full_correlation/gul_S2_summaryaalcalc/P4.bin work/full_correlation/gul_S2_summaryleccalc/P4.bin > /dev/null & pid308=$!
+tee < fifo/full_correlation/gul_S1_summary_P5 fifo/full_correlation/gul_S1_eltcalc_P5 fifo/full_correlation/gul_S1_summarycalc_P5 fifo/full_correlation/gul_S1_pltcalc_P5 work/full_correlation/gul_S1_summaryaalcalc/P5.bin work/full_correlation/gul_S1_summaryleccalc/P5.bin > /dev/null & pid309=$!
+tee < fifo/full_correlation/gul_S2_summary_P5 fifo/full_correlation/gul_S2_eltcalc_P5 fifo/full_correlation/gul_S2_summarycalc_P5 fifo/full_correlation/gul_S2_pltcalc_P5 work/full_correlation/gul_S2_summaryaalcalc/P5.bin work/full_correlation/gul_S2_summaryleccalc/P5.bin > /dev/null & pid310=$!
+tee < fifo/full_correlation/gul_S1_summary_P6 fifo/full_correlation/gul_S1_eltcalc_P6 fifo/full_correlation/gul_S1_summarycalc_P6 fifo/full_correlation/gul_S1_pltcalc_P6 work/full_correlation/gul_S1_summaryaalcalc/P6.bin work/full_correlation/gul_S1_summaryleccalc/P6.bin > /dev/null & pid311=$!
+tee < fifo/full_correlation/gul_S2_summary_P6 fifo/full_correlation/gul_S2_eltcalc_P6 fifo/full_correlation/gul_S2_summarycalc_P6 fifo/full_correlation/gul_S2_pltcalc_P6 work/full_correlation/gul_S2_summaryaalcalc/P6.bin work/full_correlation/gul_S2_summaryleccalc/P6.bin > /dev/null & pid312=$!
+tee < fifo/full_correlation/gul_S1_summary_P7 fifo/full_correlation/gul_S1_eltcalc_P7 fifo/full_correlation/gul_S1_summarycalc_P7 fifo/full_correlation/gul_S1_pltcalc_P7 work/full_correlation/gul_S1_summaryaalcalc/P7.bin work/full_correlation/gul_S1_summaryleccalc/P7.bin > /dev/null & pid313=$!
+tee < fifo/full_correlation/gul_S2_summary_P7 fifo/full_correlation/gul_S2_eltcalc_P7 fifo/full_correlation/gul_S2_summarycalc_P7 fifo/full_correlation/gul_S2_pltcalc_P7 work/full_correlation/gul_S2_summaryaalcalc/P7.bin work/full_correlation/gul_S2_summaryleccalc/P7.bin > /dev/null & pid314=$!
+tee < fifo/full_correlation/gul_S1_summary_P8 fifo/full_correlation/gul_S1_eltcalc_P8 fifo/full_correlation/gul_S1_summarycalc_P8 fifo/full_correlation/gul_S1_pltcalc_P8 work/full_correlation/gul_S1_summaryaalcalc/P8.bin work/full_correlation/gul_S1_summaryleccalc/P8.bin > /dev/null & pid315=$!
+tee < fifo/full_correlation/gul_S2_summary_P8 fifo/full_correlation/gul_S2_eltcalc_P8 fifo/full_correlation/gul_S2_summarycalc_P8 fifo/full_correlation/gul_S2_pltcalc_P8 work/full_correlation/gul_S2_summaryaalcalc/P8.bin work/full_correlation/gul_S2_summaryleccalc/P8.bin > /dev/null & pid316=$!
+tee < fifo/full_correlation/gul_S1_summary_P9 fifo/full_correlation/gul_S1_eltcalc_P9 fifo/full_correlation/gul_S1_summarycalc_P9 fifo/full_correlation/gul_S1_pltcalc_P9 work/full_correlation/gul_S1_summaryaalcalc/P9.bin work/full_correlation/gul_S1_summaryleccalc/P9.bin > /dev/null & pid317=$!
+tee < fifo/full_correlation/gul_S2_summary_P9 fifo/full_correlation/gul_S2_eltcalc_P9 fifo/full_correlation/gul_S2_summarycalc_P9 fifo/full_correlation/gul_S2_pltcalc_P9 work/full_correlation/gul_S2_summaryaalcalc/P9.bin work/full_correlation/gul_S2_summaryleccalc/P9.bin > /dev/null & pid318=$!
+tee < fifo/full_correlation/gul_S1_summary_P10 fifo/full_correlation/gul_S1_eltcalc_P10 fifo/full_correlation/gul_S1_summarycalc_P10 fifo/full_correlation/gul_S1_pltcalc_P10 work/full_correlation/gul_S1_summaryaalcalc/P10.bin work/full_correlation/gul_S1_summaryleccalc/P10.bin > /dev/null & pid319=$!
+tee < fifo/full_correlation/gul_S2_summary_P10 fifo/full_correlation/gul_S2_eltcalc_P10 fifo/full_correlation/gul_S2_summarycalc_P10 fifo/full_correlation/gul_S2_pltcalc_P10 work/full_correlation/gul_S2_summaryaalcalc/P10.bin work/full_correlation/gul_S2_summaryleccalc/P10.bin > /dev/null & pid320=$!
+
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P1 -2 fifo/full_correlation/gul_S2_summary_P1 < fifo/full_correlation/gul_P1 &
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P2 -2 fifo/full_correlation/gul_S2_summary_P2 < fifo/full_correlation/gul_P2 &
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P3 -2 fifo/full_correlation/gul_S2_summary_P3 < fifo/full_correlation/gul_P3 &
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P4 -2 fifo/full_correlation/gul_S2_summary_P4 < fifo/full_correlation/gul_P4 &
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P5 -2 fifo/full_correlation/gul_S2_summary_P5 < fifo/full_correlation/gul_P5 &
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P6 -2 fifo/full_correlation/gul_S2_summary_P6 < fifo/full_correlation/gul_P6 &
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P7 -2 fifo/full_correlation/gul_S2_summary_P7 < fifo/full_correlation/gul_P7 &
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P8 -2 fifo/full_correlation/gul_S2_summary_P8 < fifo/full_correlation/gul_P8 &
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P9 -2 fifo/full_correlation/gul_S2_summary_P9 < fifo/full_correlation/gul_P9 &
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P10 -2 fifo/full_correlation/gul_S2_summary_P10 < fifo/full_correlation/gul_P10 &
+
+tee < fifo/full_correlation/gul_fc_P1 fifo/full_correlation/gul_P1  | fmcalc -a2 > fifo/full_correlation/il_P1  &
+tee < fifo/full_correlation/gul_fc_P2 fifo/full_correlation/gul_P2  | fmcalc -a2 > fifo/full_correlation/il_P2  &
+tee < fifo/full_correlation/gul_fc_P3 fifo/full_correlation/gul_P3  | fmcalc -a2 > fifo/full_correlation/il_P3  &
+tee < fifo/full_correlation/gul_fc_P4 fifo/full_correlation/gul_P4  | fmcalc -a2 > fifo/full_correlation/il_P4  &
+tee < fifo/full_correlation/gul_fc_P5 fifo/full_correlation/gul_P5  | fmcalc -a2 > fifo/full_correlation/il_P5  &
+tee < fifo/full_correlation/gul_fc_P6 fifo/full_correlation/gul_P6  | fmcalc -a2 > fifo/full_correlation/il_P6  &
+tee < fifo/full_correlation/gul_fc_P7 fifo/full_correlation/gul_P7  | fmcalc -a2 > fifo/full_correlation/il_P7  &
+tee < fifo/full_correlation/gul_fc_P8 fifo/full_correlation/gul_P8  | fmcalc -a2 > fifo/full_correlation/il_P8  &
+tee < fifo/full_correlation/gul_fc_P9 fifo/full_correlation/gul_P9  | fmcalc -a2 > fifo/full_correlation/il_P9  &
+tee < fifo/full_correlation/gul_fc_P10 fifo/full_correlation/gul_P10  | fmcalc -a2 > fifo/full_correlation/il_P10  &
+eve 1 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_fc_P1 -a1 -i - | tee fifo/gul_P1 | fmcalc -a2 > fifo/il_P1  &
+eve 2 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_fc_P2 -a1 -i - | tee fifo/gul_P2 | fmcalc -a2 > fifo/il_P2  &
+eve 3 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_fc_P3 -a1 -i - | tee fifo/gul_P3 | fmcalc -a2 > fifo/il_P3  &
+eve 4 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_fc_P4 -a1 -i - | tee fifo/gul_P4 | fmcalc -a2 > fifo/il_P4  &
+eve 5 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_fc_P5 -a1 -i - | tee fifo/gul_P5 | fmcalc -a2 > fifo/il_P5  &
+eve 6 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_fc_P6 -a1 -i - | tee fifo/gul_P6 | fmcalc -a2 > fifo/il_P6  &
+eve 7 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_fc_P7 -a1 -i - | tee fifo/gul_P7 | fmcalc -a2 > fifo/il_P7  &
+eve 8 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_fc_P8 -a1 -i - | tee fifo/gul_P8 | fmcalc -a2 > fifo/il_P8  &
+eve 9 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_fc_P9 -a1 -i - | tee fifo/gul_P9 | fmcalc -a2 > fifo/il_P9  &
+eve 10 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_fc_P10 -a1 -i - | tee fifo/gul_P10 | fmcalc -a2 > fifo/il_P10  &
+
+wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 $pid13 $pid14 $pid15 $pid16 $pid17 $pid18 $pid19 $pid20 $pid21 $pid22 $pid23 $pid24 $pid25 $pid26 $pid27 $pid28 $pid29 $pid30 $pid31 $pid32 $pid33 $pid34 $pid35 $pid36 $pid37 $pid38 $pid39 $pid40 $pid41 $pid42 $pid43 $pid44 $pid45 $pid46 $pid47 $pid48 $pid49 $pid50 $pid51 $pid52 $pid53 $pid54 $pid55 $pid56 $pid57 $pid58 $pid59 $pid60 $pid61 $pid62 $pid63 $pid64 $pid65 $pid66 $pid67 $pid68 $pid69 $pid70 $pid71 $pid72 $pid73 $pid74 $pid75 $pid76 $pid77 $pid78 $pid79 $pid80 $pid81 $pid82 $pid83 $pid84 $pid85 $pid86 $pid87 $pid88 $pid89 $pid90 $pid91 $pid92 $pid93 $pid94 $pid95 $pid96 $pid97 $pid98 $pid99 $pid100 $pid101 $pid102 $pid103 $pid104 $pid105 $pid106 $pid107 $pid108 $pid109 $pid110 $pid111 $pid112 $pid113 $pid114 $pid115 $pid116 $pid117 $pid118 $pid119 $pid120 $pid121 $pid122 $pid123 $pid124 $pid125 $pid126 $pid127 $pid128 $pid129 $pid130 $pid131 $pid132 $pid133 $pid134 $pid135 $pid136 $pid137 $pid138 $pid139 $pid140 $pid141 $pid142 $pid143 $pid144 $pid145 $pid146 $pid147 $pid148 $pid149 $pid150 $pid151 $pid152 $pid153 $pid154 $pid155 $pid156 $pid157 $pid158 $pid159 $pid160 $pid161 $pid162 $pid163 $pid164 $pid165 $pid166 $pid167 $pid168 $pid169 $pid170 $pid171 $pid172 $pid173 $pid174 $pid175 $pid176 $pid177 $pid178 $pid179 $pid180 $pid181 $pid182 $pid183 $pid184 $pid185 $pid186 $pid187 $pid188 $pid189 $pid190 $pid191 $pid192 $pid193 $pid194 $pid195 $pid196 $pid197 $pid198 $pid199 $pid200 $pid201 $pid202 $pid203 $pid204 $pid205 $pid206 $pid207 $pid208 $pid209 $pid210 $pid211 $pid212 $pid213 $pid214 $pid215 $pid216 $pid217 $pid218 $pid219 $pid220 $pid221 $pid222 $pid223 $pid224 $pid225 $pid226 $pid227 $pid228 $pid229 $pid230 $pid231 $pid232 $pid233 $pid234 $pid235 $pid236 $pid237 $pid238 $pid239 $pid240 $pid241 $pid242 $pid243 $pid244 $pid245 $pid246 $pid247 $pid248 $pid249 $pid250 $pid251 $pid252 $pid253 $pid254 $pid255 $pid256 $pid257 $pid258 $pid259 $pid260 $pid261 $pid262 $pid263 $pid264 $pid265 $pid266 $pid267 $pid268 $pid269 $pid270 $pid271 $pid272 $pid273 $pid274 $pid275 $pid276 $pid277 $pid278 $pid279 $pid280 $pid281 $pid282 $pid283 $pid284 $pid285 $pid286 $pid287 $pid288 $pid289 $pid290 $pid291 $pid292 $pid293 $pid294 $pid295 $pid296 $pid297 $pid298 $pid299 $pid300 $pid301 $pid302 $pid303 $pid304 $pid305 $pid306 $pid307 $pid308 $pid309 $pid310 $pid311 $pid312 $pid313 $pid314 $pid315 $pid316 $pid317 $pid318 $pid319 $pid320
+
+
+# --- Do insured loss kats ---
+
+kat -s work/kat/il_S1_eltcalc_P1 work/kat/il_S1_eltcalc_P2 work/kat/il_S1_eltcalc_P3 work/kat/il_S1_eltcalc_P4 work/kat/il_S1_eltcalc_P5 work/kat/il_S1_eltcalc_P6 work/kat/il_S1_eltcalc_P7 work/kat/il_S1_eltcalc_P8 work/kat/il_S1_eltcalc_P9 work/kat/il_S1_eltcalc_P10 > output/il_S1_eltcalc.csv & kpid1=$!
+kat work/kat/il_S1_pltcalc_P1 work/kat/il_S1_pltcalc_P2 work/kat/il_S1_pltcalc_P3 work/kat/il_S1_pltcalc_P4 work/kat/il_S1_pltcalc_P5 work/kat/il_S1_pltcalc_P6 work/kat/il_S1_pltcalc_P7 work/kat/il_S1_pltcalc_P8 work/kat/il_S1_pltcalc_P9 work/kat/il_S1_pltcalc_P10 > output/il_S1_pltcalc.csv & kpid2=$!
+kat work/kat/il_S1_summarycalc_P1 work/kat/il_S1_summarycalc_P2 work/kat/il_S1_summarycalc_P3 work/kat/il_S1_summarycalc_P4 work/kat/il_S1_summarycalc_P5 work/kat/il_S1_summarycalc_P6 work/kat/il_S1_summarycalc_P7 work/kat/il_S1_summarycalc_P8 work/kat/il_S1_summarycalc_P9 work/kat/il_S1_summarycalc_P10 > output/il_S1_summarycalc.csv & kpid3=$!
+kat -s work/kat/il_S2_eltcalc_P1 work/kat/il_S2_eltcalc_P2 work/kat/il_S2_eltcalc_P3 work/kat/il_S2_eltcalc_P4 work/kat/il_S2_eltcalc_P5 work/kat/il_S2_eltcalc_P6 work/kat/il_S2_eltcalc_P7 work/kat/il_S2_eltcalc_P8 work/kat/il_S2_eltcalc_P9 work/kat/il_S2_eltcalc_P10 > output/il_S2_eltcalc.csv & kpid4=$!
+kat work/kat/il_S2_pltcalc_P1 work/kat/il_S2_pltcalc_P2 work/kat/il_S2_pltcalc_P3 work/kat/il_S2_pltcalc_P4 work/kat/il_S2_pltcalc_P5 work/kat/il_S2_pltcalc_P6 work/kat/il_S2_pltcalc_P7 work/kat/il_S2_pltcalc_P8 work/kat/il_S2_pltcalc_P9 work/kat/il_S2_pltcalc_P10 > output/il_S2_pltcalc.csv & kpid5=$!
+kat work/kat/il_S2_summarycalc_P1 work/kat/il_S2_summarycalc_P2 work/kat/il_S2_summarycalc_P3 work/kat/il_S2_summarycalc_P4 work/kat/il_S2_summarycalc_P5 work/kat/il_S2_summarycalc_P6 work/kat/il_S2_summarycalc_P7 work/kat/il_S2_summarycalc_P8 work/kat/il_S2_summarycalc_P9 work/kat/il_S2_summarycalc_P10 > output/il_S2_summarycalc.csv & kpid6=$!
+
+# --- Do insured loss kats for fully correlated output ---
+
+kat -s work/full_correlation/kat/il_S1_eltcalc_P1 work/full_correlation/kat/il_S1_eltcalc_P2 work/full_correlation/kat/il_S1_eltcalc_P3 work/full_correlation/kat/il_S1_eltcalc_P4 work/full_correlation/kat/il_S1_eltcalc_P5 work/full_correlation/kat/il_S1_eltcalc_P6 work/full_correlation/kat/il_S1_eltcalc_P7 work/full_correlation/kat/il_S1_eltcalc_P8 work/full_correlation/kat/il_S1_eltcalc_P9 work/full_correlation/kat/il_S1_eltcalc_P10 > output/full_correlation/il_S1_eltcalc.csv & kpid7=$!
+kat work/full_correlation/kat/il_S1_pltcalc_P1 work/full_correlation/kat/il_S1_pltcalc_P2 work/full_correlation/kat/il_S1_pltcalc_P3 work/full_correlation/kat/il_S1_pltcalc_P4 work/full_correlation/kat/il_S1_pltcalc_P5 work/full_correlation/kat/il_S1_pltcalc_P6 work/full_correlation/kat/il_S1_pltcalc_P7 work/full_correlation/kat/il_S1_pltcalc_P8 work/full_correlation/kat/il_S1_pltcalc_P9 work/full_correlation/kat/il_S1_pltcalc_P10 > output/full_correlation/il_S1_pltcalc.csv & kpid8=$!
+kat work/full_correlation/kat/il_S1_summarycalc_P1 work/full_correlation/kat/il_S1_summarycalc_P2 work/full_correlation/kat/il_S1_summarycalc_P3 work/full_correlation/kat/il_S1_summarycalc_P4 work/full_correlation/kat/il_S1_summarycalc_P5 work/full_correlation/kat/il_S1_summarycalc_P6 work/full_correlation/kat/il_S1_summarycalc_P7 work/full_correlation/kat/il_S1_summarycalc_P8 work/full_correlation/kat/il_S1_summarycalc_P9 work/full_correlation/kat/il_S1_summarycalc_P10 > output/full_correlation/il_S1_summarycalc.csv & kpid9=$!
+kat -s work/full_correlation/kat/il_S2_eltcalc_P1 work/full_correlation/kat/il_S2_eltcalc_P2 work/full_correlation/kat/il_S2_eltcalc_P3 work/full_correlation/kat/il_S2_eltcalc_P4 work/full_correlation/kat/il_S2_eltcalc_P5 work/full_correlation/kat/il_S2_eltcalc_P6 work/full_correlation/kat/il_S2_eltcalc_P7 work/full_correlation/kat/il_S2_eltcalc_P8 work/full_correlation/kat/il_S2_eltcalc_P9 work/full_correlation/kat/il_S2_eltcalc_P10 > output/full_correlation/il_S2_eltcalc.csv & kpid10=$!
+kat work/full_correlation/kat/il_S2_pltcalc_P1 work/full_correlation/kat/il_S2_pltcalc_P2 work/full_correlation/kat/il_S2_pltcalc_P3 work/full_correlation/kat/il_S2_pltcalc_P4 work/full_correlation/kat/il_S2_pltcalc_P5 work/full_correlation/kat/il_S2_pltcalc_P6 work/full_correlation/kat/il_S2_pltcalc_P7 work/full_correlation/kat/il_S2_pltcalc_P8 work/full_correlation/kat/il_S2_pltcalc_P9 work/full_correlation/kat/il_S2_pltcalc_P10 > output/full_correlation/il_S2_pltcalc.csv & kpid11=$!
+kat work/full_correlation/kat/il_S2_summarycalc_P1 work/full_correlation/kat/il_S2_summarycalc_P2 work/full_correlation/kat/il_S2_summarycalc_P3 work/full_correlation/kat/il_S2_summarycalc_P4 work/full_correlation/kat/il_S2_summarycalc_P5 work/full_correlation/kat/il_S2_summarycalc_P6 work/full_correlation/kat/il_S2_summarycalc_P7 work/full_correlation/kat/il_S2_summarycalc_P8 work/full_correlation/kat/il_S2_summarycalc_P9 work/full_correlation/kat/il_S2_summarycalc_P10 > output/full_correlation/il_S2_summarycalc.csv & kpid12=$!
+
+# --- Do ground up loss kats ---
+
+kat -s work/kat/gul_S1_eltcalc_P1 work/kat/gul_S1_eltcalc_P2 work/kat/gul_S1_eltcalc_P3 work/kat/gul_S1_eltcalc_P4 work/kat/gul_S1_eltcalc_P5 work/kat/gul_S1_eltcalc_P6 work/kat/gul_S1_eltcalc_P7 work/kat/gul_S1_eltcalc_P8 work/kat/gul_S1_eltcalc_P9 work/kat/gul_S1_eltcalc_P10 > output/gul_S1_eltcalc.csv & kpid13=$!
+kat work/kat/gul_S1_pltcalc_P1 work/kat/gul_S1_pltcalc_P2 work/kat/gul_S1_pltcalc_P3 work/kat/gul_S1_pltcalc_P4 work/kat/gul_S1_pltcalc_P5 work/kat/gul_S1_pltcalc_P6 work/kat/gul_S1_pltcalc_P7 work/kat/gul_S1_pltcalc_P8 work/kat/gul_S1_pltcalc_P9 work/kat/gul_S1_pltcalc_P10 > output/gul_S1_pltcalc.csv & kpid14=$!
+kat work/kat/gul_S1_summarycalc_P1 work/kat/gul_S1_summarycalc_P2 work/kat/gul_S1_summarycalc_P3 work/kat/gul_S1_summarycalc_P4 work/kat/gul_S1_summarycalc_P5 work/kat/gul_S1_summarycalc_P6 work/kat/gul_S1_summarycalc_P7 work/kat/gul_S1_summarycalc_P8 work/kat/gul_S1_summarycalc_P9 work/kat/gul_S1_summarycalc_P10 > output/gul_S1_summarycalc.csv & kpid15=$!
+kat -s work/kat/gul_S2_eltcalc_P1 work/kat/gul_S2_eltcalc_P2 work/kat/gul_S2_eltcalc_P3 work/kat/gul_S2_eltcalc_P4 work/kat/gul_S2_eltcalc_P5 work/kat/gul_S2_eltcalc_P6 work/kat/gul_S2_eltcalc_P7 work/kat/gul_S2_eltcalc_P8 work/kat/gul_S2_eltcalc_P9 work/kat/gul_S2_eltcalc_P10 > output/gul_S2_eltcalc.csv & kpid16=$!
+kat work/kat/gul_S2_pltcalc_P1 work/kat/gul_S2_pltcalc_P2 work/kat/gul_S2_pltcalc_P3 work/kat/gul_S2_pltcalc_P4 work/kat/gul_S2_pltcalc_P5 work/kat/gul_S2_pltcalc_P6 work/kat/gul_S2_pltcalc_P7 work/kat/gul_S2_pltcalc_P8 work/kat/gul_S2_pltcalc_P9 work/kat/gul_S2_pltcalc_P10 > output/gul_S2_pltcalc.csv & kpid17=$!
+kat work/kat/gul_S2_summarycalc_P1 work/kat/gul_S2_summarycalc_P2 work/kat/gul_S2_summarycalc_P3 work/kat/gul_S2_summarycalc_P4 work/kat/gul_S2_summarycalc_P5 work/kat/gul_S2_summarycalc_P6 work/kat/gul_S2_summarycalc_P7 work/kat/gul_S2_summarycalc_P8 work/kat/gul_S2_summarycalc_P9 work/kat/gul_S2_summarycalc_P10 > output/gul_S2_summarycalc.csv & kpid18=$!
+
+# --- Do ground up loss kats for fully correlated output ---
+
+kat -s work/full_correlation/kat/gul_S1_eltcalc_P1 work/full_correlation/kat/gul_S1_eltcalc_P2 work/full_correlation/kat/gul_S1_eltcalc_P3 work/full_correlation/kat/gul_S1_eltcalc_P4 work/full_correlation/kat/gul_S1_eltcalc_P5 work/full_correlation/kat/gul_S1_eltcalc_P6 work/full_correlation/kat/gul_S1_eltcalc_P7 work/full_correlation/kat/gul_S1_eltcalc_P8 work/full_correlation/kat/gul_S1_eltcalc_P9 work/full_correlation/kat/gul_S1_eltcalc_P10 > output/full_correlation/gul_S1_eltcalc.csv & kpid19=$!
+kat work/full_correlation/kat/gul_S1_pltcalc_P1 work/full_correlation/kat/gul_S1_pltcalc_P2 work/full_correlation/kat/gul_S1_pltcalc_P3 work/full_correlation/kat/gul_S1_pltcalc_P4 work/full_correlation/kat/gul_S1_pltcalc_P5 work/full_correlation/kat/gul_S1_pltcalc_P6 work/full_correlation/kat/gul_S1_pltcalc_P7 work/full_correlation/kat/gul_S1_pltcalc_P8 work/full_correlation/kat/gul_S1_pltcalc_P9 work/full_correlation/kat/gul_S1_pltcalc_P10 > output/full_correlation/gul_S1_pltcalc.csv & kpid20=$!
+kat work/full_correlation/kat/gul_S1_summarycalc_P1 work/full_correlation/kat/gul_S1_summarycalc_P2 work/full_correlation/kat/gul_S1_summarycalc_P3 work/full_correlation/kat/gul_S1_summarycalc_P4 work/full_correlation/kat/gul_S1_summarycalc_P5 work/full_correlation/kat/gul_S1_summarycalc_P6 work/full_correlation/kat/gul_S1_summarycalc_P7 work/full_correlation/kat/gul_S1_summarycalc_P8 work/full_correlation/kat/gul_S1_summarycalc_P9 work/full_correlation/kat/gul_S1_summarycalc_P10 > output/full_correlation/gul_S1_summarycalc.csv & kpid21=$!
+kat -s work/full_correlation/kat/gul_S2_eltcalc_P1 work/full_correlation/kat/gul_S2_eltcalc_P2 work/full_correlation/kat/gul_S2_eltcalc_P3 work/full_correlation/kat/gul_S2_eltcalc_P4 work/full_correlation/kat/gul_S2_eltcalc_P5 work/full_correlation/kat/gul_S2_eltcalc_P6 work/full_correlation/kat/gul_S2_eltcalc_P7 work/full_correlation/kat/gul_S2_eltcalc_P8 work/full_correlation/kat/gul_S2_eltcalc_P9 work/full_correlation/kat/gul_S2_eltcalc_P10 > output/full_correlation/gul_S2_eltcalc.csv & kpid22=$!
+kat work/full_correlation/kat/gul_S2_pltcalc_P1 work/full_correlation/kat/gul_S2_pltcalc_P2 work/full_correlation/kat/gul_S2_pltcalc_P3 work/full_correlation/kat/gul_S2_pltcalc_P4 work/full_correlation/kat/gul_S2_pltcalc_P5 work/full_correlation/kat/gul_S2_pltcalc_P6 work/full_correlation/kat/gul_S2_pltcalc_P7 work/full_correlation/kat/gul_S2_pltcalc_P8 work/full_correlation/kat/gul_S2_pltcalc_P9 work/full_correlation/kat/gul_S2_pltcalc_P10 > output/full_correlation/gul_S2_pltcalc.csv & kpid23=$!
+kat work/full_correlation/kat/gul_S2_summarycalc_P1 work/full_correlation/kat/gul_S2_summarycalc_P2 work/full_correlation/kat/gul_S2_summarycalc_P3 work/full_correlation/kat/gul_S2_summarycalc_P4 work/full_correlation/kat/gul_S2_summarycalc_P5 work/full_correlation/kat/gul_S2_summarycalc_P6 work/full_correlation/kat/gul_S2_summarycalc_P7 work/full_correlation/kat/gul_S2_summarycalc_P8 work/full_correlation/kat/gul_S2_summarycalc_P9 work/full_correlation/kat/gul_S2_summarycalc_P10 > output/full_correlation/gul_S2_summarycalc.csv & kpid24=$!
+wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpid11 $kpid12 $kpid13 $kpid14 $kpid15 $kpid16 $kpid17 $kpid18 $kpid19 $kpid20 $kpid21 $kpid22 $kpid23 $kpid24
+
+
+aalcalc -Kil_S1_summaryaalcalc > output/il_S1_aalcalc.csv & lpid1=$!
+ordleccalc -r -Kil_S1_summaryleccalc -F -S -s -M -m -W -w -O output/il_S1_ept.csv -o output/il_S1_psept.csv & lpid2=$!
+aalcalc -Kil_S2_summaryaalcalc > output/il_S2_aalcalc.csv & lpid3=$!
+ordleccalc -r -Kil_S2_summaryleccalc -F -S -s -M -m -W -w -O output/il_S2_ept.csv -o output/il_S2_psept.csv & lpid4=$!
+aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv & lpid5=$!
+ordleccalc -r -Kgul_S1_summaryleccalc -F -S -s -M -m -W -w -O output/gul_S1_ept.csv -o output/gul_S1_psept.csv & lpid6=$!
+aalcalc -Kgul_S2_summaryaalcalc > output/gul_S2_aalcalc.csv & lpid7=$!
+ordleccalc -r -Kgul_S2_summaryleccalc -F -S -s -M -m -W -w -O output/gul_S2_ept.csv -o output/gul_S2_psept.csv & lpid8=$!
+aalcalc -Kfull_correlation/il_S1_summaryaalcalc > output/full_correlation/il_S1_aalcalc.csv & lpid9=$!
+ordleccalc -r -Kfull_correlation/il_S1_summaryleccalc -F -S -s -M -m -W -w -O output/full_correlation/il_S1_ept.csv -o output/full_correlation/il_S1_psept.csv & lpid10=$!
+aalcalc -Kfull_correlation/il_S2_summaryaalcalc > output/full_correlation/il_S2_aalcalc.csv & lpid11=$!
+ordleccalc -r -Kfull_correlation/il_S2_summaryleccalc -F -S -s -M -m -W -w -O output/full_correlation/il_S2_ept.csv -o output/full_correlation/il_S2_psept.csv & lpid12=$!
+aalcalc -Kfull_correlation/gul_S1_summaryaalcalc > output/full_correlation/gul_S1_aalcalc.csv & lpid13=$!
+ordleccalc -r -Kfull_correlation/gul_S1_summaryleccalc -F -S -s -M -m -W -w -O output/full_correlation/gul_S1_ept.csv -o output/full_correlation/gul_S1_psept.csv & lpid14=$!
+aalcalc -Kfull_correlation/gul_S2_summaryaalcalc > output/full_correlation/gul_S2_aalcalc.csv & lpid15=$!
+ordleccalc -r -Kfull_correlation/gul_S2_summaryleccalc -F -S -s -M -m -W -w -O output/full_correlation/gul_S2_ept.csv -o output/full_correlation/gul_S2_psept.csv & lpid16=$!
+wait $lpid1 $lpid2 $lpid3 $lpid4 $lpid5 $lpid6 $lpid7 $lpid8 $lpid9 $lpid10 $lpid11 $lpid12 $lpid13 $lpid14 $lpid15 $lpid16
+
+rm -R -f work/*
+rm -R -f fifo/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_il_ord_psept_lec_1_output_10_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_il_ord_psept_lec_1_output_10_partition.sh
@@ -1,0 +1,574 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+mkdir output/full_correlation/
+
+rm -R -f fifo/*
+mkdir fifo/full_correlation/
+rm -R -f work/*
+mkdir work/kat/
+mkdir work/full_correlation/
+mkdir work/full_correlation/kat/
+
+mkdir work/gul_S1_summaryleccalc
+mkdir work/gul_S1_summaryaalcalc
+mkdir work/full_correlation/gul_S1_summaryleccalc
+mkdir work/full_correlation/gul_S1_summaryaalcalc
+mkdir work/il_S1_summaryleccalc
+mkdir work/il_S1_summaryaalcalc
+mkdir work/full_correlation/il_S1_summaryleccalc
+mkdir work/full_correlation/il_S1_summaryaalcalc
+
+mkfifo fifo/full_correlation/gul_fc_P1
+mkfifo fifo/full_correlation/gul_fc_P2
+mkfifo fifo/full_correlation/gul_fc_P3
+mkfifo fifo/full_correlation/gul_fc_P4
+mkfifo fifo/full_correlation/gul_fc_P5
+mkfifo fifo/full_correlation/gul_fc_P6
+mkfifo fifo/full_correlation/gul_fc_P7
+mkfifo fifo/full_correlation/gul_fc_P8
+mkfifo fifo/full_correlation/gul_fc_P9
+mkfifo fifo/full_correlation/gul_fc_P10
+
+mkfifo fifo/gul_P1
+mkfifo fifo/gul_P2
+mkfifo fifo/gul_P3
+mkfifo fifo/gul_P4
+mkfifo fifo/gul_P5
+mkfifo fifo/gul_P6
+mkfifo fifo/gul_P7
+mkfifo fifo/gul_P8
+mkfifo fifo/gul_P9
+mkfifo fifo/gul_P10
+
+mkfifo fifo/gul_S1_summary_P1
+mkfifo fifo/gul_S1_eltcalc_P1
+mkfifo fifo/gul_S1_summarycalc_P1
+mkfifo fifo/gul_S1_pltcalc_P1
+
+mkfifo fifo/gul_S1_summary_P2
+mkfifo fifo/gul_S1_eltcalc_P2
+mkfifo fifo/gul_S1_summarycalc_P2
+mkfifo fifo/gul_S1_pltcalc_P2
+
+mkfifo fifo/gul_S1_summary_P3
+mkfifo fifo/gul_S1_eltcalc_P3
+mkfifo fifo/gul_S1_summarycalc_P3
+mkfifo fifo/gul_S1_pltcalc_P3
+
+mkfifo fifo/gul_S1_summary_P4
+mkfifo fifo/gul_S1_eltcalc_P4
+mkfifo fifo/gul_S1_summarycalc_P4
+mkfifo fifo/gul_S1_pltcalc_P4
+
+mkfifo fifo/gul_S1_summary_P5
+mkfifo fifo/gul_S1_eltcalc_P5
+mkfifo fifo/gul_S1_summarycalc_P5
+mkfifo fifo/gul_S1_pltcalc_P5
+
+mkfifo fifo/gul_S1_summary_P6
+mkfifo fifo/gul_S1_eltcalc_P6
+mkfifo fifo/gul_S1_summarycalc_P6
+mkfifo fifo/gul_S1_pltcalc_P6
+
+mkfifo fifo/gul_S1_summary_P7
+mkfifo fifo/gul_S1_eltcalc_P7
+mkfifo fifo/gul_S1_summarycalc_P7
+mkfifo fifo/gul_S1_pltcalc_P7
+
+mkfifo fifo/gul_S1_summary_P8
+mkfifo fifo/gul_S1_eltcalc_P8
+mkfifo fifo/gul_S1_summarycalc_P8
+mkfifo fifo/gul_S1_pltcalc_P8
+
+mkfifo fifo/gul_S1_summary_P9
+mkfifo fifo/gul_S1_eltcalc_P9
+mkfifo fifo/gul_S1_summarycalc_P9
+mkfifo fifo/gul_S1_pltcalc_P9
+
+mkfifo fifo/gul_S1_summary_P10
+mkfifo fifo/gul_S1_eltcalc_P10
+mkfifo fifo/gul_S1_summarycalc_P10
+mkfifo fifo/gul_S1_pltcalc_P10
+
+mkfifo fifo/il_P1
+mkfifo fifo/il_P2
+mkfifo fifo/il_P3
+mkfifo fifo/il_P4
+mkfifo fifo/il_P5
+mkfifo fifo/il_P6
+mkfifo fifo/il_P7
+mkfifo fifo/il_P8
+mkfifo fifo/il_P9
+mkfifo fifo/il_P10
+
+mkfifo fifo/il_S1_summary_P1
+mkfifo fifo/il_S1_eltcalc_P1
+mkfifo fifo/il_S1_summarycalc_P1
+mkfifo fifo/il_S1_pltcalc_P1
+
+mkfifo fifo/il_S1_summary_P2
+mkfifo fifo/il_S1_eltcalc_P2
+mkfifo fifo/il_S1_summarycalc_P2
+mkfifo fifo/il_S1_pltcalc_P2
+
+mkfifo fifo/il_S1_summary_P3
+mkfifo fifo/il_S1_eltcalc_P3
+mkfifo fifo/il_S1_summarycalc_P3
+mkfifo fifo/il_S1_pltcalc_P3
+
+mkfifo fifo/il_S1_summary_P4
+mkfifo fifo/il_S1_eltcalc_P4
+mkfifo fifo/il_S1_summarycalc_P4
+mkfifo fifo/il_S1_pltcalc_P4
+
+mkfifo fifo/il_S1_summary_P5
+mkfifo fifo/il_S1_eltcalc_P5
+mkfifo fifo/il_S1_summarycalc_P5
+mkfifo fifo/il_S1_pltcalc_P5
+
+mkfifo fifo/il_S1_summary_P6
+mkfifo fifo/il_S1_eltcalc_P6
+mkfifo fifo/il_S1_summarycalc_P6
+mkfifo fifo/il_S1_pltcalc_P6
+
+mkfifo fifo/il_S1_summary_P7
+mkfifo fifo/il_S1_eltcalc_P7
+mkfifo fifo/il_S1_summarycalc_P7
+mkfifo fifo/il_S1_pltcalc_P7
+
+mkfifo fifo/il_S1_summary_P8
+mkfifo fifo/il_S1_eltcalc_P8
+mkfifo fifo/il_S1_summarycalc_P8
+mkfifo fifo/il_S1_pltcalc_P8
+
+mkfifo fifo/il_S1_summary_P9
+mkfifo fifo/il_S1_eltcalc_P9
+mkfifo fifo/il_S1_summarycalc_P9
+mkfifo fifo/il_S1_pltcalc_P9
+
+mkfifo fifo/il_S1_summary_P10
+mkfifo fifo/il_S1_eltcalc_P10
+mkfifo fifo/il_S1_summarycalc_P10
+mkfifo fifo/il_S1_pltcalc_P10
+
+mkfifo fifo/full_correlation/gul_P1
+mkfifo fifo/full_correlation/gul_P2
+mkfifo fifo/full_correlation/gul_P3
+mkfifo fifo/full_correlation/gul_P4
+mkfifo fifo/full_correlation/gul_P5
+mkfifo fifo/full_correlation/gul_P6
+mkfifo fifo/full_correlation/gul_P7
+mkfifo fifo/full_correlation/gul_P8
+mkfifo fifo/full_correlation/gul_P9
+mkfifo fifo/full_correlation/gul_P10
+
+mkfifo fifo/full_correlation/gul_S1_summary_P1
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P1
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P1
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P1
+
+mkfifo fifo/full_correlation/gul_S1_summary_P2
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P2
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P2
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P2
+
+mkfifo fifo/full_correlation/gul_S1_summary_P3
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P3
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P3
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P3
+
+mkfifo fifo/full_correlation/gul_S1_summary_P4
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P4
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P4
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P4
+
+mkfifo fifo/full_correlation/gul_S1_summary_P5
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P5
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P5
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P5
+
+mkfifo fifo/full_correlation/gul_S1_summary_P6
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P6
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P6
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P6
+
+mkfifo fifo/full_correlation/gul_S1_summary_P7
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P7
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P7
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P7
+
+mkfifo fifo/full_correlation/gul_S1_summary_P8
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P8
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P8
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P8
+
+mkfifo fifo/full_correlation/gul_S1_summary_P9
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P9
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P9
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P9
+
+mkfifo fifo/full_correlation/gul_S1_summary_P10
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P10
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P10
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P10
+
+mkfifo fifo/full_correlation/il_P1
+mkfifo fifo/full_correlation/il_P2
+mkfifo fifo/full_correlation/il_P3
+mkfifo fifo/full_correlation/il_P4
+mkfifo fifo/full_correlation/il_P5
+mkfifo fifo/full_correlation/il_P6
+mkfifo fifo/full_correlation/il_P7
+mkfifo fifo/full_correlation/il_P8
+mkfifo fifo/full_correlation/il_P9
+mkfifo fifo/full_correlation/il_P10
+
+mkfifo fifo/full_correlation/il_S1_summary_P1
+mkfifo fifo/full_correlation/il_S1_eltcalc_P1
+mkfifo fifo/full_correlation/il_S1_summarycalc_P1
+mkfifo fifo/full_correlation/il_S1_pltcalc_P1
+
+mkfifo fifo/full_correlation/il_S1_summary_P2
+mkfifo fifo/full_correlation/il_S1_eltcalc_P2
+mkfifo fifo/full_correlation/il_S1_summarycalc_P2
+mkfifo fifo/full_correlation/il_S1_pltcalc_P2
+
+mkfifo fifo/full_correlation/il_S1_summary_P3
+mkfifo fifo/full_correlation/il_S1_eltcalc_P3
+mkfifo fifo/full_correlation/il_S1_summarycalc_P3
+mkfifo fifo/full_correlation/il_S1_pltcalc_P3
+
+mkfifo fifo/full_correlation/il_S1_summary_P4
+mkfifo fifo/full_correlation/il_S1_eltcalc_P4
+mkfifo fifo/full_correlation/il_S1_summarycalc_P4
+mkfifo fifo/full_correlation/il_S1_pltcalc_P4
+
+mkfifo fifo/full_correlation/il_S1_summary_P5
+mkfifo fifo/full_correlation/il_S1_eltcalc_P5
+mkfifo fifo/full_correlation/il_S1_summarycalc_P5
+mkfifo fifo/full_correlation/il_S1_pltcalc_P5
+
+mkfifo fifo/full_correlation/il_S1_summary_P6
+mkfifo fifo/full_correlation/il_S1_eltcalc_P6
+mkfifo fifo/full_correlation/il_S1_summarycalc_P6
+mkfifo fifo/full_correlation/il_S1_pltcalc_P6
+
+mkfifo fifo/full_correlation/il_S1_summary_P7
+mkfifo fifo/full_correlation/il_S1_eltcalc_P7
+mkfifo fifo/full_correlation/il_S1_summarycalc_P7
+mkfifo fifo/full_correlation/il_S1_pltcalc_P7
+
+mkfifo fifo/full_correlation/il_S1_summary_P8
+mkfifo fifo/full_correlation/il_S1_eltcalc_P8
+mkfifo fifo/full_correlation/il_S1_summarycalc_P8
+mkfifo fifo/full_correlation/il_S1_pltcalc_P8
+
+mkfifo fifo/full_correlation/il_S1_summary_P9
+mkfifo fifo/full_correlation/il_S1_eltcalc_P9
+mkfifo fifo/full_correlation/il_S1_summarycalc_P9
+mkfifo fifo/full_correlation/il_S1_pltcalc_P9
+
+mkfifo fifo/full_correlation/il_S1_summary_P10
+mkfifo fifo/full_correlation/il_S1_eltcalc_P10
+mkfifo fifo/full_correlation/il_S1_summarycalc_P10
+mkfifo fifo/full_correlation/il_S1_pltcalc_P10
+
+
+
+# --- Do insured loss computes ---
+
+eltcalc < fifo/il_S1_eltcalc_P1 > work/kat/il_S1_eltcalc_P1 & pid1=$!
+summarycalctocsv < fifo/il_S1_summarycalc_P1 > work/kat/il_S1_summarycalc_P1 & pid2=$!
+pltcalc < fifo/il_S1_pltcalc_P1 > work/kat/il_S1_pltcalc_P1 & pid3=$!
+eltcalc -s < fifo/il_S1_eltcalc_P2 > work/kat/il_S1_eltcalc_P2 & pid4=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P2 > work/kat/il_S1_summarycalc_P2 & pid5=$!
+pltcalc -s < fifo/il_S1_pltcalc_P2 > work/kat/il_S1_pltcalc_P2 & pid6=$!
+eltcalc -s < fifo/il_S1_eltcalc_P3 > work/kat/il_S1_eltcalc_P3 & pid7=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P3 > work/kat/il_S1_summarycalc_P3 & pid8=$!
+pltcalc -s < fifo/il_S1_pltcalc_P3 > work/kat/il_S1_pltcalc_P3 & pid9=$!
+eltcalc -s < fifo/il_S1_eltcalc_P4 > work/kat/il_S1_eltcalc_P4 & pid10=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P4 > work/kat/il_S1_summarycalc_P4 & pid11=$!
+pltcalc -s < fifo/il_S1_pltcalc_P4 > work/kat/il_S1_pltcalc_P4 & pid12=$!
+eltcalc -s < fifo/il_S1_eltcalc_P5 > work/kat/il_S1_eltcalc_P5 & pid13=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P5 > work/kat/il_S1_summarycalc_P5 & pid14=$!
+pltcalc -s < fifo/il_S1_pltcalc_P5 > work/kat/il_S1_pltcalc_P5 & pid15=$!
+eltcalc -s < fifo/il_S1_eltcalc_P6 > work/kat/il_S1_eltcalc_P6 & pid16=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P6 > work/kat/il_S1_summarycalc_P6 & pid17=$!
+pltcalc -s < fifo/il_S1_pltcalc_P6 > work/kat/il_S1_pltcalc_P6 & pid18=$!
+eltcalc -s < fifo/il_S1_eltcalc_P7 > work/kat/il_S1_eltcalc_P7 & pid19=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P7 > work/kat/il_S1_summarycalc_P7 & pid20=$!
+pltcalc -s < fifo/il_S1_pltcalc_P7 > work/kat/il_S1_pltcalc_P7 & pid21=$!
+eltcalc -s < fifo/il_S1_eltcalc_P8 > work/kat/il_S1_eltcalc_P8 & pid22=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P8 > work/kat/il_S1_summarycalc_P8 & pid23=$!
+pltcalc -s < fifo/il_S1_pltcalc_P8 > work/kat/il_S1_pltcalc_P8 & pid24=$!
+eltcalc -s < fifo/il_S1_eltcalc_P9 > work/kat/il_S1_eltcalc_P9 & pid25=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P9 > work/kat/il_S1_summarycalc_P9 & pid26=$!
+pltcalc -s < fifo/il_S1_pltcalc_P9 > work/kat/il_S1_pltcalc_P9 & pid27=$!
+eltcalc -s < fifo/il_S1_eltcalc_P10 > work/kat/il_S1_eltcalc_P10 & pid28=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P10 > work/kat/il_S1_summarycalc_P10 & pid29=$!
+pltcalc -s < fifo/il_S1_pltcalc_P10 > work/kat/il_S1_pltcalc_P10 & pid30=$!
+
+tee < fifo/il_S1_summary_P1 fifo/il_S1_eltcalc_P1 fifo/il_S1_summarycalc_P1 fifo/il_S1_pltcalc_P1 work/il_S1_summaryaalcalc/P1.bin work/il_S1_summaryleccalc/P1.bin > /dev/null & pid31=$!
+tee < fifo/il_S1_summary_P2 fifo/il_S1_eltcalc_P2 fifo/il_S1_summarycalc_P2 fifo/il_S1_pltcalc_P2 work/il_S1_summaryaalcalc/P2.bin work/il_S1_summaryleccalc/P2.bin > /dev/null & pid32=$!
+tee < fifo/il_S1_summary_P3 fifo/il_S1_eltcalc_P3 fifo/il_S1_summarycalc_P3 fifo/il_S1_pltcalc_P3 work/il_S1_summaryaalcalc/P3.bin work/il_S1_summaryleccalc/P3.bin > /dev/null & pid33=$!
+tee < fifo/il_S1_summary_P4 fifo/il_S1_eltcalc_P4 fifo/il_S1_summarycalc_P4 fifo/il_S1_pltcalc_P4 work/il_S1_summaryaalcalc/P4.bin work/il_S1_summaryleccalc/P4.bin > /dev/null & pid34=$!
+tee < fifo/il_S1_summary_P5 fifo/il_S1_eltcalc_P5 fifo/il_S1_summarycalc_P5 fifo/il_S1_pltcalc_P5 work/il_S1_summaryaalcalc/P5.bin work/il_S1_summaryleccalc/P5.bin > /dev/null & pid35=$!
+tee < fifo/il_S1_summary_P6 fifo/il_S1_eltcalc_P6 fifo/il_S1_summarycalc_P6 fifo/il_S1_pltcalc_P6 work/il_S1_summaryaalcalc/P6.bin work/il_S1_summaryleccalc/P6.bin > /dev/null & pid36=$!
+tee < fifo/il_S1_summary_P7 fifo/il_S1_eltcalc_P7 fifo/il_S1_summarycalc_P7 fifo/il_S1_pltcalc_P7 work/il_S1_summaryaalcalc/P7.bin work/il_S1_summaryleccalc/P7.bin > /dev/null & pid37=$!
+tee < fifo/il_S1_summary_P8 fifo/il_S1_eltcalc_P8 fifo/il_S1_summarycalc_P8 fifo/il_S1_pltcalc_P8 work/il_S1_summaryaalcalc/P8.bin work/il_S1_summaryleccalc/P8.bin > /dev/null & pid38=$!
+tee < fifo/il_S1_summary_P9 fifo/il_S1_eltcalc_P9 fifo/il_S1_summarycalc_P9 fifo/il_S1_pltcalc_P9 work/il_S1_summaryaalcalc/P9.bin work/il_S1_summaryleccalc/P9.bin > /dev/null & pid39=$!
+tee < fifo/il_S1_summary_P10 fifo/il_S1_eltcalc_P10 fifo/il_S1_summarycalc_P10 fifo/il_S1_pltcalc_P10 work/il_S1_summaryaalcalc/P10.bin work/il_S1_summaryleccalc/P10.bin > /dev/null & pid40=$!
+
+summarycalc -f  -1 fifo/il_S1_summary_P1 < fifo/il_P1 &
+summarycalc -f  -1 fifo/il_S1_summary_P2 < fifo/il_P2 &
+summarycalc -f  -1 fifo/il_S1_summary_P3 < fifo/il_P3 &
+summarycalc -f  -1 fifo/il_S1_summary_P4 < fifo/il_P4 &
+summarycalc -f  -1 fifo/il_S1_summary_P5 < fifo/il_P5 &
+summarycalc -f  -1 fifo/il_S1_summary_P6 < fifo/il_P6 &
+summarycalc -f  -1 fifo/il_S1_summary_P7 < fifo/il_P7 &
+summarycalc -f  -1 fifo/il_S1_summary_P8 < fifo/il_P8 &
+summarycalc -f  -1 fifo/il_S1_summary_P9 < fifo/il_P9 &
+summarycalc -f  -1 fifo/il_S1_summary_P10 < fifo/il_P10 &
+
+# --- Do ground up loss computes ---
+
+eltcalc < fifo/gul_S1_eltcalc_P1 > work/kat/gul_S1_eltcalc_P1 & pid41=$!
+summarycalctocsv < fifo/gul_S1_summarycalc_P1 > work/kat/gul_S1_summarycalc_P1 & pid42=$!
+pltcalc < fifo/gul_S1_pltcalc_P1 > work/kat/gul_S1_pltcalc_P1 & pid43=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P2 > work/kat/gul_S1_eltcalc_P2 & pid44=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P2 > work/kat/gul_S1_summarycalc_P2 & pid45=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P2 > work/kat/gul_S1_pltcalc_P2 & pid46=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P3 > work/kat/gul_S1_eltcalc_P3 & pid47=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P3 > work/kat/gul_S1_summarycalc_P3 & pid48=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P3 > work/kat/gul_S1_pltcalc_P3 & pid49=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P4 > work/kat/gul_S1_eltcalc_P4 & pid50=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P4 > work/kat/gul_S1_summarycalc_P4 & pid51=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P4 > work/kat/gul_S1_pltcalc_P4 & pid52=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P5 > work/kat/gul_S1_eltcalc_P5 & pid53=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P5 > work/kat/gul_S1_summarycalc_P5 & pid54=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P5 > work/kat/gul_S1_pltcalc_P5 & pid55=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P6 > work/kat/gul_S1_eltcalc_P6 & pid56=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P6 > work/kat/gul_S1_summarycalc_P6 & pid57=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P6 > work/kat/gul_S1_pltcalc_P6 & pid58=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P7 > work/kat/gul_S1_eltcalc_P7 & pid59=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P7 > work/kat/gul_S1_summarycalc_P7 & pid60=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P7 > work/kat/gul_S1_pltcalc_P7 & pid61=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P8 > work/kat/gul_S1_eltcalc_P8 & pid62=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P8 > work/kat/gul_S1_summarycalc_P8 & pid63=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P8 > work/kat/gul_S1_pltcalc_P8 & pid64=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P9 > work/kat/gul_S1_eltcalc_P9 & pid65=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P9 > work/kat/gul_S1_summarycalc_P9 & pid66=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P9 > work/kat/gul_S1_pltcalc_P9 & pid67=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P10 > work/kat/gul_S1_eltcalc_P10 & pid68=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P10 > work/kat/gul_S1_summarycalc_P10 & pid69=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P10 > work/kat/gul_S1_pltcalc_P10 & pid70=$!
+
+tee < fifo/gul_S1_summary_P1 fifo/gul_S1_eltcalc_P1 fifo/gul_S1_summarycalc_P1 fifo/gul_S1_pltcalc_P1 work/gul_S1_summaryaalcalc/P1.bin work/gul_S1_summaryleccalc/P1.bin > /dev/null & pid71=$!
+tee < fifo/gul_S1_summary_P2 fifo/gul_S1_eltcalc_P2 fifo/gul_S1_summarycalc_P2 fifo/gul_S1_pltcalc_P2 work/gul_S1_summaryaalcalc/P2.bin work/gul_S1_summaryleccalc/P2.bin > /dev/null & pid72=$!
+tee < fifo/gul_S1_summary_P3 fifo/gul_S1_eltcalc_P3 fifo/gul_S1_summarycalc_P3 fifo/gul_S1_pltcalc_P3 work/gul_S1_summaryaalcalc/P3.bin work/gul_S1_summaryleccalc/P3.bin > /dev/null & pid73=$!
+tee < fifo/gul_S1_summary_P4 fifo/gul_S1_eltcalc_P4 fifo/gul_S1_summarycalc_P4 fifo/gul_S1_pltcalc_P4 work/gul_S1_summaryaalcalc/P4.bin work/gul_S1_summaryleccalc/P4.bin > /dev/null & pid74=$!
+tee < fifo/gul_S1_summary_P5 fifo/gul_S1_eltcalc_P5 fifo/gul_S1_summarycalc_P5 fifo/gul_S1_pltcalc_P5 work/gul_S1_summaryaalcalc/P5.bin work/gul_S1_summaryleccalc/P5.bin > /dev/null & pid75=$!
+tee < fifo/gul_S1_summary_P6 fifo/gul_S1_eltcalc_P6 fifo/gul_S1_summarycalc_P6 fifo/gul_S1_pltcalc_P6 work/gul_S1_summaryaalcalc/P6.bin work/gul_S1_summaryleccalc/P6.bin > /dev/null & pid76=$!
+tee < fifo/gul_S1_summary_P7 fifo/gul_S1_eltcalc_P7 fifo/gul_S1_summarycalc_P7 fifo/gul_S1_pltcalc_P7 work/gul_S1_summaryaalcalc/P7.bin work/gul_S1_summaryleccalc/P7.bin > /dev/null & pid77=$!
+tee < fifo/gul_S1_summary_P8 fifo/gul_S1_eltcalc_P8 fifo/gul_S1_summarycalc_P8 fifo/gul_S1_pltcalc_P8 work/gul_S1_summaryaalcalc/P8.bin work/gul_S1_summaryleccalc/P8.bin > /dev/null & pid78=$!
+tee < fifo/gul_S1_summary_P9 fifo/gul_S1_eltcalc_P9 fifo/gul_S1_summarycalc_P9 fifo/gul_S1_pltcalc_P9 work/gul_S1_summaryaalcalc/P9.bin work/gul_S1_summaryleccalc/P9.bin > /dev/null & pid79=$!
+tee < fifo/gul_S1_summary_P10 fifo/gul_S1_eltcalc_P10 fifo/gul_S1_summarycalc_P10 fifo/gul_S1_pltcalc_P10 work/gul_S1_summaryaalcalc/P10.bin work/gul_S1_summaryleccalc/P10.bin > /dev/null & pid80=$!
+
+summarycalc -i  -1 fifo/gul_S1_summary_P1 < fifo/gul_P1 &
+summarycalc -i  -1 fifo/gul_S1_summary_P2 < fifo/gul_P2 &
+summarycalc -i  -1 fifo/gul_S1_summary_P3 < fifo/gul_P3 &
+summarycalc -i  -1 fifo/gul_S1_summary_P4 < fifo/gul_P4 &
+summarycalc -i  -1 fifo/gul_S1_summary_P5 < fifo/gul_P5 &
+summarycalc -i  -1 fifo/gul_S1_summary_P6 < fifo/gul_P6 &
+summarycalc -i  -1 fifo/gul_S1_summary_P7 < fifo/gul_P7 &
+summarycalc -i  -1 fifo/gul_S1_summary_P8 < fifo/gul_P8 &
+summarycalc -i  -1 fifo/gul_S1_summary_P9 < fifo/gul_P9 &
+summarycalc -i  -1 fifo/gul_S1_summary_P10 < fifo/gul_P10 &
+
+# --- Do insured loss computes ---
+
+eltcalc < fifo/full_correlation/il_S1_eltcalc_P1 > work/full_correlation/kat/il_S1_eltcalc_P1 & pid81=$!
+summarycalctocsv < fifo/full_correlation/il_S1_summarycalc_P1 > work/full_correlation/kat/il_S1_summarycalc_P1 & pid82=$!
+pltcalc < fifo/full_correlation/il_S1_pltcalc_P1 > work/full_correlation/kat/il_S1_pltcalc_P1 & pid83=$!
+eltcalc -s < fifo/full_correlation/il_S1_eltcalc_P2 > work/full_correlation/kat/il_S1_eltcalc_P2 & pid84=$!
+summarycalctocsv -s < fifo/full_correlation/il_S1_summarycalc_P2 > work/full_correlation/kat/il_S1_summarycalc_P2 & pid85=$!
+pltcalc -s < fifo/full_correlation/il_S1_pltcalc_P2 > work/full_correlation/kat/il_S1_pltcalc_P2 & pid86=$!
+eltcalc -s < fifo/full_correlation/il_S1_eltcalc_P3 > work/full_correlation/kat/il_S1_eltcalc_P3 & pid87=$!
+summarycalctocsv -s < fifo/full_correlation/il_S1_summarycalc_P3 > work/full_correlation/kat/il_S1_summarycalc_P3 & pid88=$!
+pltcalc -s < fifo/full_correlation/il_S1_pltcalc_P3 > work/full_correlation/kat/il_S1_pltcalc_P3 & pid89=$!
+eltcalc -s < fifo/full_correlation/il_S1_eltcalc_P4 > work/full_correlation/kat/il_S1_eltcalc_P4 & pid90=$!
+summarycalctocsv -s < fifo/full_correlation/il_S1_summarycalc_P4 > work/full_correlation/kat/il_S1_summarycalc_P4 & pid91=$!
+pltcalc -s < fifo/full_correlation/il_S1_pltcalc_P4 > work/full_correlation/kat/il_S1_pltcalc_P4 & pid92=$!
+eltcalc -s < fifo/full_correlation/il_S1_eltcalc_P5 > work/full_correlation/kat/il_S1_eltcalc_P5 & pid93=$!
+summarycalctocsv -s < fifo/full_correlation/il_S1_summarycalc_P5 > work/full_correlation/kat/il_S1_summarycalc_P5 & pid94=$!
+pltcalc -s < fifo/full_correlation/il_S1_pltcalc_P5 > work/full_correlation/kat/il_S1_pltcalc_P5 & pid95=$!
+eltcalc -s < fifo/full_correlation/il_S1_eltcalc_P6 > work/full_correlation/kat/il_S1_eltcalc_P6 & pid96=$!
+summarycalctocsv -s < fifo/full_correlation/il_S1_summarycalc_P6 > work/full_correlation/kat/il_S1_summarycalc_P6 & pid97=$!
+pltcalc -s < fifo/full_correlation/il_S1_pltcalc_P6 > work/full_correlation/kat/il_S1_pltcalc_P6 & pid98=$!
+eltcalc -s < fifo/full_correlation/il_S1_eltcalc_P7 > work/full_correlation/kat/il_S1_eltcalc_P7 & pid99=$!
+summarycalctocsv -s < fifo/full_correlation/il_S1_summarycalc_P7 > work/full_correlation/kat/il_S1_summarycalc_P7 & pid100=$!
+pltcalc -s < fifo/full_correlation/il_S1_pltcalc_P7 > work/full_correlation/kat/il_S1_pltcalc_P7 & pid101=$!
+eltcalc -s < fifo/full_correlation/il_S1_eltcalc_P8 > work/full_correlation/kat/il_S1_eltcalc_P8 & pid102=$!
+summarycalctocsv -s < fifo/full_correlation/il_S1_summarycalc_P8 > work/full_correlation/kat/il_S1_summarycalc_P8 & pid103=$!
+pltcalc -s < fifo/full_correlation/il_S1_pltcalc_P8 > work/full_correlation/kat/il_S1_pltcalc_P8 & pid104=$!
+eltcalc -s < fifo/full_correlation/il_S1_eltcalc_P9 > work/full_correlation/kat/il_S1_eltcalc_P9 & pid105=$!
+summarycalctocsv -s < fifo/full_correlation/il_S1_summarycalc_P9 > work/full_correlation/kat/il_S1_summarycalc_P9 & pid106=$!
+pltcalc -s < fifo/full_correlation/il_S1_pltcalc_P9 > work/full_correlation/kat/il_S1_pltcalc_P9 & pid107=$!
+eltcalc -s < fifo/full_correlation/il_S1_eltcalc_P10 > work/full_correlation/kat/il_S1_eltcalc_P10 & pid108=$!
+summarycalctocsv -s < fifo/full_correlation/il_S1_summarycalc_P10 > work/full_correlation/kat/il_S1_summarycalc_P10 & pid109=$!
+pltcalc -s < fifo/full_correlation/il_S1_pltcalc_P10 > work/full_correlation/kat/il_S1_pltcalc_P10 & pid110=$!
+
+tee < fifo/full_correlation/il_S1_summary_P1 fifo/full_correlation/il_S1_eltcalc_P1 fifo/full_correlation/il_S1_summarycalc_P1 fifo/full_correlation/il_S1_pltcalc_P1 work/full_correlation/il_S1_summaryaalcalc/P1.bin work/full_correlation/il_S1_summaryleccalc/P1.bin > /dev/null & pid111=$!
+tee < fifo/full_correlation/il_S1_summary_P2 fifo/full_correlation/il_S1_eltcalc_P2 fifo/full_correlation/il_S1_summarycalc_P2 fifo/full_correlation/il_S1_pltcalc_P2 work/full_correlation/il_S1_summaryaalcalc/P2.bin work/full_correlation/il_S1_summaryleccalc/P2.bin > /dev/null & pid112=$!
+tee < fifo/full_correlation/il_S1_summary_P3 fifo/full_correlation/il_S1_eltcalc_P3 fifo/full_correlation/il_S1_summarycalc_P3 fifo/full_correlation/il_S1_pltcalc_P3 work/full_correlation/il_S1_summaryaalcalc/P3.bin work/full_correlation/il_S1_summaryleccalc/P3.bin > /dev/null & pid113=$!
+tee < fifo/full_correlation/il_S1_summary_P4 fifo/full_correlation/il_S1_eltcalc_P4 fifo/full_correlation/il_S1_summarycalc_P4 fifo/full_correlation/il_S1_pltcalc_P4 work/full_correlation/il_S1_summaryaalcalc/P4.bin work/full_correlation/il_S1_summaryleccalc/P4.bin > /dev/null & pid114=$!
+tee < fifo/full_correlation/il_S1_summary_P5 fifo/full_correlation/il_S1_eltcalc_P5 fifo/full_correlation/il_S1_summarycalc_P5 fifo/full_correlation/il_S1_pltcalc_P5 work/full_correlation/il_S1_summaryaalcalc/P5.bin work/full_correlation/il_S1_summaryleccalc/P5.bin > /dev/null & pid115=$!
+tee < fifo/full_correlation/il_S1_summary_P6 fifo/full_correlation/il_S1_eltcalc_P6 fifo/full_correlation/il_S1_summarycalc_P6 fifo/full_correlation/il_S1_pltcalc_P6 work/full_correlation/il_S1_summaryaalcalc/P6.bin work/full_correlation/il_S1_summaryleccalc/P6.bin > /dev/null & pid116=$!
+tee < fifo/full_correlation/il_S1_summary_P7 fifo/full_correlation/il_S1_eltcalc_P7 fifo/full_correlation/il_S1_summarycalc_P7 fifo/full_correlation/il_S1_pltcalc_P7 work/full_correlation/il_S1_summaryaalcalc/P7.bin work/full_correlation/il_S1_summaryleccalc/P7.bin > /dev/null & pid117=$!
+tee < fifo/full_correlation/il_S1_summary_P8 fifo/full_correlation/il_S1_eltcalc_P8 fifo/full_correlation/il_S1_summarycalc_P8 fifo/full_correlation/il_S1_pltcalc_P8 work/full_correlation/il_S1_summaryaalcalc/P8.bin work/full_correlation/il_S1_summaryleccalc/P8.bin > /dev/null & pid118=$!
+tee < fifo/full_correlation/il_S1_summary_P9 fifo/full_correlation/il_S1_eltcalc_P9 fifo/full_correlation/il_S1_summarycalc_P9 fifo/full_correlation/il_S1_pltcalc_P9 work/full_correlation/il_S1_summaryaalcalc/P9.bin work/full_correlation/il_S1_summaryleccalc/P9.bin > /dev/null & pid119=$!
+tee < fifo/full_correlation/il_S1_summary_P10 fifo/full_correlation/il_S1_eltcalc_P10 fifo/full_correlation/il_S1_summarycalc_P10 fifo/full_correlation/il_S1_pltcalc_P10 work/full_correlation/il_S1_summaryaalcalc/P10.bin work/full_correlation/il_S1_summaryleccalc/P10.bin > /dev/null & pid120=$!
+
+summarycalc -f  -1 fifo/full_correlation/il_S1_summary_P1 < fifo/full_correlation/il_P1 &
+summarycalc -f  -1 fifo/full_correlation/il_S1_summary_P2 < fifo/full_correlation/il_P2 &
+summarycalc -f  -1 fifo/full_correlation/il_S1_summary_P3 < fifo/full_correlation/il_P3 &
+summarycalc -f  -1 fifo/full_correlation/il_S1_summary_P4 < fifo/full_correlation/il_P4 &
+summarycalc -f  -1 fifo/full_correlation/il_S1_summary_P5 < fifo/full_correlation/il_P5 &
+summarycalc -f  -1 fifo/full_correlation/il_S1_summary_P6 < fifo/full_correlation/il_P6 &
+summarycalc -f  -1 fifo/full_correlation/il_S1_summary_P7 < fifo/full_correlation/il_P7 &
+summarycalc -f  -1 fifo/full_correlation/il_S1_summary_P8 < fifo/full_correlation/il_P8 &
+summarycalc -f  -1 fifo/full_correlation/il_S1_summary_P9 < fifo/full_correlation/il_P9 &
+summarycalc -f  -1 fifo/full_correlation/il_S1_summary_P10 < fifo/full_correlation/il_P10 &
+
+# --- Do ground up loss computes ---
+
+eltcalc < fifo/full_correlation/gul_S1_eltcalc_P1 > work/full_correlation/kat/gul_S1_eltcalc_P1 & pid121=$!
+summarycalctocsv < fifo/full_correlation/gul_S1_summarycalc_P1 > work/full_correlation/kat/gul_S1_summarycalc_P1 & pid122=$!
+pltcalc < fifo/full_correlation/gul_S1_pltcalc_P1 > work/full_correlation/kat/gul_S1_pltcalc_P1 & pid123=$!
+eltcalc -s < fifo/full_correlation/gul_S1_eltcalc_P2 > work/full_correlation/kat/gul_S1_eltcalc_P2 & pid124=$!
+summarycalctocsv -s < fifo/full_correlation/gul_S1_summarycalc_P2 > work/full_correlation/kat/gul_S1_summarycalc_P2 & pid125=$!
+pltcalc -s < fifo/full_correlation/gul_S1_pltcalc_P2 > work/full_correlation/kat/gul_S1_pltcalc_P2 & pid126=$!
+eltcalc -s < fifo/full_correlation/gul_S1_eltcalc_P3 > work/full_correlation/kat/gul_S1_eltcalc_P3 & pid127=$!
+summarycalctocsv -s < fifo/full_correlation/gul_S1_summarycalc_P3 > work/full_correlation/kat/gul_S1_summarycalc_P3 & pid128=$!
+pltcalc -s < fifo/full_correlation/gul_S1_pltcalc_P3 > work/full_correlation/kat/gul_S1_pltcalc_P3 & pid129=$!
+eltcalc -s < fifo/full_correlation/gul_S1_eltcalc_P4 > work/full_correlation/kat/gul_S1_eltcalc_P4 & pid130=$!
+summarycalctocsv -s < fifo/full_correlation/gul_S1_summarycalc_P4 > work/full_correlation/kat/gul_S1_summarycalc_P4 & pid131=$!
+pltcalc -s < fifo/full_correlation/gul_S1_pltcalc_P4 > work/full_correlation/kat/gul_S1_pltcalc_P4 & pid132=$!
+eltcalc -s < fifo/full_correlation/gul_S1_eltcalc_P5 > work/full_correlation/kat/gul_S1_eltcalc_P5 & pid133=$!
+summarycalctocsv -s < fifo/full_correlation/gul_S1_summarycalc_P5 > work/full_correlation/kat/gul_S1_summarycalc_P5 & pid134=$!
+pltcalc -s < fifo/full_correlation/gul_S1_pltcalc_P5 > work/full_correlation/kat/gul_S1_pltcalc_P5 & pid135=$!
+eltcalc -s < fifo/full_correlation/gul_S1_eltcalc_P6 > work/full_correlation/kat/gul_S1_eltcalc_P6 & pid136=$!
+summarycalctocsv -s < fifo/full_correlation/gul_S1_summarycalc_P6 > work/full_correlation/kat/gul_S1_summarycalc_P6 & pid137=$!
+pltcalc -s < fifo/full_correlation/gul_S1_pltcalc_P6 > work/full_correlation/kat/gul_S1_pltcalc_P6 & pid138=$!
+eltcalc -s < fifo/full_correlation/gul_S1_eltcalc_P7 > work/full_correlation/kat/gul_S1_eltcalc_P7 & pid139=$!
+summarycalctocsv -s < fifo/full_correlation/gul_S1_summarycalc_P7 > work/full_correlation/kat/gul_S1_summarycalc_P7 & pid140=$!
+pltcalc -s < fifo/full_correlation/gul_S1_pltcalc_P7 > work/full_correlation/kat/gul_S1_pltcalc_P7 & pid141=$!
+eltcalc -s < fifo/full_correlation/gul_S1_eltcalc_P8 > work/full_correlation/kat/gul_S1_eltcalc_P8 & pid142=$!
+summarycalctocsv -s < fifo/full_correlation/gul_S1_summarycalc_P8 > work/full_correlation/kat/gul_S1_summarycalc_P8 & pid143=$!
+pltcalc -s < fifo/full_correlation/gul_S1_pltcalc_P8 > work/full_correlation/kat/gul_S1_pltcalc_P8 & pid144=$!
+eltcalc -s < fifo/full_correlation/gul_S1_eltcalc_P9 > work/full_correlation/kat/gul_S1_eltcalc_P9 & pid145=$!
+summarycalctocsv -s < fifo/full_correlation/gul_S1_summarycalc_P9 > work/full_correlation/kat/gul_S1_summarycalc_P9 & pid146=$!
+pltcalc -s < fifo/full_correlation/gul_S1_pltcalc_P9 > work/full_correlation/kat/gul_S1_pltcalc_P9 & pid147=$!
+eltcalc -s < fifo/full_correlation/gul_S1_eltcalc_P10 > work/full_correlation/kat/gul_S1_eltcalc_P10 & pid148=$!
+summarycalctocsv -s < fifo/full_correlation/gul_S1_summarycalc_P10 > work/full_correlation/kat/gul_S1_summarycalc_P10 & pid149=$!
+pltcalc -s < fifo/full_correlation/gul_S1_pltcalc_P10 > work/full_correlation/kat/gul_S1_pltcalc_P10 & pid150=$!
+
+tee < fifo/full_correlation/gul_S1_summary_P1 fifo/full_correlation/gul_S1_eltcalc_P1 fifo/full_correlation/gul_S1_summarycalc_P1 fifo/full_correlation/gul_S1_pltcalc_P1 work/full_correlation/gul_S1_summaryaalcalc/P1.bin work/full_correlation/gul_S1_summaryleccalc/P1.bin > /dev/null & pid151=$!
+tee < fifo/full_correlation/gul_S1_summary_P2 fifo/full_correlation/gul_S1_eltcalc_P2 fifo/full_correlation/gul_S1_summarycalc_P2 fifo/full_correlation/gul_S1_pltcalc_P2 work/full_correlation/gul_S1_summaryaalcalc/P2.bin work/full_correlation/gul_S1_summaryleccalc/P2.bin > /dev/null & pid152=$!
+tee < fifo/full_correlation/gul_S1_summary_P3 fifo/full_correlation/gul_S1_eltcalc_P3 fifo/full_correlation/gul_S1_summarycalc_P3 fifo/full_correlation/gul_S1_pltcalc_P3 work/full_correlation/gul_S1_summaryaalcalc/P3.bin work/full_correlation/gul_S1_summaryleccalc/P3.bin > /dev/null & pid153=$!
+tee < fifo/full_correlation/gul_S1_summary_P4 fifo/full_correlation/gul_S1_eltcalc_P4 fifo/full_correlation/gul_S1_summarycalc_P4 fifo/full_correlation/gul_S1_pltcalc_P4 work/full_correlation/gul_S1_summaryaalcalc/P4.bin work/full_correlation/gul_S1_summaryleccalc/P4.bin > /dev/null & pid154=$!
+tee < fifo/full_correlation/gul_S1_summary_P5 fifo/full_correlation/gul_S1_eltcalc_P5 fifo/full_correlation/gul_S1_summarycalc_P5 fifo/full_correlation/gul_S1_pltcalc_P5 work/full_correlation/gul_S1_summaryaalcalc/P5.bin work/full_correlation/gul_S1_summaryleccalc/P5.bin > /dev/null & pid155=$!
+tee < fifo/full_correlation/gul_S1_summary_P6 fifo/full_correlation/gul_S1_eltcalc_P6 fifo/full_correlation/gul_S1_summarycalc_P6 fifo/full_correlation/gul_S1_pltcalc_P6 work/full_correlation/gul_S1_summaryaalcalc/P6.bin work/full_correlation/gul_S1_summaryleccalc/P6.bin > /dev/null & pid156=$!
+tee < fifo/full_correlation/gul_S1_summary_P7 fifo/full_correlation/gul_S1_eltcalc_P7 fifo/full_correlation/gul_S1_summarycalc_P7 fifo/full_correlation/gul_S1_pltcalc_P7 work/full_correlation/gul_S1_summaryaalcalc/P7.bin work/full_correlation/gul_S1_summaryleccalc/P7.bin > /dev/null & pid157=$!
+tee < fifo/full_correlation/gul_S1_summary_P8 fifo/full_correlation/gul_S1_eltcalc_P8 fifo/full_correlation/gul_S1_summarycalc_P8 fifo/full_correlation/gul_S1_pltcalc_P8 work/full_correlation/gul_S1_summaryaalcalc/P8.bin work/full_correlation/gul_S1_summaryleccalc/P8.bin > /dev/null & pid158=$!
+tee < fifo/full_correlation/gul_S1_summary_P9 fifo/full_correlation/gul_S1_eltcalc_P9 fifo/full_correlation/gul_S1_summarycalc_P9 fifo/full_correlation/gul_S1_pltcalc_P9 work/full_correlation/gul_S1_summaryaalcalc/P9.bin work/full_correlation/gul_S1_summaryleccalc/P9.bin > /dev/null & pid159=$!
+tee < fifo/full_correlation/gul_S1_summary_P10 fifo/full_correlation/gul_S1_eltcalc_P10 fifo/full_correlation/gul_S1_summarycalc_P10 fifo/full_correlation/gul_S1_pltcalc_P10 work/full_correlation/gul_S1_summaryaalcalc/P10.bin work/full_correlation/gul_S1_summaryleccalc/P10.bin > /dev/null & pid160=$!
+
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P1 < fifo/full_correlation/gul_P1 &
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P2 < fifo/full_correlation/gul_P2 &
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P3 < fifo/full_correlation/gul_P3 &
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P4 < fifo/full_correlation/gul_P4 &
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P5 < fifo/full_correlation/gul_P5 &
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P6 < fifo/full_correlation/gul_P6 &
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P7 < fifo/full_correlation/gul_P7 &
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P8 < fifo/full_correlation/gul_P8 &
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P9 < fifo/full_correlation/gul_P9 &
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P10 < fifo/full_correlation/gul_P10 &
+
+tee < fifo/full_correlation/gul_fc_P1 fifo/full_correlation/gul_P1  | fmcalc -a2 > fifo/full_correlation/il_P1  &
+tee < fifo/full_correlation/gul_fc_P2 fifo/full_correlation/gul_P2  | fmcalc -a2 > fifo/full_correlation/il_P2  &
+tee < fifo/full_correlation/gul_fc_P3 fifo/full_correlation/gul_P3  | fmcalc -a2 > fifo/full_correlation/il_P3  &
+tee < fifo/full_correlation/gul_fc_P4 fifo/full_correlation/gul_P4  | fmcalc -a2 > fifo/full_correlation/il_P4  &
+tee < fifo/full_correlation/gul_fc_P5 fifo/full_correlation/gul_P5  | fmcalc -a2 > fifo/full_correlation/il_P5  &
+tee < fifo/full_correlation/gul_fc_P6 fifo/full_correlation/gul_P6  | fmcalc -a2 > fifo/full_correlation/il_P6  &
+tee < fifo/full_correlation/gul_fc_P7 fifo/full_correlation/gul_P7  | fmcalc -a2 > fifo/full_correlation/il_P7  &
+tee < fifo/full_correlation/gul_fc_P8 fifo/full_correlation/gul_P8  | fmcalc -a2 > fifo/full_correlation/il_P8  &
+tee < fifo/full_correlation/gul_fc_P9 fifo/full_correlation/gul_P9  | fmcalc -a2 > fifo/full_correlation/il_P9  &
+tee < fifo/full_correlation/gul_fc_P10 fifo/full_correlation/gul_P10  | fmcalc -a2 > fifo/full_correlation/il_P10  &
+eve 1 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_fc_P1 -a1 -i - | tee fifo/gul_P1 | fmcalc -a2 > fifo/il_P1  &
+eve 2 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_fc_P2 -a1 -i - | tee fifo/gul_P2 | fmcalc -a2 > fifo/il_P2  &
+eve 3 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_fc_P3 -a1 -i - | tee fifo/gul_P3 | fmcalc -a2 > fifo/il_P3  &
+eve 4 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_fc_P4 -a1 -i - | tee fifo/gul_P4 | fmcalc -a2 > fifo/il_P4  &
+eve 5 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_fc_P5 -a1 -i - | tee fifo/gul_P5 | fmcalc -a2 > fifo/il_P5  &
+eve 6 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_fc_P6 -a1 -i - | tee fifo/gul_P6 | fmcalc -a2 > fifo/il_P6  &
+eve 7 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_fc_P7 -a1 -i - | tee fifo/gul_P7 | fmcalc -a2 > fifo/il_P7  &
+eve 8 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_fc_P8 -a1 -i - | tee fifo/gul_P8 | fmcalc -a2 > fifo/il_P8  &
+eve 9 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_fc_P9 -a1 -i - | tee fifo/gul_P9 | fmcalc -a2 > fifo/il_P9  &
+eve 10 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_fc_P10 -a1 -i - | tee fifo/gul_P10 | fmcalc -a2 > fifo/il_P10  &
+
+wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 $pid13 $pid14 $pid15 $pid16 $pid17 $pid18 $pid19 $pid20 $pid21 $pid22 $pid23 $pid24 $pid25 $pid26 $pid27 $pid28 $pid29 $pid30 $pid31 $pid32 $pid33 $pid34 $pid35 $pid36 $pid37 $pid38 $pid39 $pid40 $pid41 $pid42 $pid43 $pid44 $pid45 $pid46 $pid47 $pid48 $pid49 $pid50 $pid51 $pid52 $pid53 $pid54 $pid55 $pid56 $pid57 $pid58 $pid59 $pid60 $pid61 $pid62 $pid63 $pid64 $pid65 $pid66 $pid67 $pid68 $pid69 $pid70 $pid71 $pid72 $pid73 $pid74 $pid75 $pid76 $pid77 $pid78 $pid79 $pid80 $pid81 $pid82 $pid83 $pid84 $pid85 $pid86 $pid87 $pid88 $pid89 $pid90 $pid91 $pid92 $pid93 $pid94 $pid95 $pid96 $pid97 $pid98 $pid99 $pid100 $pid101 $pid102 $pid103 $pid104 $pid105 $pid106 $pid107 $pid108 $pid109 $pid110 $pid111 $pid112 $pid113 $pid114 $pid115 $pid116 $pid117 $pid118 $pid119 $pid120 $pid121 $pid122 $pid123 $pid124 $pid125 $pid126 $pid127 $pid128 $pid129 $pid130 $pid131 $pid132 $pid133 $pid134 $pid135 $pid136 $pid137 $pid138 $pid139 $pid140 $pid141 $pid142 $pid143 $pid144 $pid145 $pid146 $pid147 $pid148 $pid149 $pid150 $pid151 $pid152 $pid153 $pid154 $pid155 $pid156 $pid157 $pid158 $pid159 $pid160
+
+
+# --- Do insured loss kats ---
+
+kat -s work/kat/il_S1_eltcalc_P1 work/kat/il_S1_eltcalc_P2 work/kat/il_S1_eltcalc_P3 work/kat/il_S1_eltcalc_P4 work/kat/il_S1_eltcalc_P5 work/kat/il_S1_eltcalc_P6 work/kat/il_S1_eltcalc_P7 work/kat/il_S1_eltcalc_P8 work/kat/il_S1_eltcalc_P9 work/kat/il_S1_eltcalc_P10 > output/il_S1_eltcalc.csv & kpid1=$!
+kat work/kat/il_S1_pltcalc_P1 work/kat/il_S1_pltcalc_P2 work/kat/il_S1_pltcalc_P3 work/kat/il_S1_pltcalc_P4 work/kat/il_S1_pltcalc_P5 work/kat/il_S1_pltcalc_P6 work/kat/il_S1_pltcalc_P7 work/kat/il_S1_pltcalc_P8 work/kat/il_S1_pltcalc_P9 work/kat/il_S1_pltcalc_P10 > output/il_S1_pltcalc.csv & kpid2=$!
+kat work/kat/il_S1_summarycalc_P1 work/kat/il_S1_summarycalc_P2 work/kat/il_S1_summarycalc_P3 work/kat/il_S1_summarycalc_P4 work/kat/il_S1_summarycalc_P5 work/kat/il_S1_summarycalc_P6 work/kat/il_S1_summarycalc_P7 work/kat/il_S1_summarycalc_P8 work/kat/il_S1_summarycalc_P9 work/kat/il_S1_summarycalc_P10 > output/il_S1_summarycalc.csv & kpid3=$!
+
+# --- Do insured loss kats for fully correlated output ---
+
+kat -s work/full_correlation/kat/il_S1_eltcalc_P1 work/full_correlation/kat/il_S1_eltcalc_P2 work/full_correlation/kat/il_S1_eltcalc_P3 work/full_correlation/kat/il_S1_eltcalc_P4 work/full_correlation/kat/il_S1_eltcalc_P5 work/full_correlation/kat/il_S1_eltcalc_P6 work/full_correlation/kat/il_S1_eltcalc_P7 work/full_correlation/kat/il_S1_eltcalc_P8 work/full_correlation/kat/il_S1_eltcalc_P9 work/full_correlation/kat/il_S1_eltcalc_P10 > output/full_correlation/il_S1_eltcalc.csv & kpid4=$!
+kat work/full_correlation/kat/il_S1_pltcalc_P1 work/full_correlation/kat/il_S1_pltcalc_P2 work/full_correlation/kat/il_S1_pltcalc_P3 work/full_correlation/kat/il_S1_pltcalc_P4 work/full_correlation/kat/il_S1_pltcalc_P5 work/full_correlation/kat/il_S1_pltcalc_P6 work/full_correlation/kat/il_S1_pltcalc_P7 work/full_correlation/kat/il_S1_pltcalc_P8 work/full_correlation/kat/il_S1_pltcalc_P9 work/full_correlation/kat/il_S1_pltcalc_P10 > output/full_correlation/il_S1_pltcalc.csv & kpid5=$!
+kat work/full_correlation/kat/il_S1_summarycalc_P1 work/full_correlation/kat/il_S1_summarycalc_P2 work/full_correlation/kat/il_S1_summarycalc_P3 work/full_correlation/kat/il_S1_summarycalc_P4 work/full_correlation/kat/il_S1_summarycalc_P5 work/full_correlation/kat/il_S1_summarycalc_P6 work/full_correlation/kat/il_S1_summarycalc_P7 work/full_correlation/kat/il_S1_summarycalc_P8 work/full_correlation/kat/il_S1_summarycalc_P9 work/full_correlation/kat/il_S1_summarycalc_P10 > output/full_correlation/il_S1_summarycalc.csv & kpid6=$!
+
+# --- Do ground up loss kats ---
+
+kat -s work/kat/gul_S1_eltcalc_P1 work/kat/gul_S1_eltcalc_P2 work/kat/gul_S1_eltcalc_P3 work/kat/gul_S1_eltcalc_P4 work/kat/gul_S1_eltcalc_P5 work/kat/gul_S1_eltcalc_P6 work/kat/gul_S1_eltcalc_P7 work/kat/gul_S1_eltcalc_P8 work/kat/gul_S1_eltcalc_P9 work/kat/gul_S1_eltcalc_P10 > output/gul_S1_eltcalc.csv & kpid7=$!
+kat work/kat/gul_S1_pltcalc_P1 work/kat/gul_S1_pltcalc_P2 work/kat/gul_S1_pltcalc_P3 work/kat/gul_S1_pltcalc_P4 work/kat/gul_S1_pltcalc_P5 work/kat/gul_S1_pltcalc_P6 work/kat/gul_S1_pltcalc_P7 work/kat/gul_S1_pltcalc_P8 work/kat/gul_S1_pltcalc_P9 work/kat/gul_S1_pltcalc_P10 > output/gul_S1_pltcalc.csv & kpid8=$!
+kat work/kat/gul_S1_summarycalc_P1 work/kat/gul_S1_summarycalc_P2 work/kat/gul_S1_summarycalc_P3 work/kat/gul_S1_summarycalc_P4 work/kat/gul_S1_summarycalc_P5 work/kat/gul_S1_summarycalc_P6 work/kat/gul_S1_summarycalc_P7 work/kat/gul_S1_summarycalc_P8 work/kat/gul_S1_summarycalc_P9 work/kat/gul_S1_summarycalc_P10 > output/gul_S1_summarycalc.csv & kpid9=$!
+
+# --- Do ground up loss kats for fully correlated output ---
+
+kat -s work/full_correlation/kat/gul_S1_eltcalc_P1 work/full_correlation/kat/gul_S1_eltcalc_P2 work/full_correlation/kat/gul_S1_eltcalc_P3 work/full_correlation/kat/gul_S1_eltcalc_P4 work/full_correlation/kat/gul_S1_eltcalc_P5 work/full_correlation/kat/gul_S1_eltcalc_P6 work/full_correlation/kat/gul_S1_eltcalc_P7 work/full_correlation/kat/gul_S1_eltcalc_P8 work/full_correlation/kat/gul_S1_eltcalc_P9 work/full_correlation/kat/gul_S1_eltcalc_P10 > output/full_correlation/gul_S1_eltcalc.csv & kpid10=$!
+kat work/full_correlation/kat/gul_S1_pltcalc_P1 work/full_correlation/kat/gul_S1_pltcalc_P2 work/full_correlation/kat/gul_S1_pltcalc_P3 work/full_correlation/kat/gul_S1_pltcalc_P4 work/full_correlation/kat/gul_S1_pltcalc_P5 work/full_correlation/kat/gul_S1_pltcalc_P6 work/full_correlation/kat/gul_S1_pltcalc_P7 work/full_correlation/kat/gul_S1_pltcalc_P8 work/full_correlation/kat/gul_S1_pltcalc_P9 work/full_correlation/kat/gul_S1_pltcalc_P10 > output/full_correlation/gul_S1_pltcalc.csv & kpid11=$!
+kat work/full_correlation/kat/gul_S1_summarycalc_P1 work/full_correlation/kat/gul_S1_summarycalc_P2 work/full_correlation/kat/gul_S1_summarycalc_P3 work/full_correlation/kat/gul_S1_summarycalc_P4 work/full_correlation/kat/gul_S1_summarycalc_P5 work/full_correlation/kat/gul_S1_summarycalc_P6 work/full_correlation/kat/gul_S1_summarycalc_P7 work/full_correlation/kat/gul_S1_summarycalc_P8 work/full_correlation/kat/gul_S1_summarycalc_P9 work/full_correlation/kat/gul_S1_summarycalc_P10 > output/full_correlation/gul_S1_summarycalc.csv & kpid12=$!
+wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpid11 $kpid12
+
+
+aalcalc -Kil_S1_summaryaalcalc > output/il_S1_aalcalc.csv & lpid1=$!
+ordleccalc -r -Kil_S1_summaryleccalc -W -w -o output/il_S1_psept.csv & lpid2=$!
+leccalc -r -Kil_S1_summaryleccalc -F output/il_S1_leccalc_full_uncertainty_aep.csv -f output/il_S1_leccalc_full_uncertainty_oep.csv -S output/il_S1_leccalc_sample_mean_aep.csv -s output/il_S1_leccalc_sample_mean_oep.csv -W output/il_S1_leccalc_wheatsheaf_aep.csv -M output/il_S1_leccalc_wheatsheaf_mean_aep.csv -m output/il_S1_leccalc_wheatsheaf_mean_oep.csv -w output/il_S1_leccalc_wheatsheaf_oep.csv & lpid3=$!
+aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv & lpid4=$!
+ordleccalc  -Kgul_S1_summaryleccalc -W -w -o output/gul_S1_psept.csv & lpid5=$!
+leccalc -r -Kgul_S1_summaryleccalc -F output/gul_S1_leccalc_full_uncertainty_aep.csv -f output/gul_S1_leccalc_full_uncertainty_oep.csv -S output/gul_S1_leccalc_sample_mean_aep.csv -s output/gul_S1_leccalc_sample_mean_oep.csv -W output/gul_S1_leccalc_wheatsheaf_aep.csv -M output/gul_S1_leccalc_wheatsheaf_mean_aep.csv -m output/gul_S1_leccalc_wheatsheaf_mean_oep.csv -w output/gul_S1_leccalc_wheatsheaf_oep.csv & lpid6=$!
+aalcalc -Kfull_correlation/il_S1_summaryaalcalc > output/full_correlation/il_S1_aalcalc.csv & lpid7=$!
+ordleccalc -r -Kfull_correlation/il_S1_summaryleccalc -W -w -o output/full_correlation/il_S1_psept.csv & lpid8=$!
+leccalc -r -Kfull_correlation/il_S1_summaryleccalc -F output/full_correlation/il_S1_leccalc_full_uncertainty_aep.csv -f output/full_correlation/il_S1_leccalc_full_uncertainty_oep.csv -S output/full_correlation/il_S1_leccalc_sample_mean_aep.csv -s output/full_correlation/il_S1_leccalc_sample_mean_oep.csv -W output/full_correlation/il_S1_leccalc_wheatsheaf_aep.csv -M output/full_correlation/il_S1_leccalc_wheatsheaf_mean_aep.csv -m output/full_correlation/il_S1_leccalc_wheatsheaf_mean_oep.csv -w output/full_correlation/il_S1_leccalc_wheatsheaf_oep.csv & lpid9=$!
+aalcalc -Kfull_correlation/gul_S1_summaryaalcalc > output/full_correlation/gul_S1_aalcalc.csv & lpid10=$!
+ordleccalc  -Kfull_correlation/gul_S1_summaryleccalc -W -w -o output/full_correlation/gul_S1_psept.csv & lpid11=$!
+leccalc -r -Kfull_correlation/gul_S1_summaryleccalc -F output/full_correlation/gul_S1_leccalc_full_uncertainty_aep.csv -f output/full_correlation/gul_S1_leccalc_full_uncertainty_oep.csv -S output/full_correlation/gul_S1_leccalc_sample_mean_aep.csv -s output/full_correlation/gul_S1_leccalc_sample_mean_oep.csv -W output/full_correlation/gul_S1_leccalc_wheatsheaf_aep.csv -M output/full_correlation/gul_S1_leccalc_wheatsheaf_mean_aep.csv -m output/full_correlation/gul_S1_leccalc_wheatsheaf_mean_oep.csv -w output/full_correlation/gul_S1_leccalc_wheatsheaf_oep.csv & lpid12=$!
+wait $lpid1 $lpid2 $lpid3 $lpid4 $lpid5 $lpid6 $lpid7 $lpid8 $lpid9 $lpid10 $lpid11 $lpid12
+
+rm -R -f work/*
+rm -R -f fifo/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_ord_ept_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_ord_ept_1_output_1_partition.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+mkdir output/full_correlation/
+
+rm -R -f fifo/*
+mkdir fifo/full_correlation/
+rm -R -f work/*
+mkdir work/kat/
+mkdir work/full_correlation/
+mkdir work/full_correlation/kat/
+
+mkdir work/gul_S1_summaryleccalc
+mkdir work/full_correlation/gul_S1_summaryleccalc
+
+mkfifo fifo/gul_P1
+
+mkfifo fifo/gul_S1_summary_P1
+
+mkfifo fifo/full_correlation/gul_P1
+
+mkfifo fifo/full_correlation/gul_S1_summary_P1
+
+
+
+# --- Do ground up loss computes ---
+
+
+tee < fifo/gul_S1_summary_P1 work/gul_S1_summaryleccalc/P1.bin > /dev/null & pid1=$!
+
+summarycalc -i  -1 fifo/gul_S1_summary_P1 < fifo/gul_P1 &
+
+# --- Do ground up loss computes ---
+
+
+tee < fifo/full_correlation/gul_S1_summary_P1 work/full_correlation/gul_S1_summaryleccalc/P1.bin > /dev/null & pid2=$!
+
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P1 < fifo/full_correlation/gul_P1 &
+
+eve 1 1 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P1 -a1 -i - > fifo/gul_P1  &
+
+wait $pid1 $pid2
+
+
+# --- Do ground up loss kats ---
+
+
+# --- Do ground up loss kats for fully correlated output ---
+
+
+ordleccalc -r -Kgul_S1_summaryleccalc -F -f -S -s -M -m -O output/gul_S1_ept.csv & lpid1=$!
+ordleccalc -r -Kfull_correlation/gul_S1_summaryleccalc -F -f -S -s -M -m -O output/full_correlation/gul_S1_ept.csv & lpid2=$!
+wait $lpid1 $lpid2
+
+rm -R -f work/*
+rm -R -f fifo/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_ord_ept_1_output_20_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_ord_ept_1_output_20_partition.sh
@@ -1,0 +1,275 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+mkdir output/full_correlation/
+
+rm -R -f fifo/*
+mkdir fifo/full_correlation/
+rm -R -f work/*
+mkdir work/kat/
+mkdir work/full_correlation/
+mkdir work/full_correlation/kat/
+
+mkdir work/gul_S1_summaryleccalc
+mkdir work/full_correlation/gul_S1_summaryleccalc
+
+mkfifo fifo/gul_P1
+mkfifo fifo/gul_P2
+mkfifo fifo/gul_P3
+mkfifo fifo/gul_P4
+mkfifo fifo/gul_P5
+mkfifo fifo/gul_P6
+mkfifo fifo/gul_P7
+mkfifo fifo/gul_P8
+mkfifo fifo/gul_P9
+mkfifo fifo/gul_P10
+mkfifo fifo/gul_P11
+mkfifo fifo/gul_P12
+mkfifo fifo/gul_P13
+mkfifo fifo/gul_P14
+mkfifo fifo/gul_P15
+mkfifo fifo/gul_P16
+mkfifo fifo/gul_P17
+mkfifo fifo/gul_P18
+mkfifo fifo/gul_P19
+mkfifo fifo/gul_P20
+
+mkfifo fifo/gul_S1_summary_P1
+
+mkfifo fifo/gul_S1_summary_P2
+
+mkfifo fifo/gul_S1_summary_P3
+
+mkfifo fifo/gul_S1_summary_P4
+
+mkfifo fifo/gul_S1_summary_P5
+
+mkfifo fifo/gul_S1_summary_P6
+
+mkfifo fifo/gul_S1_summary_P7
+
+mkfifo fifo/gul_S1_summary_P8
+
+mkfifo fifo/gul_S1_summary_P9
+
+mkfifo fifo/gul_S1_summary_P10
+
+mkfifo fifo/gul_S1_summary_P11
+
+mkfifo fifo/gul_S1_summary_P12
+
+mkfifo fifo/gul_S1_summary_P13
+
+mkfifo fifo/gul_S1_summary_P14
+
+mkfifo fifo/gul_S1_summary_P15
+
+mkfifo fifo/gul_S1_summary_P16
+
+mkfifo fifo/gul_S1_summary_P17
+
+mkfifo fifo/gul_S1_summary_P18
+
+mkfifo fifo/gul_S1_summary_P19
+
+mkfifo fifo/gul_S1_summary_P20
+
+mkfifo fifo/full_correlation/gul_P1
+mkfifo fifo/full_correlation/gul_P2
+mkfifo fifo/full_correlation/gul_P3
+mkfifo fifo/full_correlation/gul_P4
+mkfifo fifo/full_correlation/gul_P5
+mkfifo fifo/full_correlation/gul_P6
+mkfifo fifo/full_correlation/gul_P7
+mkfifo fifo/full_correlation/gul_P8
+mkfifo fifo/full_correlation/gul_P9
+mkfifo fifo/full_correlation/gul_P10
+mkfifo fifo/full_correlation/gul_P11
+mkfifo fifo/full_correlation/gul_P12
+mkfifo fifo/full_correlation/gul_P13
+mkfifo fifo/full_correlation/gul_P14
+mkfifo fifo/full_correlation/gul_P15
+mkfifo fifo/full_correlation/gul_P16
+mkfifo fifo/full_correlation/gul_P17
+mkfifo fifo/full_correlation/gul_P18
+mkfifo fifo/full_correlation/gul_P19
+mkfifo fifo/full_correlation/gul_P20
+
+mkfifo fifo/full_correlation/gul_S1_summary_P1
+
+mkfifo fifo/full_correlation/gul_S1_summary_P2
+
+mkfifo fifo/full_correlation/gul_S1_summary_P3
+
+mkfifo fifo/full_correlation/gul_S1_summary_P4
+
+mkfifo fifo/full_correlation/gul_S1_summary_P5
+
+mkfifo fifo/full_correlation/gul_S1_summary_P6
+
+mkfifo fifo/full_correlation/gul_S1_summary_P7
+
+mkfifo fifo/full_correlation/gul_S1_summary_P8
+
+mkfifo fifo/full_correlation/gul_S1_summary_P9
+
+mkfifo fifo/full_correlation/gul_S1_summary_P10
+
+mkfifo fifo/full_correlation/gul_S1_summary_P11
+
+mkfifo fifo/full_correlation/gul_S1_summary_P12
+
+mkfifo fifo/full_correlation/gul_S1_summary_P13
+
+mkfifo fifo/full_correlation/gul_S1_summary_P14
+
+mkfifo fifo/full_correlation/gul_S1_summary_P15
+
+mkfifo fifo/full_correlation/gul_S1_summary_P16
+
+mkfifo fifo/full_correlation/gul_S1_summary_P17
+
+mkfifo fifo/full_correlation/gul_S1_summary_P18
+
+mkfifo fifo/full_correlation/gul_S1_summary_P19
+
+mkfifo fifo/full_correlation/gul_S1_summary_P20
+
+
+
+# --- Do ground up loss computes ---
+
+
+tee < fifo/gul_S1_summary_P1 work/gul_S1_summaryleccalc/P1.bin > /dev/null & pid1=$!
+tee < fifo/gul_S1_summary_P2 work/gul_S1_summaryleccalc/P2.bin > /dev/null & pid2=$!
+tee < fifo/gul_S1_summary_P3 work/gul_S1_summaryleccalc/P3.bin > /dev/null & pid3=$!
+tee < fifo/gul_S1_summary_P4 work/gul_S1_summaryleccalc/P4.bin > /dev/null & pid4=$!
+tee < fifo/gul_S1_summary_P5 work/gul_S1_summaryleccalc/P5.bin > /dev/null & pid5=$!
+tee < fifo/gul_S1_summary_P6 work/gul_S1_summaryleccalc/P6.bin > /dev/null & pid6=$!
+tee < fifo/gul_S1_summary_P7 work/gul_S1_summaryleccalc/P7.bin > /dev/null & pid7=$!
+tee < fifo/gul_S1_summary_P8 work/gul_S1_summaryleccalc/P8.bin > /dev/null & pid8=$!
+tee < fifo/gul_S1_summary_P9 work/gul_S1_summaryleccalc/P9.bin > /dev/null & pid9=$!
+tee < fifo/gul_S1_summary_P10 work/gul_S1_summaryleccalc/P10.bin > /dev/null & pid10=$!
+tee < fifo/gul_S1_summary_P11 work/gul_S1_summaryleccalc/P11.bin > /dev/null & pid11=$!
+tee < fifo/gul_S1_summary_P12 work/gul_S1_summaryleccalc/P12.bin > /dev/null & pid12=$!
+tee < fifo/gul_S1_summary_P13 work/gul_S1_summaryleccalc/P13.bin > /dev/null & pid13=$!
+tee < fifo/gul_S1_summary_P14 work/gul_S1_summaryleccalc/P14.bin > /dev/null & pid14=$!
+tee < fifo/gul_S1_summary_P15 work/gul_S1_summaryleccalc/P15.bin > /dev/null & pid15=$!
+tee < fifo/gul_S1_summary_P16 work/gul_S1_summaryleccalc/P16.bin > /dev/null & pid16=$!
+tee < fifo/gul_S1_summary_P17 work/gul_S1_summaryleccalc/P17.bin > /dev/null & pid17=$!
+tee < fifo/gul_S1_summary_P18 work/gul_S1_summaryleccalc/P18.bin > /dev/null & pid18=$!
+tee < fifo/gul_S1_summary_P19 work/gul_S1_summaryleccalc/P19.bin > /dev/null & pid19=$!
+tee < fifo/gul_S1_summary_P20 work/gul_S1_summaryleccalc/P20.bin > /dev/null & pid20=$!
+
+summarycalc -i  -1 fifo/gul_S1_summary_P1 < fifo/gul_P1 &
+summarycalc -i  -1 fifo/gul_S1_summary_P2 < fifo/gul_P2 &
+summarycalc -i  -1 fifo/gul_S1_summary_P3 < fifo/gul_P3 &
+summarycalc -i  -1 fifo/gul_S1_summary_P4 < fifo/gul_P4 &
+summarycalc -i  -1 fifo/gul_S1_summary_P5 < fifo/gul_P5 &
+summarycalc -i  -1 fifo/gul_S1_summary_P6 < fifo/gul_P6 &
+summarycalc -i  -1 fifo/gul_S1_summary_P7 < fifo/gul_P7 &
+summarycalc -i  -1 fifo/gul_S1_summary_P8 < fifo/gul_P8 &
+summarycalc -i  -1 fifo/gul_S1_summary_P9 < fifo/gul_P9 &
+summarycalc -i  -1 fifo/gul_S1_summary_P10 < fifo/gul_P10 &
+summarycalc -i  -1 fifo/gul_S1_summary_P11 < fifo/gul_P11 &
+summarycalc -i  -1 fifo/gul_S1_summary_P12 < fifo/gul_P12 &
+summarycalc -i  -1 fifo/gul_S1_summary_P13 < fifo/gul_P13 &
+summarycalc -i  -1 fifo/gul_S1_summary_P14 < fifo/gul_P14 &
+summarycalc -i  -1 fifo/gul_S1_summary_P15 < fifo/gul_P15 &
+summarycalc -i  -1 fifo/gul_S1_summary_P16 < fifo/gul_P16 &
+summarycalc -i  -1 fifo/gul_S1_summary_P17 < fifo/gul_P17 &
+summarycalc -i  -1 fifo/gul_S1_summary_P18 < fifo/gul_P18 &
+summarycalc -i  -1 fifo/gul_S1_summary_P19 < fifo/gul_P19 &
+summarycalc -i  -1 fifo/gul_S1_summary_P20 < fifo/gul_P20 &
+
+# --- Do ground up loss computes ---
+
+
+tee < fifo/full_correlation/gul_S1_summary_P1 work/full_correlation/gul_S1_summaryleccalc/P1.bin > /dev/null & pid21=$!
+tee < fifo/full_correlation/gul_S1_summary_P2 work/full_correlation/gul_S1_summaryleccalc/P2.bin > /dev/null & pid22=$!
+tee < fifo/full_correlation/gul_S1_summary_P3 work/full_correlation/gul_S1_summaryleccalc/P3.bin > /dev/null & pid23=$!
+tee < fifo/full_correlation/gul_S1_summary_P4 work/full_correlation/gul_S1_summaryleccalc/P4.bin > /dev/null & pid24=$!
+tee < fifo/full_correlation/gul_S1_summary_P5 work/full_correlation/gul_S1_summaryleccalc/P5.bin > /dev/null & pid25=$!
+tee < fifo/full_correlation/gul_S1_summary_P6 work/full_correlation/gul_S1_summaryleccalc/P6.bin > /dev/null & pid26=$!
+tee < fifo/full_correlation/gul_S1_summary_P7 work/full_correlation/gul_S1_summaryleccalc/P7.bin > /dev/null & pid27=$!
+tee < fifo/full_correlation/gul_S1_summary_P8 work/full_correlation/gul_S1_summaryleccalc/P8.bin > /dev/null & pid28=$!
+tee < fifo/full_correlation/gul_S1_summary_P9 work/full_correlation/gul_S1_summaryleccalc/P9.bin > /dev/null & pid29=$!
+tee < fifo/full_correlation/gul_S1_summary_P10 work/full_correlation/gul_S1_summaryleccalc/P10.bin > /dev/null & pid30=$!
+tee < fifo/full_correlation/gul_S1_summary_P11 work/full_correlation/gul_S1_summaryleccalc/P11.bin > /dev/null & pid31=$!
+tee < fifo/full_correlation/gul_S1_summary_P12 work/full_correlation/gul_S1_summaryleccalc/P12.bin > /dev/null & pid32=$!
+tee < fifo/full_correlation/gul_S1_summary_P13 work/full_correlation/gul_S1_summaryleccalc/P13.bin > /dev/null & pid33=$!
+tee < fifo/full_correlation/gul_S1_summary_P14 work/full_correlation/gul_S1_summaryleccalc/P14.bin > /dev/null & pid34=$!
+tee < fifo/full_correlation/gul_S1_summary_P15 work/full_correlation/gul_S1_summaryleccalc/P15.bin > /dev/null & pid35=$!
+tee < fifo/full_correlation/gul_S1_summary_P16 work/full_correlation/gul_S1_summaryleccalc/P16.bin > /dev/null & pid36=$!
+tee < fifo/full_correlation/gul_S1_summary_P17 work/full_correlation/gul_S1_summaryleccalc/P17.bin > /dev/null & pid37=$!
+tee < fifo/full_correlation/gul_S1_summary_P18 work/full_correlation/gul_S1_summaryleccalc/P18.bin > /dev/null & pid38=$!
+tee < fifo/full_correlation/gul_S1_summary_P19 work/full_correlation/gul_S1_summaryleccalc/P19.bin > /dev/null & pid39=$!
+tee < fifo/full_correlation/gul_S1_summary_P20 work/full_correlation/gul_S1_summaryleccalc/P20.bin > /dev/null & pid40=$!
+
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P1 < fifo/full_correlation/gul_P1 &
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P2 < fifo/full_correlation/gul_P2 &
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P3 < fifo/full_correlation/gul_P3 &
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P4 < fifo/full_correlation/gul_P4 &
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P5 < fifo/full_correlation/gul_P5 &
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P6 < fifo/full_correlation/gul_P6 &
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P7 < fifo/full_correlation/gul_P7 &
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P8 < fifo/full_correlation/gul_P8 &
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P9 < fifo/full_correlation/gul_P9 &
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P10 < fifo/full_correlation/gul_P10 &
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P11 < fifo/full_correlation/gul_P11 &
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P12 < fifo/full_correlation/gul_P12 &
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P13 < fifo/full_correlation/gul_P13 &
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P14 < fifo/full_correlation/gul_P14 &
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P15 < fifo/full_correlation/gul_P15 &
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P16 < fifo/full_correlation/gul_P16 &
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P17 < fifo/full_correlation/gul_P17 &
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P18 < fifo/full_correlation/gul_P18 &
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P19 < fifo/full_correlation/gul_P19 &
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P20 < fifo/full_correlation/gul_P20 &
+
+eve 1 20 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P1 -a1 -i - > fifo/gul_P1  &
+eve 2 20 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P2 -a1 -i - > fifo/gul_P2  &
+eve 3 20 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P3 -a1 -i - > fifo/gul_P3  &
+eve 4 20 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P4 -a1 -i - > fifo/gul_P4  &
+eve 5 20 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P5 -a1 -i - > fifo/gul_P5  &
+eve 6 20 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P6 -a1 -i - > fifo/gul_P6  &
+eve 7 20 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P7 -a1 -i - > fifo/gul_P7  &
+eve 8 20 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P8 -a1 -i - > fifo/gul_P8  &
+eve 9 20 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P9 -a1 -i - > fifo/gul_P9  &
+eve 10 20 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P10 -a1 -i - > fifo/gul_P10  &
+eve 11 20 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P11 -a1 -i - > fifo/gul_P11  &
+eve 12 20 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P12 -a1 -i - > fifo/gul_P12  &
+eve 13 20 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P13 -a1 -i - > fifo/gul_P13  &
+eve 14 20 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P14 -a1 -i - > fifo/gul_P14  &
+eve 15 20 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P15 -a1 -i - > fifo/gul_P15  &
+eve 16 20 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P16 -a1 -i - > fifo/gul_P16  &
+eve 17 20 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P17 -a1 -i - > fifo/gul_P17  &
+eve 18 20 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P18 -a1 -i - > fifo/gul_P18  &
+eve 19 20 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P19 -a1 -i - > fifo/gul_P19  &
+eve 20 20 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P20 -a1 -i - > fifo/gul_P20  &
+
+wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 $pid13 $pid14 $pid15 $pid16 $pid17 $pid18 $pid19 $pid20 $pid21 $pid22 $pid23 $pid24 $pid25 $pid26 $pid27 $pid28 $pid29 $pid30 $pid31 $pid32 $pid33 $pid34 $pid35 $pid36 $pid37 $pid38 $pid39 $pid40
+
+
+# --- Do ground up loss kats ---
+
+
+# --- Do ground up loss kats for fully correlated output ---
+
+
+ordleccalc -r -Kgul_S1_summaryleccalc -F -f -S -s -M -m -O output/gul_S1_ept.csv & lpid1=$!
+ordleccalc -r -Kfull_correlation/gul_S1_summaryleccalc -F -f -S -s -M -m -O output/full_correlation/gul_S1_ept.csv & lpid2=$!
+wait $lpid1 $lpid2
+
+rm -R -f work/*
+rm -R -f fifo/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_ord_ept_psept_lec_2_output_10_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_ord_ept_psept_lec_2_output_10_partition.sh
@@ -1,0 +1,475 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+mkdir output/full_correlation/
+
+rm -R -f fifo/*
+mkdir fifo/full_correlation/
+rm -R -f work/*
+mkdir work/kat/
+mkdir work/full_correlation/
+mkdir work/full_correlation/kat/
+
+mkdir work/gul_S1_summaryleccalc
+mkdir work/gul_S1_summaryaalcalc
+mkdir work/gul_S2_summaryleccalc
+mkdir work/gul_S2_summaryaalcalc
+mkdir work/full_correlation/gul_S1_summaryleccalc
+mkdir work/full_correlation/gul_S1_summaryaalcalc
+mkdir work/full_correlation/gul_S2_summaryleccalc
+mkdir work/full_correlation/gul_S2_summaryaalcalc
+
+mkfifo fifo/gul_P1
+mkfifo fifo/gul_P2
+mkfifo fifo/gul_P3
+mkfifo fifo/gul_P4
+mkfifo fifo/gul_P5
+mkfifo fifo/gul_P6
+mkfifo fifo/gul_P7
+mkfifo fifo/gul_P8
+mkfifo fifo/gul_P9
+mkfifo fifo/gul_P10
+
+mkfifo fifo/gul_S1_summary_P1
+mkfifo fifo/gul_S1_eltcalc_P1
+mkfifo fifo/gul_S1_summarycalc_P1
+mkfifo fifo/gul_S1_pltcalc_P1
+mkfifo fifo/gul_S2_summary_P1
+mkfifo fifo/gul_S2_eltcalc_P1
+mkfifo fifo/gul_S2_summarycalc_P1
+mkfifo fifo/gul_S2_pltcalc_P1
+
+mkfifo fifo/gul_S1_summary_P2
+mkfifo fifo/gul_S1_eltcalc_P2
+mkfifo fifo/gul_S1_summarycalc_P2
+mkfifo fifo/gul_S1_pltcalc_P2
+mkfifo fifo/gul_S2_summary_P2
+mkfifo fifo/gul_S2_eltcalc_P2
+mkfifo fifo/gul_S2_summarycalc_P2
+mkfifo fifo/gul_S2_pltcalc_P2
+
+mkfifo fifo/gul_S1_summary_P3
+mkfifo fifo/gul_S1_eltcalc_P3
+mkfifo fifo/gul_S1_summarycalc_P3
+mkfifo fifo/gul_S1_pltcalc_P3
+mkfifo fifo/gul_S2_summary_P3
+mkfifo fifo/gul_S2_eltcalc_P3
+mkfifo fifo/gul_S2_summarycalc_P3
+mkfifo fifo/gul_S2_pltcalc_P3
+
+mkfifo fifo/gul_S1_summary_P4
+mkfifo fifo/gul_S1_eltcalc_P4
+mkfifo fifo/gul_S1_summarycalc_P4
+mkfifo fifo/gul_S1_pltcalc_P4
+mkfifo fifo/gul_S2_summary_P4
+mkfifo fifo/gul_S2_eltcalc_P4
+mkfifo fifo/gul_S2_summarycalc_P4
+mkfifo fifo/gul_S2_pltcalc_P4
+
+mkfifo fifo/gul_S1_summary_P5
+mkfifo fifo/gul_S1_eltcalc_P5
+mkfifo fifo/gul_S1_summarycalc_P5
+mkfifo fifo/gul_S1_pltcalc_P5
+mkfifo fifo/gul_S2_summary_P5
+mkfifo fifo/gul_S2_eltcalc_P5
+mkfifo fifo/gul_S2_summarycalc_P5
+mkfifo fifo/gul_S2_pltcalc_P5
+
+mkfifo fifo/gul_S1_summary_P6
+mkfifo fifo/gul_S1_eltcalc_P6
+mkfifo fifo/gul_S1_summarycalc_P6
+mkfifo fifo/gul_S1_pltcalc_P6
+mkfifo fifo/gul_S2_summary_P6
+mkfifo fifo/gul_S2_eltcalc_P6
+mkfifo fifo/gul_S2_summarycalc_P6
+mkfifo fifo/gul_S2_pltcalc_P6
+
+mkfifo fifo/gul_S1_summary_P7
+mkfifo fifo/gul_S1_eltcalc_P7
+mkfifo fifo/gul_S1_summarycalc_P7
+mkfifo fifo/gul_S1_pltcalc_P7
+mkfifo fifo/gul_S2_summary_P7
+mkfifo fifo/gul_S2_eltcalc_P7
+mkfifo fifo/gul_S2_summarycalc_P7
+mkfifo fifo/gul_S2_pltcalc_P7
+
+mkfifo fifo/gul_S1_summary_P8
+mkfifo fifo/gul_S1_eltcalc_P8
+mkfifo fifo/gul_S1_summarycalc_P8
+mkfifo fifo/gul_S1_pltcalc_P8
+mkfifo fifo/gul_S2_summary_P8
+mkfifo fifo/gul_S2_eltcalc_P8
+mkfifo fifo/gul_S2_summarycalc_P8
+mkfifo fifo/gul_S2_pltcalc_P8
+
+mkfifo fifo/gul_S1_summary_P9
+mkfifo fifo/gul_S1_eltcalc_P9
+mkfifo fifo/gul_S1_summarycalc_P9
+mkfifo fifo/gul_S1_pltcalc_P9
+mkfifo fifo/gul_S2_summary_P9
+mkfifo fifo/gul_S2_eltcalc_P9
+mkfifo fifo/gul_S2_summarycalc_P9
+mkfifo fifo/gul_S2_pltcalc_P9
+
+mkfifo fifo/gul_S1_summary_P10
+mkfifo fifo/gul_S1_eltcalc_P10
+mkfifo fifo/gul_S1_summarycalc_P10
+mkfifo fifo/gul_S1_pltcalc_P10
+mkfifo fifo/gul_S2_summary_P10
+mkfifo fifo/gul_S2_eltcalc_P10
+mkfifo fifo/gul_S2_summarycalc_P10
+mkfifo fifo/gul_S2_pltcalc_P10
+
+mkfifo fifo/full_correlation/gul_P1
+mkfifo fifo/full_correlation/gul_P2
+mkfifo fifo/full_correlation/gul_P3
+mkfifo fifo/full_correlation/gul_P4
+mkfifo fifo/full_correlation/gul_P5
+mkfifo fifo/full_correlation/gul_P6
+mkfifo fifo/full_correlation/gul_P7
+mkfifo fifo/full_correlation/gul_P8
+mkfifo fifo/full_correlation/gul_P9
+mkfifo fifo/full_correlation/gul_P10
+
+mkfifo fifo/full_correlation/gul_S1_summary_P1
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P1
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P1
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P1
+mkfifo fifo/full_correlation/gul_S2_summary_P1
+mkfifo fifo/full_correlation/gul_S2_eltcalc_P1
+mkfifo fifo/full_correlation/gul_S2_summarycalc_P1
+mkfifo fifo/full_correlation/gul_S2_pltcalc_P1
+
+mkfifo fifo/full_correlation/gul_S1_summary_P2
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P2
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P2
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P2
+mkfifo fifo/full_correlation/gul_S2_summary_P2
+mkfifo fifo/full_correlation/gul_S2_eltcalc_P2
+mkfifo fifo/full_correlation/gul_S2_summarycalc_P2
+mkfifo fifo/full_correlation/gul_S2_pltcalc_P2
+
+mkfifo fifo/full_correlation/gul_S1_summary_P3
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P3
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P3
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P3
+mkfifo fifo/full_correlation/gul_S2_summary_P3
+mkfifo fifo/full_correlation/gul_S2_eltcalc_P3
+mkfifo fifo/full_correlation/gul_S2_summarycalc_P3
+mkfifo fifo/full_correlation/gul_S2_pltcalc_P3
+
+mkfifo fifo/full_correlation/gul_S1_summary_P4
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P4
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P4
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P4
+mkfifo fifo/full_correlation/gul_S2_summary_P4
+mkfifo fifo/full_correlation/gul_S2_eltcalc_P4
+mkfifo fifo/full_correlation/gul_S2_summarycalc_P4
+mkfifo fifo/full_correlation/gul_S2_pltcalc_P4
+
+mkfifo fifo/full_correlation/gul_S1_summary_P5
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P5
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P5
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P5
+mkfifo fifo/full_correlation/gul_S2_summary_P5
+mkfifo fifo/full_correlation/gul_S2_eltcalc_P5
+mkfifo fifo/full_correlation/gul_S2_summarycalc_P5
+mkfifo fifo/full_correlation/gul_S2_pltcalc_P5
+
+mkfifo fifo/full_correlation/gul_S1_summary_P6
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P6
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P6
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P6
+mkfifo fifo/full_correlation/gul_S2_summary_P6
+mkfifo fifo/full_correlation/gul_S2_eltcalc_P6
+mkfifo fifo/full_correlation/gul_S2_summarycalc_P6
+mkfifo fifo/full_correlation/gul_S2_pltcalc_P6
+
+mkfifo fifo/full_correlation/gul_S1_summary_P7
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P7
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P7
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P7
+mkfifo fifo/full_correlation/gul_S2_summary_P7
+mkfifo fifo/full_correlation/gul_S2_eltcalc_P7
+mkfifo fifo/full_correlation/gul_S2_summarycalc_P7
+mkfifo fifo/full_correlation/gul_S2_pltcalc_P7
+
+mkfifo fifo/full_correlation/gul_S1_summary_P8
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P8
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P8
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P8
+mkfifo fifo/full_correlation/gul_S2_summary_P8
+mkfifo fifo/full_correlation/gul_S2_eltcalc_P8
+mkfifo fifo/full_correlation/gul_S2_summarycalc_P8
+mkfifo fifo/full_correlation/gul_S2_pltcalc_P8
+
+mkfifo fifo/full_correlation/gul_S1_summary_P9
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P9
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P9
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P9
+mkfifo fifo/full_correlation/gul_S2_summary_P9
+mkfifo fifo/full_correlation/gul_S2_eltcalc_P9
+mkfifo fifo/full_correlation/gul_S2_summarycalc_P9
+mkfifo fifo/full_correlation/gul_S2_pltcalc_P9
+
+mkfifo fifo/full_correlation/gul_S1_summary_P10
+mkfifo fifo/full_correlation/gul_S1_eltcalc_P10
+mkfifo fifo/full_correlation/gul_S1_summarycalc_P10
+mkfifo fifo/full_correlation/gul_S1_pltcalc_P10
+mkfifo fifo/full_correlation/gul_S2_summary_P10
+mkfifo fifo/full_correlation/gul_S2_eltcalc_P10
+mkfifo fifo/full_correlation/gul_S2_summarycalc_P10
+mkfifo fifo/full_correlation/gul_S2_pltcalc_P10
+
+
+
+# --- Do ground up loss computes ---
+
+eltcalc < fifo/gul_S1_eltcalc_P1 > work/kat/gul_S1_eltcalc_P1 & pid1=$!
+summarycalctocsv < fifo/gul_S1_summarycalc_P1 > work/kat/gul_S1_summarycalc_P1 & pid2=$!
+pltcalc < fifo/gul_S1_pltcalc_P1 > work/kat/gul_S1_pltcalc_P1 & pid3=$!
+eltcalc < fifo/gul_S2_eltcalc_P1 > work/kat/gul_S2_eltcalc_P1 & pid4=$!
+summarycalctocsv < fifo/gul_S2_summarycalc_P1 > work/kat/gul_S2_summarycalc_P1 & pid5=$!
+pltcalc < fifo/gul_S2_pltcalc_P1 > work/kat/gul_S2_pltcalc_P1 & pid6=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P2 > work/kat/gul_S1_eltcalc_P2 & pid7=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P2 > work/kat/gul_S1_summarycalc_P2 & pid8=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P2 > work/kat/gul_S1_pltcalc_P2 & pid9=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P2 > work/kat/gul_S2_eltcalc_P2 & pid10=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P2 > work/kat/gul_S2_summarycalc_P2 & pid11=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P2 > work/kat/gul_S2_pltcalc_P2 & pid12=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P3 > work/kat/gul_S1_eltcalc_P3 & pid13=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P3 > work/kat/gul_S1_summarycalc_P3 & pid14=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P3 > work/kat/gul_S1_pltcalc_P3 & pid15=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P3 > work/kat/gul_S2_eltcalc_P3 & pid16=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P3 > work/kat/gul_S2_summarycalc_P3 & pid17=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P3 > work/kat/gul_S2_pltcalc_P3 & pid18=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P4 > work/kat/gul_S1_eltcalc_P4 & pid19=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P4 > work/kat/gul_S1_summarycalc_P4 & pid20=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P4 > work/kat/gul_S1_pltcalc_P4 & pid21=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P4 > work/kat/gul_S2_eltcalc_P4 & pid22=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P4 > work/kat/gul_S2_summarycalc_P4 & pid23=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P4 > work/kat/gul_S2_pltcalc_P4 & pid24=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P5 > work/kat/gul_S1_eltcalc_P5 & pid25=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P5 > work/kat/gul_S1_summarycalc_P5 & pid26=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P5 > work/kat/gul_S1_pltcalc_P5 & pid27=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P5 > work/kat/gul_S2_eltcalc_P5 & pid28=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P5 > work/kat/gul_S2_summarycalc_P5 & pid29=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P5 > work/kat/gul_S2_pltcalc_P5 & pid30=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P6 > work/kat/gul_S1_eltcalc_P6 & pid31=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P6 > work/kat/gul_S1_summarycalc_P6 & pid32=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P6 > work/kat/gul_S1_pltcalc_P6 & pid33=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P6 > work/kat/gul_S2_eltcalc_P6 & pid34=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P6 > work/kat/gul_S2_summarycalc_P6 & pid35=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P6 > work/kat/gul_S2_pltcalc_P6 & pid36=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P7 > work/kat/gul_S1_eltcalc_P7 & pid37=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P7 > work/kat/gul_S1_summarycalc_P7 & pid38=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P7 > work/kat/gul_S1_pltcalc_P7 & pid39=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P7 > work/kat/gul_S2_eltcalc_P7 & pid40=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P7 > work/kat/gul_S2_summarycalc_P7 & pid41=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P7 > work/kat/gul_S2_pltcalc_P7 & pid42=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P8 > work/kat/gul_S1_eltcalc_P8 & pid43=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P8 > work/kat/gul_S1_summarycalc_P8 & pid44=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P8 > work/kat/gul_S1_pltcalc_P8 & pid45=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P8 > work/kat/gul_S2_eltcalc_P8 & pid46=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P8 > work/kat/gul_S2_summarycalc_P8 & pid47=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P8 > work/kat/gul_S2_pltcalc_P8 & pid48=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P9 > work/kat/gul_S1_eltcalc_P9 & pid49=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P9 > work/kat/gul_S1_summarycalc_P9 & pid50=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P9 > work/kat/gul_S1_pltcalc_P9 & pid51=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P9 > work/kat/gul_S2_eltcalc_P9 & pid52=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P9 > work/kat/gul_S2_summarycalc_P9 & pid53=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P9 > work/kat/gul_S2_pltcalc_P9 & pid54=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P10 > work/kat/gul_S1_eltcalc_P10 & pid55=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P10 > work/kat/gul_S1_summarycalc_P10 & pid56=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P10 > work/kat/gul_S1_pltcalc_P10 & pid57=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P10 > work/kat/gul_S2_eltcalc_P10 & pid58=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P10 > work/kat/gul_S2_summarycalc_P10 & pid59=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P10 > work/kat/gul_S2_pltcalc_P10 & pid60=$!
+
+tee < fifo/gul_S1_summary_P1 fifo/gul_S1_eltcalc_P1 fifo/gul_S1_summarycalc_P1 fifo/gul_S1_pltcalc_P1 work/gul_S1_summaryaalcalc/P1.bin work/gul_S1_summaryleccalc/P1.bin > /dev/null & pid61=$!
+tee < fifo/gul_S2_summary_P1 fifo/gul_S2_eltcalc_P1 fifo/gul_S2_summarycalc_P1 fifo/gul_S2_pltcalc_P1 work/gul_S2_summaryaalcalc/P1.bin work/gul_S2_summaryleccalc/P1.bin > /dev/null & pid62=$!
+tee < fifo/gul_S1_summary_P2 fifo/gul_S1_eltcalc_P2 fifo/gul_S1_summarycalc_P2 fifo/gul_S1_pltcalc_P2 work/gul_S1_summaryaalcalc/P2.bin work/gul_S1_summaryleccalc/P2.bin > /dev/null & pid63=$!
+tee < fifo/gul_S2_summary_P2 fifo/gul_S2_eltcalc_P2 fifo/gul_S2_summarycalc_P2 fifo/gul_S2_pltcalc_P2 work/gul_S2_summaryaalcalc/P2.bin work/gul_S2_summaryleccalc/P2.bin > /dev/null & pid64=$!
+tee < fifo/gul_S1_summary_P3 fifo/gul_S1_eltcalc_P3 fifo/gul_S1_summarycalc_P3 fifo/gul_S1_pltcalc_P3 work/gul_S1_summaryaalcalc/P3.bin work/gul_S1_summaryleccalc/P3.bin > /dev/null & pid65=$!
+tee < fifo/gul_S2_summary_P3 fifo/gul_S2_eltcalc_P3 fifo/gul_S2_summarycalc_P3 fifo/gul_S2_pltcalc_P3 work/gul_S2_summaryaalcalc/P3.bin work/gul_S2_summaryleccalc/P3.bin > /dev/null & pid66=$!
+tee < fifo/gul_S1_summary_P4 fifo/gul_S1_eltcalc_P4 fifo/gul_S1_summarycalc_P4 fifo/gul_S1_pltcalc_P4 work/gul_S1_summaryaalcalc/P4.bin work/gul_S1_summaryleccalc/P4.bin > /dev/null & pid67=$!
+tee < fifo/gul_S2_summary_P4 fifo/gul_S2_eltcalc_P4 fifo/gul_S2_summarycalc_P4 fifo/gul_S2_pltcalc_P4 work/gul_S2_summaryaalcalc/P4.bin work/gul_S2_summaryleccalc/P4.bin > /dev/null & pid68=$!
+tee < fifo/gul_S1_summary_P5 fifo/gul_S1_eltcalc_P5 fifo/gul_S1_summarycalc_P5 fifo/gul_S1_pltcalc_P5 work/gul_S1_summaryaalcalc/P5.bin work/gul_S1_summaryleccalc/P5.bin > /dev/null & pid69=$!
+tee < fifo/gul_S2_summary_P5 fifo/gul_S2_eltcalc_P5 fifo/gul_S2_summarycalc_P5 fifo/gul_S2_pltcalc_P5 work/gul_S2_summaryaalcalc/P5.bin work/gul_S2_summaryleccalc/P5.bin > /dev/null & pid70=$!
+tee < fifo/gul_S1_summary_P6 fifo/gul_S1_eltcalc_P6 fifo/gul_S1_summarycalc_P6 fifo/gul_S1_pltcalc_P6 work/gul_S1_summaryaalcalc/P6.bin work/gul_S1_summaryleccalc/P6.bin > /dev/null & pid71=$!
+tee < fifo/gul_S2_summary_P6 fifo/gul_S2_eltcalc_P6 fifo/gul_S2_summarycalc_P6 fifo/gul_S2_pltcalc_P6 work/gul_S2_summaryaalcalc/P6.bin work/gul_S2_summaryleccalc/P6.bin > /dev/null & pid72=$!
+tee < fifo/gul_S1_summary_P7 fifo/gul_S1_eltcalc_P7 fifo/gul_S1_summarycalc_P7 fifo/gul_S1_pltcalc_P7 work/gul_S1_summaryaalcalc/P7.bin work/gul_S1_summaryleccalc/P7.bin > /dev/null & pid73=$!
+tee < fifo/gul_S2_summary_P7 fifo/gul_S2_eltcalc_P7 fifo/gul_S2_summarycalc_P7 fifo/gul_S2_pltcalc_P7 work/gul_S2_summaryaalcalc/P7.bin work/gul_S2_summaryleccalc/P7.bin > /dev/null & pid74=$!
+tee < fifo/gul_S1_summary_P8 fifo/gul_S1_eltcalc_P8 fifo/gul_S1_summarycalc_P8 fifo/gul_S1_pltcalc_P8 work/gul_S1_summaryaalcalc/P8.bin work/gul_S1_summaryleccalc/P8.bin > /dev/null & pid75=$!
+tee < fifo/gul_S2_summary_P8 fifo/gul_S2_eltcalc_P8 fifo/gul_S2_summarycalc_P8 fifo/gul_S2_pltcalc_P8 work/gul_S2_summaryaalcalc/P8.bin work/gul_S2_summaryleccalc/P8.bin > /dev/null & pid76=$!
+tee < fifo/gul_S1_summary_P9 fifo/gul_S1_eltcalc_P9 fifo/gul_S1_summarycalc_P9 fifo/gul_S1_pltcalc_P9 work/gul_S1_summaryaalcalc/P9.bin work/gul_S1_summaryleccalc/P9.bin > /dev/null & pid77=$!
+tee < fifo/gul_S2_summary_P9 fifo/gul_S2_eltcalc_P9 fifo/gul_S2_summarycalc_P9 fifo/gul_S2_pltcalc_P9 work/gul_S2_summaryaalcalc/P9.bin work/gul_S2_summaryleccalc/P9.bin > /dev/null & pid78=$!
+tee < fifo/gul_S1_summary_P10 fifo/gul_S1_eltcalc_P10 fifo/gul_S1_summarycalc_P10 fifo/gul_S1_pltcalc_P10 work/gul_S1_summaryaalcalc/P10.bin work/gul_S1_summaryleccalc/P10.bin > /dev/null & pid79=$!
+tee < fifo/gul_S2_summary_P10 fifo/gul_S2_eltcalc_P10 fifo/gul_S2_summarycalc_P10 fifo/gul_S2_pltcalc_P10 work/gul_S2_summaryaalcalc/P10.bin work/gul_S2_summaryleccalc/P10.bin > /dev/null & pid80=$!
+
+summarycalc -i  -1 fifo/gul_S1_summary_P1 -2 fifo/gul_S2_summary_P1 < fifo/gul_P1 &
+summarycalc -i  -1 fifo/gul_S1_summary_P2 -2 fifo/gul_S2_summary_P2 < fifo/gul_P2 &
+summarycalc -i  -1 fifo/gul_S1_summary_P3 -2 fifo/gul_S2_summary_P3 < fifo/gul_P3 &
+summarycalc -i  -1 fifo/gul_S1_summary_P4 -2 fifo/gul_S2_summary_P4 < fifo/gul_P4 &
+summarycalc -i  -1 fifo/gul_S1_summary_P5 -2 fifo/gul_S2_summary_P5 < fifo/gul_P5 &
+summarycalc -i  -1 fifo/gul_S1_summary_P6 -2 fifo/gul_S2_summary_P6 < fifo/gul_P6 &
+summarycalc -i  -1 fifo/gul_S1_summary_P7 -2 fifo/gul_S2_summary_P7 < fifo/gul_P7 &
+summarycalc -i  -1 fifo/gul_S1_summary_P8 -2 fifo/gul_S2_summary_P8 < fifo/gul_P8 &
+summarycalc -i  -1 fifo/gul_S1_summary_P9 -2 fifo/gul_S2_summary_P9 < fifo/gul_P9 &
+summarycalc -i  -1 fifo/gul_S1_summary_P10 -2 fifo/gul_S2_summary_P10 < fifo/gul_P10 &
+
+# --- Do ground up loss computes ---
+
+eltcalc < fifo/full_correlation/gul_S1_eltcalc_P1 > work/full_correlation/kat/gul_S1_eltcalc_P1 & pid81=$!
+summarycalctocsv < fifo/full_correlation/gul_S1_summarycalc_P1 > work/full_correlation/kat/gul_S1_summarycalc_P1 & pid82=$!
+pltcalc < fifo/full_correlation/gul_S1_pltcalc_P1 > work/full_correlation/kat/gul_S1_pltcalc_P1 & pid83=$!
+eltcalc < fifo/full_correlation/gul_S2_eltcalc_P1 > work/full_correlation/kat/gul_S2_eltcalc_P1 & pid84=$!
+summarycalctocsv < fifo/full_correlation/gul_S2_summarycalc_P1 > work/full_correlation/kat/gul_S2_summarycalc_P1 & pid85=$!
+pltcalc < fifo/full_correlation/gul_S2_pltcalc_P1 > work/full_correlation/kat/gul_S2_pltcalc_P1 & pid86=$!
+eltcalc -s < fifo/full_correlation/gul_S1_eltcalc_P2 > work/full_correlation/kat/gul_S1_eltcalc_P2 & pid87=$!
+summarycalctocsv -s < fifo/full_correlation/gul_S1_summarycalc_P2 > work/full_correlation/kat/gul_S1_summarycalc_P2 & pid88=$!
+pltcalc -s < fifo/full_correlation/gul_S1_pltcalc_P2 > work/full_correlation/kat/gul_S1_pltcalc_P2 & pid89=$!
+eltcalc -s < fifo/full_correlation/gul_S2_eltcalc_P2 > work/full_correlation/kat/gul_S2_eltcalc_P2 & pid90=$!
+summarycalctocsv -s < fifo/full_correlation/gul_S2_summarycalc_P2 > work/full_correlation/kat/gul_S2_summarycalc_P2 & pid91=$!
+pltcalc -s < fifo/full_correlation/gul_S2_pltcalc_P2 > work/full_correlation/kat/gul_S2_pltcalc_P2 & pid92=$!
+eltcalc -s < fifo/full_correlation/gul_S1_eltcalc_P3 > work/full_correlation/kat/gul_S1_eltcalc_P3 & pid93=$!
+summarycalctocsv -s < fifo/full_correlation/gul_S1_summarycalc_P3 > work/full_correlation/kat/gul_S1_summarycalc_P3 & pid94=$!
+pltcalc -s < fifo/full_correlation/gul_S1_pltcalc_P3 > work/full_correlation/kat/gul_S1_pltcalc_P3 & pid95=$!
+eltcalc -s < fifo/full_correlation/gul_S2_eltcalc_P3 > work/full_correlation/kat/gul_S2_eltcalc_P3 & pid96=$!
+summarycalctocsv -s < fifo/full_correlation/gul_S2_summarycalc_P3 > work/full_correlation/kat/gul_S2_summarycalc_P3 & pid97=$!
+pltcalc -s < fifo/full_correlation/gul_S2_pltcalc_P3 > work/full_correlation/kat/gul_S2_pltcalc_P3 & pid98=$!
+eltcalc -s < fifo/full_correlation/gul_S1_eltcalc_P4 > work/full_correlation/kat/gul_S1_eltcalc_P4 & pid99=$!
+summarycalctocsv -s < fifo/full_correlation/gul_S1_summarycalc_P4 > work/full_correlation/kat/gul_S1_summarycalc_P4 & pid100=$!
+pltcalc -s < fifo/full_correlation/gul_S1_pltcalc_P4 > work/full_correlation/kat/gul_S1_pltcalc_P4 & pid101=$!
+eltcalc -s < fifo/full_correlation/gul_S2_eltcalc_P4 > work/full_correlation/kat/gul_S2_eltcalc_P4 & pid102=$!
+summarycalctocsv -s < fifo/full_correlation/gul_S2_summarycalc_P4 > work/full_correlation/kat/gul_S2_summarycalc_P4 & pid103=$!
+pltcalc -s < fifo/full_correlation/gul_S2_pltcalc_P4 > work/full_correlation/kat/gul_S2_pltcalc_P4 & pid104=$!
+eltcalc -s < fifo/full_correlation/gul_S1_eltcalc_P5 > work/full_correlation/kat/gul_S1_eltcalc_P5 & pid105=$!
+summarycalctocsv -s < fifo/full_correlation/gul_S1_summarycalc_P5 > work/full_correlation/kat/gul_S1_summarycalc_P5 & pid106=$!
+pltcalc -s < fifo/full_correlation/gul_S1_pltcalc_P5 > work/full_correlation/kat/gul_S1_pltcalc_P5 & pid107=$!
+eltcalc -s < fifo/full_correlation/gul_S2_eltcalc_P5 > work/full_correlation/kat/gul_S2_eltcalc_P5 & pid108=$!
+summarycalctocsv -s < fifo/full_correlation/gul_S2_summarycalc_P5 > work/full_correlation/kat/gul_S2_summarycalc_P5 & pid109=$!
+pltcalc -s < fifo/full_correlation/gul_S2_pltcalc_P5 > work/full_correlation/kat/gul_S2_pltcalc_P5 & pid110=$!
+eltcalc -s < fifo/full_correlation/gul_S1_eltcalc_P6 > work/full_correlation/kat/gul_S1_eltcalc_P6 & pid111=$!
+summarycalctocsv -s < fifo/full_correlation/gul_S1_summarycalc_P6 > work/full_correlation/kat/gul_S1_summarycalc_P6 & pid112=$!
+pltcalc -s < fifo/full_correlation/gul_S1_pltcalc_P6 > work/full_correlation/kat/gul_S1_pltcalc_P6 & pid113=$!
+eltcalc -s < fifo/full_correlation/gul_S2_eltcalc_P6 > work/full_correlation/kat/gul_S2_eltcalc_P6 & pid114=$!
+summarycalctocsv -s < fifo/full_correlation/gul_S2_summarycalc_P6 > work/full_correlation/kat/gul_S2_summarycalc_P6 & pid115=$!
+pltcalc -s < fifo/full_correlation/gul_S2_pltcalc_P6 > work/full_correlation/kat/gul_S2_pltcalc_P6 & pid116=$!
+eltcalc -s < fifo/full_correlation/gul_S1_eltcalc_P7 > work/full_correlation/kat/gul_S1_eltcalc_P7 & pid117=$!
+summarycalctocsv -s < fifo/full_correlation/gul_S1_summarycalc_P7 > work/full_correlation/kat/gul_S1_summarycalc_P7 & pid118=$!
+pltcalc -s < fifo/full_correlation/gul_S1_pltcalc_P7 > work/full_correlation/kat/gul_S1_pltcalc_P7 & pid119=$!
+eltcalc -s < fifo/full_correlation/gul_S2_eltcalc_P7 > work/full_correlation/kat/gul_S2_eltcalc_P7 & pid120=$!
+summarycalctocsv -s < fifo/full_correlation/gul_S2_summarycalc_P7 > work/full_correlation/kat/gul_S2_summarycalc_P7 & pid121=$!
+pltcalc -s < fifo/full_correlation/gul_S2_pltcalc_P7 > work/full_correlation/kat/gul_S2_pltcalc_P7 & pid122=$!
+eltcalc -s < fifo/full_correlation/gul_S1_eltcalc_P8 > work/full_correlation/kat/gul_S1_eltcalc_P8 & pid123=$!
+summarycalctocsv -s < fifo/full_correlation/gul_S1_summarycalc_P8 > work/full_correlation/kat/gul_S1_summarycalc_P8 & pid124=$!
+pltcalc -s < fifo/full_correlation/gul_S1_pltcalc_P8 > work/full_correlation/kat/gul_S1_pltcalc_P8 & pid125=$!
+eltcalc -s < fifo/full_correlation/gul_S2_eltcalc_P8 > work/full_correlation/kat/gul_S2_eltcalc_P8 & pid126=$!
+summarycalctocsv -s < fifo/full_correlation/gul_S2_summarycalc_P8 > work/full_correlation/kat/gul_S2_summarycalc_P8 & pid127=$!
+pltcalc -s < fifo/full_correlation/gul_S2_pltcalc_P8 > work/full_correlation/kat/gul_S2_pltcalc_P8 & pid128=$!
+eltcalc -s < fifo/full_correlation/gul_S1_eltcalc_P9 > work/full_correlation/kat/gul_S1_eltcalc_P9 & pid129=$!
+summarycalctocsv -s < fifo/full_correlation/gul_S1_summarycalc_P9 > work/full_correlation/kat/gul_S1_summarycalc_P9 & pid130=$!
+pltcalc -s < fifo/full_correlation/gul_S1_pltcalc_P9 > work/full_correlation/kat/gul_S1_pltcalc_P9 & pid131=$!
+eltcalc -s < fifo/full_correlation/gul_S2_eltcalc_P9 > work/full_correlation/kat/gul_S2_eltcalc_P9 & pid132=$!
+summarycalctocsv -s < fifo/full_correlation/gul_S2_summarycalc_P9 > work/full_correlation/kat/gul_S2_summarycalc_P9 & pid133=$!
+pltcalc -s < fifo/full_correlation/gul_S2_pltcalc_P9 > work/full_correlation/kat/gul_S2_pltcalc_P9 & pid134=$!
+eltcalc -s < fifo/full_correlation/gul_S1_eltcalc_P10 > work/full_correlation/kat/gul_S1_eltcalc_P10 & pid135=$!
+summarycalctocsv -s < fifo/full_correlation/gul_S1_summarycalc_P10 > work/full_correlation/kat/gul_S1_summarycalc_P10 & pid136=$!
+pltcalc -s < fifo/full_correlation/gul_S1_pltcalc_P10 > work/full_correlation/kat/gul_S1_pltcalc_P10 & pid137=$!
+eltcalc -s < fifo/full_correlation/gul_S2_eltcalc_P10 > work/full_correlation/kat/gul_S2_eltcalc_P10 & pid138=$!
+summarycalctocsv -s < fifo/full_correlation/gul_S2_summarycalc_P10 > work/full_correlation/kat/gul_S2_summarycalc_P10 & pid139=$!
+pltcalc -s < fifo/full_correlation/gul_S2_pltcalc_P10 > work/full_correlation/kat/gul_S2_pltcalc_P10 & pid140=$!
+
+tee < fifo/full_correlation/gul_S1_summary_P1 fifo/full_correlation/gul_S1_eltcalc_P1 fifo/full_correlation/gul_S1_summarycalc_P1 fifo/full_correlation/gul_S1_pltcalc_P1 work/full_correlation/gul_S1_summaryaalcalc/P1.bin work/full_correlation/gul_S1_summaryleccalc/P1.bin > /dev/null & pid141=$!
+tee < fifo/full_correlation/gul_S2_summary_P1 fifo/full_correlation/gul_S2_eltcalc_P1 fifo/full_correlation/gul_S2_summarycalc_P1 fifo/full_correlation/gul_S2_pltcalc_P1 work/full_correlation/gul_S2_summaryaalcalc/P1.bin work/full_correlation/gul_S2_summaryleccalc/P1.bin > /dev/null & pid142=$!
+tee < fifo/full_correlation/gul_S1_summary_P2 fifo/full_correlation/gul_S1_eltcalc_P2 fifo/full_correlation/gul_S1_summarycalc_P2 fifo/full_correlation/gul_S1_pltcalc_P2 work/full_correlation/gul_S1_summaryaalcalc/P2.bin work/full_correlation/gul_S1_summaryleccalc/P2.bin > /dev/null & pid143=$!
+tee < fifo/full_correlation/gul_S2_summary_P2 fifo/full_correlation/gul_S2_eltcalc_P2 fifo/full_correlation/gul_S2_summarycalc_P2 fifo/full_correlation/gul_S2_pltcalc_P2 work/full_correlation/gul_S2_summaryaalcalc/P2.bin work/full_correlation/gul_S2_summaryleccalc/P2.bin > /dev/null & pid144=$!
+tee < fifo/full_correlation/gul_S1_summary_P3 fifo/full_correlation/gul_S1_eltcalc_P3 fifo/full_correlation/gul_S1_summarycalc_P3 fifo/full_correlation/gul_S1_pltcalc_P3 work/full_correlation/gul_S1_summaryaalcalc/P3.bin work/full_correlation/gul_S1_summaryleccalc/P3.bin > /dev/null & pid145=$!
+tee < fifo/full_correlation/gul_S2_summary_P3 fifo/full_correlation/gul_S2_eltcalc_P3 fifo/full_correlation/gul_S2_summarycalc_P3 fifo/full_correlation/gul_S2_pltcalc_P3 work/full_correlation/gul_S2_summaryaalcalc/P3.bin work/full_correlation/gul_S2_summaryleccalc/P3.bin > /dev/null & pid146=$!
+tee < fifo/full_correlation/gul_S1_summary_P4 fifo/full_correlation/gul_S1_eltcalc_P4 fifo/full_correlation/gul_S1_summarycalc_P4 fifo/full_correlation/gul_S1_pltcalc_P4 work/full_correlation/gul_S1_summaryaalcalc/P4.bin work/full_correlation/gul_S1_summaryleccalc/P4.bin > /dev/null & pid147=$!
+tee < fifo/full_correlation/gul_S2_summary_P4 fifo/full_correlation/gul_S2_eltcalc_P4 fifo/full_correlation/gul_S2_summarycalc_P4 fifo/full_correlation/gul_S2_pltcalc_P4 work/full_correlation/gul_S2_summaryaalcalc/P4.bin work/full_correlation/gul_S2_summaryleccalc/P4.bin > /dev/null & pid148=$!
+tee < fifo/full_correlation/gul_S1_summary_P5 fifo/full_correlation/gul_S1_eltcalc_P5 fifo/full_correlation/gul_S1_summarycalc_P5 fifo/full_correlation/gul_S1_pltcalc_P5 work/full_correlation/gul_S1_summaryaalcalc/P5.bin work/full_correlation/gul_S1_summaryleccalc/P5.bin > /dev/null & pid149=$!
+tee < fifo/full_correlation/gul_S2_summary_P5 fifo/full_correlation/gul_S2_eltcalc_P5 fifo/full_correlation/gul_S2_summarycalc_P5 fifo/full_correlation/gul_S2_pltcalc_P5 work/full_correlation/gul_S2_summaryaalcalc/P5.bin work/full_correlation/gul_S2_summaryleccalc/P5.bin > /dev/null & pid150=$!
+tee < fifo/full_correlation/gul_S1_summary_P6 fifo/full_correlation/gul_S1_eltcalc_P6 fifo/full_correlation/gul_S1_summarycalc_P6 fifo/full_correlation/gul_S1_pltcalc_P6 work/full_correlation/gul_S1_summaryaalcalc/P6.bin work/full_correlation/gul_S1_summaryleccalc/P6.bin > /dev/null & pid151=$!
+tee < fifo/full_correlation/gul_S2_summary_P6 fifo/full_correlation/gul_S2_eltcalc_P6 fifo/full_correlation/gul_S2_summarycalc_P6 fifo/full_correlation/gul_S2_pltcalc_P6 work/full_correlation/gul_S2_summaryaalcalc/P6.bin work/full_correlation/gul_S2_summaryleccalc/P6.bin > /dev/null & pid152=$!
+tee < fifo/full_correlation/gul_S1_summary_P7 fifo/full_correlation/gul_S1_eltcalc_P7 fifo/full_correlation/gul_S1_summarycalc_P7 fifo/full_correlation/gul_S1_pltcalc_P7 work/full_correlation/gul_S1_summaryaalcalc/P7.bin work/full_correlation/gul_S1_summaryleccalc/P7.bin > /dev/null & pid153=$!
+tee < fifo/full_correlation/gul_S2_summary_P7 fifo/full_correlation/gul_S2_eltcalc_P7 fifo/full_correlation/gul_S2_summarycalc_P7 fifo/full_correlation/gul_S2_pltcalc_P7 work/full_correlation/gul_S2_summaryaalcalc/P7.bin work/full_correlation/gul_S2_summaryleccalc/P7.bin > /dev/null & pid154=$!
+tee < fifo/full_correlation/gul_S1_summary_P8 fifo/full_correlation/gul_S1_eltcalc_P8 fifo/full_correlation/gul_S1_summarycalc_P8 fifo/full_correlation/gul_S1_pltcalc_P8 work/full_correlation/gul_S1_summaryaalcalc/P8.bin work/full_correlation/gul_S1_summaryleccalc/P8.bin > /dev/null & pid155=$!
+tee < fifo/full_correlation/gul_S2_summary_P8 fifo/full_correlation/gul_S2_eltcalc_P8 fifo/full_correlation/gul_S2_summarycalc_P8 fifo/full_correlation/gul_S2_pltcalc_P8 work/full_correlation/gul_S2_summaryaalcalc/P8.bin work/full_correlation/gul_S2_summaryleccalc/P8.bin > /dev/null & pid156=$!
+tee < fifo/full_correlation/gul_S1_summary_P9 fifo/full_correlation/gul_S1_eltcalc_P9 fifo/full_correlation/gul_S1_summarycalc_P9 fifo/full_correlation/gul_S1_pltcalc_P9 work/full_correlation/gul_S1_summaryaalcalc/P9.bin work/full_correlation/gul_S1_summaryleccalc/P9.bin > /dev/null & pid157=$!
+tee < fifo/full_correlation/gul_S2_summary_P9 fifo/full_correlation/gul_S2_eltcalc_P9 fifo/full_correlation/gul_S2_summarycalc_P9 fifo/full_correlation/gul_S2_pltcalc_P9 work/full_correlation/gul_S2_summaryaalcalc/P9.bin work/full_correlation/gul_S2_summaryleccalc/P9.bin > /dev/null & pid158=$!
+tee < fifo/full_correlation/gul_S1_summary_P10 fifo/full_correlation/gul_S1_eltcalc_P10 fifo/full_correlation/gul_S1_summarycalc_P10 fifo/full_correlation/gul_S1_pltcalc_P10 work/full_correlation/gul_S1_summaryaalcalc/P10.bin work/full_correlation/gul_S1_summaryleccalc/P10.bin > /dev/null & pid159=$!
+tee < fifo/full_correlation/gul_S2_summary_P10 fifo/full_correlation/gul_S2_eltcalc_P10 fifo/full_correlation/gul_S2_summarycalc_P10 fifo/full_correlation/gul_S2_pltcalc_P10 work/full_correlation/gul_S2_summaryaalcalc/P10.bin work/full_correlation/gul_S2_summaryleccalc/P10.bin > /dev/null & pid160=$!
+
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P1 -2 fifo/full_correlation/gul_S2_summary_P1 < fifo/full_correlation/gul_P1 &
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P2 -2 fifo/full_correlation/gul_S2_summary_P2 < fifo/full_correlation/gul_P2 &
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P3 -2 fifo/full_correlation/gul_S2_summary_P3 < fifo/full_correlation/gul_P3 &
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P4 -2 fifo/full_correlation/gul_S2_summary_P4 < fifo/full_correlation/gul_P4 &
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P5 -2 fifo/full_correlation/gul_S2_summary_P5 < fifo/full_correlation/gul_P5 &
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P6 -2 fifo/full_correlation/gul_S2_summary_P6 < fifo/full_correlation/gul_P6 &
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P7 -2 fifo/full_correlation/gul_S2_summary_P7 < fifo/full_correlation/gul_P7 &
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P8 -2 fifo/full_correlation/gul_S2_summary_P8 < fifo/full_correlation/gul_P8 &
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P9 -2 fifo/full_correlation/gul_S2_summary_P9 < fifo/full_correlation/gul_P9 &
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P10 -2 fifo/full_correlation/gul_S2_summary_P10 < fifo/full_correlation/gul_P10 &
+
+eve 1 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P1 -a1 -i - > fifo/gul_P1  &
+eve 2 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P2 -a1 -i - > fifo/gul_P2  &
+eve 3 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P3 -a1 -i - > fifo/gul_P3  &
+eve 4 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P4 -a1 -i - > fifo/gul_P4  &
+eve 5 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P5 -a1 -i - > fifo/gul_P5  &
+eve 6 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P6 -a1 -i - > fifo/gul_P6  &
+eve 7 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P7 -a1 -i - > fifo/gul_P7  &
+eve 8 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P8 -a1 -i - > fifo/gul_P8  &
+eve 9 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P9 -a1 -i - > fifo/gul_P9  &
+eve 10 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P10 -a1 -i - > fifo/gul_P10  &
+
+wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 $pid13 $pid14 $pid15 $pid16 $pid17 $pid18 $pid19 $pid20 $pid21 $pid22 $pid23 $pid24 $pid25 $pid26 $pid27 $pid28 $pid29 $pid30 $pid31 $pid32 $pid33 $pid34 $pid35 $pid36 $pid37 $pid38 $pid39 $pid40 $pid41 $pid42 $pid43 $pid44 $pid45 $pid46 $pid47 $pid48 $pid49 $pid50 $pid51 $pid52 $pid53 $pid54 $pid55 $pid56 $pid57 $pid58 $pid59 $pid60 $pid61 $pid62 $pid63 $pid64 $pid65 $pid66 $pid67 $pid68 $pid69 $pid70 $pid71 $pid72 $pid73 $pid74 $pid75 $pid76 $pid77 $pid78 $pid79 $pid80 $pid81 $pid82 $pid83 $pid84 $pid85 $pid86 $pid87 $pid88 $pid89 $pid90 $pid91 $pid92 $pid93 $pid94 $pid95 $pid96 $pid97 $pid98 $pid99 $pid100 $pid101 $pid102 $pid103 $pid104 $pid105 $pid106 $pid107 $pid108 $pid109 $pid110 $pid111 $pid112 $pid113 $pid114 $pid115 $pid116 $pid117 $pid118 $pid119 $pid120 $pid121 $pid122 $pid123 $pid124 $pid125 $pid126 $pid127 $pid128 $pid129 $pid130 $pid131 $pid132 $pid133 $pid134 $pid135 $pid136 $pid137 $pid138 $pid139 $pid140 $pid141 $pid142 $pid143 $pid144 $pid145 $pid146 $pid147 $pid148 $pid149 $pid150 $pid151 $pid152 $pid153 $pid154 $pid155 $pid156 $pid157 $pid158 $pid159 $pid160
+
+
+# --- Do ground up loss kats ---
+
+kat -s work/kat/gul_S1_eltcalc_P1 work/kat/gul_S1_eltcalc_P2 work/kat/gul_S1_eltcalc_P3 work/kat/gul_S1_eltcalc_P4 work/kat/gul_S1_eltcalc_P5 work/kat/gul_S1_eltcalc_P6 work/kat/gul_S1_eltcalc_P7 work/kat/gul_S1_eltcalc_P8 work/kat/gul_S1_eltcalc_P9 work/kat/gul_S1_eltcalc_P10 > output/gul_S1_eltcalc.csv & kpid1=$!
+kat work/kat/gul_S1_pltcalc_P1 work/kat/gul_S1_pltcalc_P2 work/kat/gul_S1_pltcalc_P3 work/kat/gul_S1_pltcalc_P4 work/kat/gul_S1_pltcalc_P5 work/kat/gul_S1_pltcalc_P6 work/kat/gul_S1_pltcalc_P7 work/kat/gul_S1_pltcalc_P8 work/kat/gul_S1_pltcalc_P9 work/kat/gul_S1_pltcalc_P10 > output/gul_S1_pltcalc.csv & kpid2=$!
+kat work/kat/gul_S1_summarycalc_P1 work/kat/gul_S1_summarycalc_P2 work/kat/gul_S1_summarycalc_P3 work/kat/gul_S1_summarycalc_P4 work/kat/gul_S1_summarycalc_P5 work/kat/gul_S1_summarycalc_P6 work/kat/gul_S1_summarycalc_P7 work/kat/gul_S1_summarycalc_P8 work/kat/gul_S1_summarycalc_P9 work/kat/gul_S1_summarycalc_P10 > output/gul_S1_summarycalc.csv & kpid3=$!
+kat -s work/kat/gul_S2_eltcalc_P1 work/kat/gul_S2_eltcalc_P2 work/kat/gul_S2_eltcalc_P3 work/kat/gul_S2_eltcalc_P4 work/kat/gul_S2_eltcalc_P5 work/kat/gul_S2_eltcalc_P6 work/kat/gul_S2_eltcalc_P7 work/kat/gul_S2_eltcalc_P8 work/kat/gul_S2_eltcalc_P9 work/kat/gul_S2_eltcalc_P10 > output/gul_S2_eltcalc.csv & kpid4=$!
+kat work/kat/gul_S2_pltcalc_P1 work/kat/gul_S2_pltcalc_P2 work/kat/gul_S2_pltcalc_P3 work/kat/gul_S2_pltcalc_P4 work/kat/gul_S2_pltcalc_P5 work/kat/gul_S2_pltcalc_P6 work/kat/gul_S2_pltcalc_P7 work/kat/gul_S2_pltcalc_P8 work/kat/gul_S2_pltcalc_P9 work/kat/gul_S2_pltcalc_P10 > output/gul_S2_pltcalc.csv & kpid5=$!
+kat work/kat/gul_S2_summarycalc_P1 work/kat/gul_S2_summarycalc_P2 work/kat/gul_S2_summarycalc_P3 work/kat/gul_S2_summarycalc_P4 work/kat/gul_S2_summarycalc_P5 work/kat/gul_S2_summarycalc_P6 work/kat/gul_S2_summarycalc_P7 work/kat/gul_S2_summarycalc_P8 work/kat/gul_S2_summarycalc_P9 work/kat/gul_S2_summarycalc_P10 > output/gul_S2_summarycalc.csv & kpid6=$!
+
+# --- Do ground up loss kats for fully correlated output ---
+
+kat -s work/full_correlation/kat/gul_S1_eltcalc_P1 work/full_correlation/kat/gul_S1_eltcalc_P2 work/full_correlation/kat/gul_S1_eltcalc_P3 work/full_correlation/kat/gul_S1_eltcalc_P4 work/full_correlation/kat/gul_S1_eltcalc_P5 work/full_correlation/kat/gul_S1_eltcalc_P6 work/full_correlation/kat/gul_S1_eltcalc_P7 work/full_correlation/kat/gul_S1_eltcalc_P8 work/full_correlation/kat/gul_S1_eltcalc_P9 work/full_correlation/kat/gul_S1_eltcalc_P10 > output/full_correlation/gul_S1_eltcalc.csv & kpid7=$!
+kat work/full_correlation/kat/gul_S1_pltcalc_P1 work/full_correlation/kat/gul_S1_pltcalc_P2 work/full_correlation/kat/gul_S1_pltcalc_P3 work/full_correlation/kat/gul_S1_pltcalc_P4 work/full_correlation/kat/gul_S1_pltcalc_P5 work/full_correlation/kat/gul_S1_pltcalc_P6 work/full_correlation/kat/gul_S1_pltcalc_P7 work/full_correlation/kat/gul_S1_pltcalc_P8 work/full_correlation/kat/gul_S1_pltcalc_P9 work/full_correlation/kat/gul_S1_pltcalc_P10 > output/full_correlation/gul_S1_pltcalc.csv & kpid8=$!
+kat work/full_correlation/kat/gul_S1_summarycalc_P1 work/full_correlation/kat/gul_S1_summarycalc_P2 work/full_correlation/kat/gul_S1_summarycalc_P3 work/full_correlation/kat/gul_S1_summarycalc_P4 work/full_correlation/kat/gul_S1_summarycalc_P5 work/full_correlation/kat/gul_S1_summarycalc_P6 work/full_correlation/kat/gul_S1_summarycalc_P7 work/full_correlation/kat/gul_S1_summarycalc_P8 work/full_correlation/kat/gul_S1_summarycalc_P9 work/full_correlation/kat/gul_S1_summarycalc_P10 > output/full_correlation/gul_S1_summarycalc.csv & kpid9=$!
+kat -s work/full_correlation/kat/gul_S2_eltcalc_P1 work/full_correlation/kat/gul_S2_eltcalc_P2 work/full_correlation/kat/gul_S2_eltcalc_P3 work/full_correlation/kat/gul_S2_eltcalc_P4 work/full_correlation/kat/gul_S2_eltcalc_P5 work/full_correlation/kat/gul_S2_eltcalc_P6 work/full_correlation/kat/gul_S2_eltcalc_P7 work/full_correlation/kat/gul_S2_eltcalc_P8 work/full_correlation/kat/gul_S2_eltcalc_P9 work/full_correlation/kat/gul_S2_eltcalc_P10 > output/full_correlation/gul_S2_eltcalc.csv & kpid10=$!
+kat work/full_correlation/kat/gul_S2_pltcalc_P1 work/full_correlation/kat/gul_S2_pltcalc_P2 work/full_correlation/kat/gul_S2_pltcalc_P3 work/full_correlation/kat/gul_S2_pltcalc_P4 work/full_correlation/kat/gul_S2_pltcalc_P5 work/full_correlation/kat/gul_S2_pltcalc_P6 work/full_correlation/kat/gul_S2_pltcalc_P7 work/full_correlation/kat/gul_S2_pltcalc_P8 work/full_correlation/kat/gul_S2_pltcalc_P9 work/full_correlation/kat/gul_S2_pltcalc_P10 > output/full_correlation/gul_S2_pltcalc.csv & kpid11=$!
+kat work/full_correlation/kat/gul_S2_summarycalc_P1 work/full_correlation/kat/gul_S2_summarycalc_P2 work/full_correlation/kat/gul_S2_summarycalc_P3 work/full_correlation/kat/gul_S2_summarycalc_P4 work/full_correlation/kat/gul_S2_summarycalc_P5 work/full_correlation/kat/gul_S2_summarycalc_P6 work/full_correlation/kat/gul_S2_summarycalc_P7 work/full_correlation/kat/gul_S2_summarycalc_P8 work/full_correlation/kat/gul_S2_summarycalc_P9 work/full_correlation/kat/gul_S2_summarycalc_P10 > output/full_correlation/gul_S2_summarycalc.csv & kpid12=$!
+wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpid11 $kpid12
+
+
+aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv & lpid1=$!
+ordleccalc -r -Kgul_S1_summaryleccalc -F -S -s -M -m -W -w -O output/gul_S1_ept.csv -o output/gul_S1_psept.csv & lpid2=$!
+leccalc -r -Kgul_S1_summaryleccalc -F output/gul_S1_leccalc_full_uncertainty_aep.csv -f output/gul_S1_leccalc_full_uncertainty_oep.csv -S output/gul_S1_leccalc_sample_mean_aep.csv -s output/gul_S1_leccalc_sample_mean_oep.csv -W output/gul_S1_leccalc_wheatsheaf_aep.csv -M output/gul_S1_leccalc_wheatsheaf_mean_aep.csv -m output/gul_S1_leccalc_wheatsheaf_mean_oep.csv -w output/gul_S1_leccalc_wheatsheaf_oep.csv & lpid3=$!
+aalcalc -Kgul_S2_summaryaalcalc > output/gul_S2_aalcalc.csv & lpid4=$!
+ordleccalc -r -Kgul_S2_summaryleccalc -F -S -s -M -m -W -w -O output/gul_S2_ept.csv -o output/gul_S2_psept.csv & lpid5=$!
+leccalc -r -Kgul_S2_summaryleccalc -F output/gul_S2_leccalc_full_uncertainty_aep.csv -f output/gul_S2_leccalc_full_uncertainty_oep.csv -S output/gul_S2_leccalc_sample_mean_aep.csv -s output/gul_S2_leccalc_sample_mean_oep.csv -W output/gul_S2_leccalc_wheatsheaf_aep.csv -M output/gul_S2_leccalc_wheatsheaf_mean_aep.csv -m output/gul_S2_leccalc_wheatsheaf_mean_oep.csv -w output/gul_S2_leccalc_wheatsheaf_oep.csv & lpid6=$!
+aalcalc -Kfull_correlation/gul_S1_summaryaalcalc > output/full_correlation/gul_S1_aalcalc.csv & lpid7=$!
+ordleccalc -r -Kfull_correlation/gul_S1_summaryleccalc -F -S -s -M -m -W -w -O output/full_correlation/gul_S1_ept.csv -o output/full_correlation/gul_S1_psept.csv & lpid8=$!
+leccalc -r -Kfull_correlation/gul_S1_summaryleccalc -F output/full_correlation/gul_S1_leccalc_full_uncertainty_aep.csv -f output/full_correlation/gul_S1_leccalc_full_uncertainty_oep.csv -S output/full_correlation/gul_S1_leccalc_sample_mean_aep.csv -s output/full_correlation/gul_S1_leccalc_sample_mean_oep.csv -W output/full_correlation/gul_S1_leccalc_wheatsheaf_aep.csv -M output/full_correlation/gul_S1_leccalc_wheatsheaf_mean_aep.csv -m output/full_correlation/gul_S1_leccalc_wheatsheaf_mean_oep.csv -w output/full_correlation/gul_S1_leccalc_wheatsheaf_oep.csv & lpid9=$!
+aalcalc -Kfull_correlation/gul_S2_summaryaalcalc > output/full_correlation/gul_S2_aalcalc.csv & lpid10=$!
+ordleccalc -r -Kfull_correlation/gul_S2_summaryleccalc -F -S -s -M -m -W -w -O output/full_correlation/gul_S2_ept.csv -o output/full_correlation/gul_S2_psept.csv & lpid11=$!
+leccalc -r -Kfull_correlation/gul_S2_summaryleccalc -F output/full_correlation/gul_S2_leccalc_full_uncertainty_aep.csv -f output/full_correlation/gul_S2_leccalc_full_uncertainty_oep.csv -S output/full_correlation/gul_S2_leccalc_sample_mean_aep.csv -s output/full_correlation/gul_S2_leccalc_sample_mean_oep.csv -W output/full_correlation/gul_S2_leccalc_wheatsheaf_aep.csv -M output/full_correlation/gul_S2_leccalc_wheatsheaf_mean_aep.csv -m output/full_correlation/gul_S2_leccalc_wheatsheaf_mean_oep.csv -w output/full_correlation/gul_S2_leccalc_wheatsheaf_oep.csv & lpid12=$!
+wait $lpid1 $lpid2 $lpid3 $lpid4 $lpid5 $lpid6 $lpid7 $lpid8 $lpid9 $lpid10 $lpid11 $lpid12
+
+rm -R -f work/*
+rm -R -f fifo/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_ord_psept_2_output_10_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_ord_psept_2_output_10_partition.sh
@@ -1,0 +1,209 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+mkdir output/full_correlation/
+
+rm -R -f fifo/*
+mkdir fifo/full_correlation/
+rm -R -f work/*
+mkdir work/kat/
+mkdir work/full_correlation/
+mkdir work/full_correlation/kat/
+
+mkdir work/gul_S1_summaryleccalc
+mkdir work/gul_S2_summaryleccalc
+mkdir work/full_correlation/gul_S1_summaryleccalc
+mkdir work/full_correlation/gul_S2_summaryleccalc
+
+mkfifo fifo/gul_P1
+mkfifo fifo/gul_P2
+mkfifo fifo/gul_P3
+mkfifo fifo/gul_P4
+mkfifo fifo/gul_P5
+mkfifo fifo/gul_P6
+mkfifo fifo/gul_P7
+mkfifo fifo/gul_P8
+mkfifo fifo/gul_P9
+mkfifo fifo/gul_P10
+
+mkfifo fifo/gul_S1_summary_P1
+mkfifo fifo/gul_S2_summary_P1
+
+mkfifo fifo/gul_S1_summary_P2
+mkfifo fifo/gul_S2_summary_P2
+
+mkfifo fifo/gul_S1_summary_P3
+mkfifo fifo/gul_S2_summary_P3
+
+mkfifo fifo/gul_S1_summary_P4
+mkfifo fifo/gul_S2_summary_P4
+
+mkfifo fifo/gul_S1_summary_P5
+mkfifo fifo/gul_S2_summary_P5
+
+mkfifo fifo/gul_S1_summary_P6
+mkfifo fifo/gul_S2_summary_P6
+
+mkfifo fifo/gul_S1_summary_P7
+mkfifo fifo/gul_S2_summary_P7
+
+mkfifo fifo/gul_S1_summary_P8
+mkfifo fifo/gul_S2_summary_P8
+
+mkfifo fifo/gul_S1_summary_P9
+mkfifo fifo/gul_S2_summary_P9
+
+mkfifo fifo/gul_S1_summary_P10
+mkfifo fifo/gul_S2_summary_P10
+
+mkfifo fifo/full_correlation/gul_P1
+mkfifo fifo/full_correlation/gul_P2
+mkfifo fifo/full_correlation/gul_P3
+mkfifo fifo/full_correlation/gul_P4
+mkfifo fifo/full_correlation/gul_P5
+mkfifo fifo/full_correlation/gul_P6
+mkfifo fifo/full_correlation/gul_P7
+mkfifo fifo/full_correlation/gul_P8
+mkfifo fifo/full_correlation/gul_P9
+mkfifo fifo/full_correlation/gul_P10
+
+mkfifo fifo/full_correlation/gul_S1_summary_P1
+mkfifo fifo/full_correlation/gul_S2_summary_P1
+
+mkfifo fifo/full_correlation/gul_S1_summary_P2
+mkfifo fifo/full_correlation/gul_S2_summary_P2
+
+mkfifo fifo/full_correlation/gul_S1_summary_P3
+mkfifo fifo/full_correlation/gul_S2_summary_P3
+
+mkfifo fifo/full_correlation/gul_S1_summary_P4
+mkfifo fifo/full_correlation/gul_S2_summary_P4
+
+mkfifo fifo/full_correlation/gul_S1_summary_P5
+mkfifo fifo/full_correlation/gul_S2_summary_P5
+
+mkfifo fifo/full_correlation/gul_S1_summary_P6
+mkfifo fifo/full_correlation/gul_S2_summary_P6
+
+mkfifo fifo/full_correlation/gul_S1_summary_P7
+mkfifo fifo/full_correlation/gul_S2_summary_P7
+
+mkfifo fifo/full_correlation/gul_S1_summary_P8
+mkfifo fifo/full_correlation/gul_S2_summary_P8
+
+mkfifo fifo/full_correlation/gul_S1_summary_P9
+mkfifo fifo/full_correlation/gul_S2_summary_P9
+
+mkfifo fifo/full_correlation/gul_S1_summary_P10
+mkfifo fifo/full_correlation/gul_S2_summary_P10
+
+
+
+# --- Do ground up loss computes ---
+
+
+tee < fifo/gul_S1_summary_P1 work/gul_S1_summaryleccalc/P1.bin > /dev/null & pid1=$!
+tee < fifo/gul_S2_summary_P1 work/gul_S2_summaryleccalc/P1.bin > /dev/null & pid2=$!
+tee < fifo/gul_S1_summary_P2 work/gul_S1_summaryleccalc/P2.bin > /dev/null & pid3=$!
+tee < fifo/gul_S2_summary_P2 work/gul_S2_summaryleccalc/P2.bin > /dev/null & pid4=$!
+tee < fifo/gul_S1_summary_P3 work/gul_S1_summaryleccalc/P3.bin > /dev/null & pid5=$!
+tee < fifo/gul_S2_summary_P3 work/gul_S2_summaryleccalc/P3.bin > /dev/null & pid6=$!
+tee < fifo/gul_S1_summary_P4 work/gul_S1_summaryleccalc/P4.bin > /dev/null & pid7=$!
+tee < fifo/gul_S2_summary_P4 work/gul_S2_summaryleccalc/P4.bin > /dev/null & pid8=$!
+tee < fifo/gul_S1_summary_P5 work/gul_S1_summaryleccalc/P5.bin > /dev/null & pid9=$!
+tee < fifo/gul_S2_summary_P5 work/gul_S2_summaryleccalc/P5.bin > /dev/null & pid10=$!
+tee < fifo/gul_S1_summary_P6 work/gul_S1_summaryleccalc/P6.bin > /dev/null & pid11=$!
+tee < fifo/gul_S2_summary_P6 work/gul_S2_summaryleccalc/P6.bin > /dev/null & pid12=$!
+tee < fifo/gul_S1_summary_P7 work/gul_S1_summaryleccalc/P7.bin > /dev/null & pid13=$!
+tee < fifo/gul_S2_summary_P7 work/gul_S2_summaryleccalc/P7.bin > /dev/null & pid14=$!
+tee < fifo/gul_S1_summary_P8 work/gul_S1_summaryleccalc/P8.bin > /dev/null & pid15=$!
+tee < fifo/gul_S2_summary_P8 work/gul_S2_summaryleccalc/P8.bin > /dev/null & pid16=$!
+tee < fifo/gul_S1_summary_P9 work/gul_S1_summaryleccalc/P9.bin > /dev/null & pid17=$!
+tee < fifo/gul_S2_summary_P9 work/gul_S2_summaryleccalc/P9.bin > /dev/null & pid18=$!
+tee < fifo/gul_S1_summary_P10 work/gul_S1_summaryleccalc/P10.bin > /dev/null & pid19=$!
+tee < fifo/gul_S2_summary_P10 work/gul_S2_summaryleccalc/P10.bin > /dev/null & pid20=$!
+
+summarycalc -i  -1 fifo/gul_S1_summary_P1 -2 fifo/gul_S2_summary_P1 < fifo/gul_P1 &
+summarycalc -i  -1 fifo/gul_S1_summary_P2 -2 fifo/gul_S2_summary_P2 < fifo/gul_P2 &
+summarycalc -i  -1 fifo/gul_S1_summary_P3 -2 fifo/gul_S2_summary_P3 < fifo/gul_P3 &
+summarycalc -i  -1 fifo/gul_S1_summary_P4 -2 fifo/gul_S2_summary_P4 < fifo/gul_P4 &
+summarycalc -i  -1 fifo/gul_S1_summary_P5 -2 fifo/gul_S2_summary_P5 < fifo/gul_P5 &
+summarycalc -i  -1 fifo/gul_S1_summary_P6 -2 fifo/gul_S2_summary_P6 < fifo/gul_P6 &
+summarycalc -i  -1 fifo/gul_S1_summary_P7 -2 fifo/gul_S2_summary_P7 < fifo/gul_P7 &
+summarycalc -i  -1 fifo/gul_S1_summary_P8 -2 fifo/gul_S2_summary_P8 < fifo/gul_P8 &
+summarycalc -i  -1 fifo/gul_S1_summary_P9 -2 fifo/gul_S2_summary_P9 < fifo/gul_P9 &
+summarycalc -i  -1 fifo/gul_S1_summary_P10 -2 fifo/gul_S2_summary_P10 < fifo/gul_P10 &
+
+# --- Do ground up loss computes ---
+
+
+tee < fifo/full_correlation/gul_S1_summary_P1 work/full_correlation/gul_S1_summaryleccalc/P1.bin > /dev/null & pid21=$!
+tee < fifo/full_correlation/gul_S2_summary_P1 work/full_correlation/gul_S2_summaryleccalc/P1.bin > /dev/null & pid22=$!
+tee < fifo/full_correlation/gul_S1_summary_P2 work/full_correlation/gul_S1_summaryleccalc/P2.bin > /dev/null & pid23=$!
+tee < fifo/full_correlation/gul_S2_summary_P2 work/full_correlation/gul_S2_summaryleccalc/P2.bin > /dev/null & pid24=$!
+tee < fifo/full_correlation/gul_S1_summary_P3 work/full_correlation/gul_S1_summaryleccalc/P3.bin > /dev/null & pid25=$!
+tee < fifo/full_correlation/gul_S2_summary_P3 work/full_correlation/gul_S2_summaryleccalc/P3.bin > /dev/null & pid26=$!
+tee < fifo/full_correlation/gul_S1_summary_P4 work/full_correlation/gul_S1_summaryleccalc/P4.bin > /dev/null & pid27=$!
+tee < fifo/full_correlation/gul_S2_summary_P4 work/full_correlation/gul_S2_summaryleccalc/P4.bin > /dev/null & pid28=$!
+tee < fifo/full_correlation/gul_S1_summary_P5 work/full_correlation/gul_S1_summaryleccalc/P5.bin > /dev/null & pid29=$!
+tee < fifo/full_correlation/gul_S2_summary_P5 work/full_correlation/gul_S2_summaryleccalc/P5.bin > /dev/null & pid30=$!
+tee < fifo/full_correlation/gul_S1_summary_P6 work/full_correlation/gul_S1_summaryleccalc/P6.bin > /dev/null & pid31=$!
+tee < fifo/full_correlation/gul_S2_summary_P6 work/full_correlation/gul_S2_summaryleccalc/P6.bin > /dev/null & pid32=$!
+tee < fifo/full_correlation/gul_S1_summary_P7 work/full_correlation/gul_S1_summaryleccalc/P7.bin > /dev/null & pid33=$!
+tee < fifo/full_correlation/gul_S2_summary_P7 work/full_correlation/gul_S2_summaryleccalc/P7.bin > /dev/null & pid34=$!
+tee < fifo/full_correlation/gul_S1_summary_P8 work/full_correlation/gul_S1_summaryleccalc/P8.bin > /dev/null & pid35=$!
+tee < fifo/full_correlation/gul_S2_summary_P8 work/full_correlation/gul_S2_summaryleccalc/P8.bin > /dev/null & pid36=$!
+tee < fifo/full_correlation/gul_S1_summary_P9 work/full_correlation/gul_S1_summaryleccalc/P9.bin > /dev/null & pid37=$!
+tee < fifo/full_correlation/gul_S2_summary_P9 work/full_correlation/gul_S2_summaryleccalc/P9.bin > /dev/null & pid38=$!
+tee < fifo/full_correlation/gul_S1_summary_P10 work/full_correlation/gul_S1_summaryleccalc/P10.bin > /dev/null & pid39=$!
+tee < fifo/full_correlation/gul_S2_summary_P10 work/full_correlation/gul_S2_summaryleccalc/P10.bin > /dev/null & pid40=$!
+
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P1 -2 fifo/full_correlation/gul_S2_summary_P1 < fifo/full_correlation/gul_P1 &
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P2 -2 fifo/full_correlation/gul_S2_summary_P2 < fifo/full_correlation/gul_P2 &
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P3 -2 fifo/full_correlation/gul_S2_summary_P3 < fifo/full_correlation/gul_P3 &
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P4 -2 fifo/full_correlation/gul_S2_summary_P4 < fifo/full_correlation/gul_P4 &
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P5 -2 fifo/full_correlation/gul_S2_summary_P5 < fifo/full_correlation/gul_P5 &
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P6 -2 fifo/full_correlation/gul_S2_summary_P6 < fifo/full_correlation/gul_P6 &
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P7 -2 fifo/full_correlation/gul_S2_summary_P7 < fifo/full_correlation/gul_P7 &
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P8 -2 fifo/full_correlation/gul_S2_summary_P8 < fifo/full_correlation/gul_P8 &
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P9 -2 fifo/full_correlation/gul_S2_summary_P9 < fifo/full_correlation/gul_P9 &
+summarycalc -i  -1 fifo/full_correlation/gul_S1_summary_P10 -2 fifo/full_correlation/gul_S2_summary_P10 < fifo/full_correlation/gul_P10 &
+
+eve 1 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P1 -a1 -i - > fifo/gul_P1  &
+eve 2 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P2 -a1 -i - > fifo/gul_P2  &
+eve 3 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P3 -a1 -i - > fifo/gul_P3  &
+eve 4 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P4 -a1 -i - > fifo/gul_P4  &
+eve 5 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P5 -a1 -i - > fifo/gul_P5  &
+eve 6 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P6 -a1 -i - > fifo/gul_P6  &
+eve 7 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P7 -a1 -i - > fifo/gul_P7  &
+eve 8 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P8 -a1 -i - > fifo/gul_P8  &
+eve 9 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P9 -a1 -i - > fifo/gul_P9  &
+eve 10 10 | getmodel | gulcalc -S0 -L0 -r -j fifo/full_correlation/gul_P10 -a1 -i - > fifo/gul_P10  &
+
+wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 $pid13 $pid14 $pid15 $pid16 $pid17 $pid18 $pid19 $pid20 $pid21 $pid22 $pid23 $pid24 $pid25 $pid26 $pid27 $pid28 $pid29 $pid30 $pid31 $pid32 $pid33 $pid34 $pid35 $pid36 $pid37 $pid38 $pid39 $pid40
+
+
+# --- Do ground up loss kats ---
+
+
+# --- Do ground up loss kats for fully correlated output ---
+
+
+ordleccalc  -Kgul_S1_summaryleccalc -W -w -o output/gul_S1_psept.csv & lpid1=$!
+ordleccalc -r -Kgul_S2_summaryleccalc -W -w -o output/gul_S2_psept.csv & lpid2=$!
+ordleccalc  -Kfull_correlation/gul_S1_summaryleccalc -W -w -o output/full_correlation/gul_S1_psept.csv & lpid3=$!
+ordleccalc -r -Kfull_correlation/gul_S2_summaryleccalc -W -w -o output/full_correlation/gul_S2_psept.csv & lpid4=$!
+wait $lpid1 $lpid2 $lpid3 $lpid4
+
+rm -R -f work/*
+rm -R -f fifo/*

--- a/tests/model_execution/itm_kparse_reference/analysis_settings_5_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/analysis_settings_5_1_reins_layer_1_partition.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+
+rm -R -f fifo/*
+rm -R -f work/*
+mkdir work/kat/
+
+mkdir work/gul_S1_summaryaalcalc
+mkdir work/il_S1_summaryleccalc
+mkdir work/ri_S1_summaryleccalc
+
+mkfifo fifo/gul_P1
+
+mkfifo fifo/gul_S1_summary_P1
+mkfifo fifo/gul_S1_eltcalc_P1
+mkfifo fifo/gul_S1_summarycalc_P1
+mkfifo fifo/gul_S1_pltcalc_P1
+
+mkfifo fifo/il_P1
+
+mkfifo fifo/il_S1_summary_P1
+
+mkfifo fifo/ri_P1
+
+mkfifo fifo/ri_S1_summary_P1
+
+
+
+# --- Do reinsurance loss computes ---
+
+
+tee < fifo/ri_S1_summary_P1 work/ri_S1_summaryleccalc/P1.bin > /dev/null & pid1=$!
+
+summarycalc -f -p RI_1 -1 fifo/ri_S1_summary_P1 < fifo/ri_P1 &
+
+# --- Do insured loss computes ---
+
+
+tee < fifo/il_S1_summary_P1 work/il_S1_summaryleccalc/P1.bin > /dev/null & pid2=$!
+
+summarycalc -f  -1 fifo/il_S1_summary_P1 < fifo/il_P1 &
+
+# --- Do ground up loss computes ---
+
+eltcalc < fifo/gul_S1_eltcalc_P1 > work/kat/gul_S1_eltcalc_P1 & pid3=$!
+summarycalctocsv < fifo/gul_S1_summarycalc_P1 > work/kat/gul_S1_summarycalc_P1 & pid4=$!
+pltcalc < fifo/gul_S1_pltcalc_P1 > work/kat/gul_S1_pltcalc_P1 & pid5=$!
+
+tee < fifo/gul_S1_summary_P1 fifo/gul_S1_eltcalc_P1 fifo/gul_S1_summarycalc_P1 fifo/gul_S1_pltcalc_P1 work/gul_S1_summaryaalcalc/P1.bin > /dev/null & pid6=$!
+
+summarycalc -i  -1 fifo/gul_S1_summary_P1 < fifo/gul_P1 &
+
+eve 1 1 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee fifo/gul_P1 | fmcalc -a2 | tee fifo/il_P1 | fmcalc -a3 -n -p RI_1 > fifo/ri_P1 &
+
+wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6
+
+
+# --- Do reinsurance loss kats ---
+
+
+# --- Do insured loss kats ---
+
+
+# --- Do ground up loss kats ---
+
+kat -s work/kat/gul_S1_eltcalc_P1 > output/gul_S1_eltcalc.csv & kpid1=$!
+kat work/kat/gul_S1_pltcalc_P1 > output/gul_S1_pltcalc.csv & kpid2=$!
+kat work/kat/gul_S1_summarycalc_P1 > output/gul_S1_summarycalc.csv & kpid3=$!
+wait $kpid1 $kpid2 $kpid3
+
+
+ordleccalc -r -Kri_S1_summaryleccalc -F -f -S -s -M -m -W -w -O output/ri_S1_ept.csv -o output/ri_S1_psept.csv & lpid1=$!
+ordleccalc  -Kil_S1_summaryleccalc -F -S -s -M -m -O output/il_S1_ept.csv & lpid2=$!
+aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv & lpid3=$!
+wait $lpid1 $lpid2 $lpid3
+
+rm -R -f work/*
+rm -R -f fifo/*

--- a/tests/model_execution/itm_kparse_reference/gul_il_ord_ept_psept_2_output_10_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_il_ord_ept_psept_2_output_10_partition.sh
@@ -1,0 +1,467 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+
+rm -R -f fifo/*
+rm -R -f work/*
+mkdir work/kat/
+
+mkdir work/gul_S1_summaryleccalc
+mkdir work/gul_S1_summaryaalcalc
+mkdir work/gul_S2_summaryleccalc
+mkdir work/gul_S2_summaryaalcalc
+mkdir work/il_S1_summaryleccalc
+mkdir work/il_S1_summaryaalcalc
+mkdir work/il_S2_summaryleccalc
+mkdir work/il_S2_summaryaalcalc
+
+mkfifo fifo/gul_P1
+mkfifo fifo/gul_P2
+mkfifo fifo/gul_P3
+mkfifo fifo/gul_P4
+mkfifo fifo/gul_P5
+mkfifo fifo/gul_P6
+mkfifo fifo/gul_P7
+mkfifo fifo/gul_P8
+mkfifo fifo/gul_P9
+mkfifo fifo/gul_P10
+
+mkfifo fifo/gul_S1_summary_P1
+mkfifo fifo/gul_S1_eltcalc_P1
+mkfifo fifo/gul_S1_summarycalc_P1
+mkfifo fifo/gul_S1_pltcalc_P1
+mkfifo fifo/gul_S2_summary_P1
+mkfifo fifo/gul_S2_eltcalc_P1
+mkfifo fifo/gul_S2_summarycalc_P1
+mkfifo fifo/gul_S2_pltcalc_P1
+
+mkfifo fifo/gul_S1_summary_P2
+mkfifo fifo/gul_S1_eltcalc_P2
+mkfifo fifo/gul_S1_summarycalc_P2
+mkfifo fifo/gul_S1_pltcalc_P2
+mkfifo fifo/gul_S2_summary_P2
+mkfifo fifo/gul_S2_eltcalc_P2
+mkfifo fifo/gul_S2_summarycalc_P2
+mkfifo fifo/gul_S2_pltcalc_P2
+
+mkfifo fifo/gul_S1_summary_P3
+mkfifo fifo/gul_S1_eltcalc_P3
+mkfifo fifo/gul_S1_summarycalc_P3
+mkfifo fifo/gul_S1_pltcalc_P3
+mkfifo fifo/gul_S2_summary_P3
+mkfifo fifo/gul_S2_eltcalc_P3
+mkfifo fifo/gul_S2_summarycalc_P3
+mkfifo fifo/gul_S2_pltcalc_P3
+
+mkfifo fifo/gul_S1_summary_P4
+mkfifo fifo/gul_S1_eltcalc_P4
+mkfifo fifo/gul_S1_summarycalc_P4
+mkfifo fifo/gul_S1_pltcalc_P4
+mkfifo fifo/gul_S2_summary_P4
+mkfifo fifo/gul_S2_eltcalc_P4
+mkfifo fifo/gul_S2_summarycalc_P4
+mkfifo fifo/gul_S2_pltcalc_P4
+
+mkfifo fifo/gul_S1_summary_P5
+mkfifo fifo/gul_S1_eltcalc_P5
+mkfifo fifo/gul_S1_summarycalc_P5
+mkfifo fifo/gul_S1_pltcalc_P5
+mkfifo fifo/gul_S2_summary_P5
+mkfifo fifo/gul_S2_eltcalc_P5
+mkfifo fifo/gul_S2_summarycalc_P5
+mkfifo fifo/gul_S2_pltcalc_P5
+
+mkfifo fifo/gul_S1_summary_P6
+mkfifo fifo/gul_S1_eltcalc_P6
+mkfifo fifo/gul_S1_summarycalc_P6
+mkfifo fifo/gul_S1_pltcalc_P6
+mkfifo fifo/gul_S2_summary_P6
+mkfifo fifo/gul_S2_eltcalc_P6
+mkfifo fifo/gul_S2_summarycalc_P6
+mkfifo fifo/gul_S2_pltcalc_P6
+
+mkfifo fifo/gul_S1_summary_P7
+mkfifo fifo/gul_S1_eltcalc_P7
+mkfifo fifo/gul_S1_summarycalc_P7
+mkfifo fifo/gul_S1_pltcalc_P7
+mkfifo fifo/gul_S2_summary_P7
+mkfifo fifo/gul_S2_eltcalc_P7
+mkfifo fifo/gul_S2_summarycalc_P7
+mkfifo fifo/gul_S2_pltcalc_P7
+
+mkfifo fifo/gul_S1_summary_P8
+mkfifo fifo/gul_S1_eltcalc_P8
+mkfifo fifo/gul_S1_summarycalc_P8
+mkfifo fifo/gul_S1_pltcalc_P8
+mkfifo fifo/gul_S2_summary_P8
+mkfifo fifo/gul_S2_eltcalc_P8
+mkfifo fifo/gul_S2_summarycalc_P8
+mkfifo fifo/gul_S2_pltcalc_P8
+
+mkfifo fifo/gul_S1_summary_P9
+mkfifo fifo/gul_S1_eltcalc_P9
+mkfifo fifo/gul_S1_summarycalc_P9
+mkfifo fifo/gul_S1_pltcalc_P9
+mkfifo fifo/gul_S2_summary_P9
+mkfifo fifo/gul_S2_eltcalc_P9
+mkfifo fifo/gul_S2_summarycalc_P9
+mkfifo fifo/gul_S2_pltcalc_P9
+
+mkfifo fifo/gul_S1_summary_P10
+mkfifo fifo/gul_S1_eltcalc_P10
+mkfifo fifo/gul_S1_summarycalc_P10
+mkfifo fifo/gul_S1_pltcalc_P10
+mkfifo fifo/gul_S2_summary_P10
+mkfifo fifo/gul_S2_eltcalc_P10
+mkfifo fifo/gul_S2_summarycalc_P10
+mkfifo fifo/gul_S2_pltcalc_P10
+
+mkfifo fifo/il_P1
+mkfifo fifo/il_P2
+mkfifo fifo/il_P3
+mkfifo fifo/il_P4
+mkfifo fifo/il_P5
+mkfifo fifo/il_P6
+mkfifo fifo/il_P7
+mkfifo fifo/il_P8
+mkfifo fifo/il_P9
+mkfifo fifo/il_P10
+
+mkfifo fifo/il_S1_summary_P1
+mkfifo fifo/il_S1_eltcalc_P1
+mkfifo fifo/il_S1_summarycalc_P1
+mkfifo fifo/il_S1_pltcalc_P1
+mkfifo fifo/il_S2_summary_P1
+mkfifo fifo/il_S2_eltcalc_P1
+mkfifo fifo/il_S2_summarycalc_P1
+mkfifo fifo/il_S2_pltcalc_P1
+
+mkfifo fifo/il_S1_summary_P2
+mkfifo fifo/il_S1_eltcalc_P2
+mkfifo fifo/il_S1_summarycalc_P2
+mkfifo fifo/il_S1_pltcalc_P2
+mkfifo fifo/il_S2_summary_P2
+mkfifo fifo/il_S2_eltcalc_P2
+mkfifo fifo/il_S2_summarycalc_P2
+mkfifo fifo/il_S2_pltcalc_P2
+
+mkfifo fifo/il_S1_summary_P3
+mkfifo fifo/il_S1_eltcalc_P3
+mkfifo fifo/il_S1_summarycalc_P3
+mkfifo fifo/il_S1_pltcalc_P3
+mkfifo fifo/il_S2_summary_P3
+mkfifo fifo/il_S2_eltcalc_P3
+mkfifo fifo/il_S2_summarycalc_P3
+mkfifo fifo/il_S2_pltcalc_P3
+
+mkfifo fifo/il_S1_summary_P4
+mkfifo fifo/il_S1_eltcalc_P4
+mkfifo fifo/il_S1_summarycalc_P4
+mkfifo fifo/il_S1_pltcalc_P4
+mkfifo fifo/il_S2_summary_P4
+mkfifo fifo/il_S2_eltcalc_P4
+mkfifo fifo/il_S2_summarycalc_P4
+mkfifo fifo/il_S2_pltcalc_P4
+
+mkfifo fifo/il_S1_summary_P5
+mkfifo fifo/il_S1_eltcalc_P5
+mkfifo fifo/il_S1_summarycalc_P5
+mkfifo fifo/il_S1_pltcalc_P5
+mkfifo fifo/il_S2_summary_P5
+mkfifo fifo/il_S2_eltcalc_P5
+mkfifo fifo/il_S2_summarycalc_P5
+mkfifo fifo/il_S2_pltcalc_P5
+
+mkfifo fifo/il_S1_summary_P6
+mkfifo fifo/il_S1_eltcalc_P6
+mkfifo fifo/il_S1_summarycalc_P6
+mkfifo fifo/il_S1_pltcalc_P6
+mkfifo fifo/il_S2_summary_P6
+mkfifo fifo/il_S2_eltcalc_P6
+mkfifo fifo/il_S2_summarycalc_P6
+mkfifo fifo/il_S2_pltcalc_P6
+
+mkfifo fifo/il_S1_summary_P7
+mkfifo fifo/il_S1_eltcalc_P7
+mkfifo fifo/il_S1_summarycalc_P7
+mkfifo fifo/il_S1_pltcalc_P7
+mkfifo fifo/il_S2_summary_P7
+mkfifo fifo/il_S2_eltcalc_P7
+mkfifo fifo/il_S2_summarycalc_P7
+mkfifo fifo/il_S2_pltcalc_P7
+
+mkfifo fifo/il_S1_summary_P8
+mkfifo fifo/il_S1_eltcalc_P8
+mkfifo fifo/il_S1_summarycalc_P8
+mkfifo fifo/il_S1_pltcalc_P8
+mkfifo fifo/il_S2_summary_P8
+mkfifo fifo/il_S2_eltcalc_P8
+mkfifo fifo/il_S2_summarycalc_P8
+mkfifo fifo/il_S2_pltcalc_P8
+
+mkfifo fifo/il_S1_summary_P9
+mkfifo fifo/il_S1_eltcalc_P9
+mkfifo fifo/il_S1_summarycalc_P9
+mkfifo fifo/il_S1_pltcalc_P9
+mkfifo fifo/il_S2_summary_P9
+mkfifo fifo/il_S2_eltcalc_P9
+mkfifo fifo/il_S2_summarycalc_P9
+mkfifo fifo/il_S2_pltcalc_P9
+
+mkfifo fifo/il_S1_summary_P10
+mkfifo fifo/il_S1_eltcalc_P10
+mkfifo fifo/il_S1_summarycalc_P10
+mkfifo fifo/il_S1_pltcalc_P10
+mkfifo fifo/il_S2_summary_P10
+mkfifo fifo/il_S2_eltcalc_P10
+mkfifo fifo/il_S2_summarycalc_P10
+mkfifo fifo/il_S2_pltcalc_P10
+
+
+
+# --- Do insured loss computes ---
+
+eltcalc < fifo/il_S1_eltcalc_P1 > work/kat/il_S1_eltcalc_P1 & pid1=$!
+summarycalctocsv < fifo/il_S1_summarycalc_P1 > work/kat/il_S1_summarycalc_P1 & pid2=$!
+pltcalc < fifo/il_S1_pltcalc_P1 > work/kat/il_S1_pltcalc_P1 & pid3=$!
+eltcalc < fifo/il_S2_eltcalc_P1 > work/kat/il_S2_eltcalc_P1 & pid4=$!
+summarycalctocsv < fifo/il_S2_summarycalc_P1 > work/kat/il_S2_summarycalc_P1 & pid5=$!
+pltcalc < fifo/il_S2_pltcalc_P1 > work/kat/il_S2_pltcalc_P1 & pid6=$!
+eltcalc -s < fifo/il_S1_eltcalc_P2 > work/kat/il_S1_eltcalc_P2 & pid7=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P2 > work/kat/il_S1_summarycalc_P2 & pid8=$!
+pltcalc -s < fifo/il_S1_pltcalc_P2 > work/kat/il_S1_pltcalc_P2 & pid9=$!
+eltcalc -s < fifo/il_S2_eltcalc_P2 > work/kat/il_S2_eltcalc_P2 & pid10=$!
+summarycalctocsv -s < fifo/il_S2_summarycalc_P2 > work/kat/il_S2_summarycalc_P2 & pid11=$!
+pltcalc -s < fifo/il_S2_pltcalc_P2 > work/kat/il_S2_pltcalc_P2 & pid12=$!
+eltcalc -s < fifo/il_S1_eltcalc_P3 > work/kat/il_S1_eltcalc_P3 & pid13=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P3 > work/kat/il_S1_summarycalc_P3 & pid14=$!
+pltcalc -s < fifo/il_S1_pltcalc_P3 > work/kat/il_S1_pltcalc_P3 & pid15=$!
+eltcalc -s < fifo/il_S2_eltcalc_P3 > work/kat/il_S2_eltcalc_P3 & pid16=$!
+summarycalctocsv -s < fifo/il_S2_summarycalc_P3 > work/kat/il_S2_summarycalc_P3 & pid17=$!
+pltcalc -s < fifo/il_S2_pltcalc_P3 > work/kat/il_S2_pltcalc_P3 & pid18=$!
+eltcalc -s < fifo/il_S1_eltcalc_P4 > work/kat/il_S1_eltcalc_P4 & pid19=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P4 > work/kat/il_S1_summarycalc_P4 & pid20=$!
+pltcalc -s < fifo/il_S1_pltcalc_P4 > work/kat/il_S1_pltcalc_P4 & pid21=$!
+eltcalc -s < fifo/il_S2_eltcalc_P4 > work/kat/il_S2_eltcalc_P4 & pid22=$!
+summarycalctocsv -s < fifo/il_S2_summarycalc_P4 > work/kat/il_S2_summarycalc_P4 & pid23=$!
+pltcalc -s < fifo/il_S2_pltcalc_P4 > work/kat/il_S2_pltcalc_P4 & pid24=$!
+eltcalc -s < fifo/il_S1_eltcalc_P5 > work/kat/il_S1_eltcalc_P5 & pid25=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P5 > work/kat/il_S1_summarycalc_P5 & pid26=$!
+pltcalc -s < fifo/il_S1_pltcalc_P5 > work/kat/il_S1_pltcalc_P5 & pid27=$!
+eltcalc -s < fifo/il_S2_eltcalc_P5 > work/kat/il_S2_eltcalc_P5 & pid28=$!
+summarycalctocsv -s < fifo/il_S2_summarycalc_P5 > work/kat/il_S2_summarycalc_P5 & pid29=$!
+pltcalc -s < fifo/il_S2_pltcalc_P5 > work/kat/il_S2_pltcalc_P5 & pid30=$!
+eltcalc -s < fifo/il_S1_eltcalc_P6 > work/kat/il_S1_eltcalc_P6 & pid31=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P6 > work/kat/il_S1_summarycalc_P6 & pid32=$!
+pltcalc -s < fifo/il_S1_pltcalc_P6 > work/kat/il_S1_pltcalc_P6 & pid33=$!
+eltcalc -s < fifo/il_S2_eltcalc_P6 > work/kat/il_S2_eltcalc_P6 & pid34=$!
+summarycalctocsv -s < fifo/il_S2_summarycalc_P6 > work/kat/il_S2_summarycalc_P6 & pid35=$!
+pltcalc -s < fifo/il_S2_pltcalc_P6 > work/kat/il_S2_pltcalc_P6 & pid36=$!
+eltcalc -s < fifo/il_S1_eltcalc_P7 > work/kat/il_S1_eltcalc_P7 & pid37=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P7 > work/kat/il_S1_summarycalc_P7 & pid38=$!
+pltcalc -s < fifo/il_S1_pltcalc_P7 > work/kat/il_S1_pltcalc_P7 & pid39=$!
+eltcalc -s < fifo/il_S2_eltcalc_P7 > work/kat/il_S2_eltcalc_P7 & pid40=$!
+summarycalctocsv -s < fifo/il_S2_summarycalc_P7 > work/kat/il_S2_summarycalc_P7 & pid41=$!
+pltcalc -s < fifo/il_S2_pltcalc_P7 > work/kat/il_S2_pltcalc_P7 & pid42=$!
+eltcalc -s < fifo/il_S1_eltcalc_P8 > work/kat/il_S1_eltcalc_P8 & pid43=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P8 > work/kat/il_S1_summarycalc_P8 & pid44=$!
+pltcalc -s < fifo/il_S1_pltcalc_P8 > work/kat/il_S1_pltcalc_P8 & pid45=$!
+eltcalc -s < fifo/il_S2_eltcalc_P8 > work/kat/il_S2_eltcalc_P8 & pid46=$!
+summarycalctocsv -s < fifo/il_S2_summarycalc_P8 > work/kat/il_S2_summarycalc_P8 & pid47=$!
+pltcalc -s < fifo/il_S2_pltcalc_P8 > work/kat/il_S2_pltcalc_P8 & pid48=$!
+eltcalc -s < fifo/il_S1_eltcalc_P9 > work/kat/il_S1_eltcalc_P9 & pid49=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P9 > work/kat/il_S1_summarycalc_P9 & pid50=$!
+pltcalc -s < fifo/il_S1_pltcalc_P9 > work/kat/il_S1_pltcalc_P9 & pid51=$!
+eltcalc -s < fifo/il_S2_eltcalc_P9 > work/kat/il_S2_eltcalc_P9 & pid52=$!
+summarycalctocsv -s < fifo/il_S2_summarycalc_P9 > work/kat/il_S2_summarycalc_P9 & pid53=$!
+pltcalc -s < fifo/il_S2_pltcalc_P9 > work/kat/il_S2_pltcalc_P9 & pid54=$!
+eltcalc -s < fifo/il_S1_eltcalc_P10 > work/kat/il_S1_eltcalc_P10 & pid55=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P10 > work/kat/il_S1_summarycalc_P10 & pid56=$!
+pltcalc -s < fifo/il_S1_pltcalc_P10 > work/kat/il_S1_pltcalc_P10 & pid57=$!
+eltcalc -s < fifo/il_S2_eltcalc_P10 > work/kat/il_S2_eltcalc_P10 & pid58=$!
+summarycalctocsv -s < fifo/il_S2_summarycalc_P10 > work/kat/il_S2_summarycalc_P10 & pid59=$!
+pltcalc -s < fifo/il_S2_pltcalc_P10 > work/kat/il_S2_pltcalc_P10 & pid60=$!
+
+tee < fifo/il_S1_summary_P1 fifo/il_S1_eltcalc_P1 fifo/il_S1_summarycalc_P1 fifo/il_S1_pltcalc_P1 work/il_S1_summaryaalcalc/P1.bin work/il_S1_summaryleccalc/P1.bin > /dev/null & pid61=$!
+tee < fifo/il_S2_summary_P1 fifo/il_S2_eltcalc_P1 fifo/il_S2_summarycalc_P1 fifo/il_S2_pltcalc_P1 work/il_S2_summaryaalcalc/P1.bin work/il_S2_summaryleccalc/P1.bin > /dev/null & pid62=$!
+tee < fifo/il_S1_summary_P2 fifo/il_S1_eltcalc_P2 fifo/il_S1_summarycalc_P2 fifo/il_S1_pltcalc_P2 work/il_S1_summaryaalcalc/P2.bin work/il_S1_summaryleccalc/P2.bin > /dev/null & pid63=$!
+tee < fifo/il_S2_summary_P2 fifo/il_S2_eltcalc_P2 fifo/il_S2_summarycalc_P2 fifo/il_S2_pltcalc_P2 work/il_S2_summaryaalcalc/P2.bin work/il_S2_summaryleccalc/P2.bin > /dev/null & pid64=$!
+tee < fifo/il_S1_summary_P3 fifo/il_S1_eltcalc_P3 fifo/il_S1_summarycalc_P3 fifo/il_S1_pltcalc_P3 work/il_S1_summaryaalcalc/P3.bin work/il_S1_summaryleccalc/P3.bin > /dev/null & pid65=$!
+tee < fifo/il_S2_summary_P3 fifo/il_S2_eltcalc_P3 fifo/il_S2_summarycalc_P3 fifo/il_S2_pltcalc_P3 work/il_S2_summaryaalcalc/P3.bin work/il_S2_summaryleccalc/P3.bin > /dev/null & pid66=$!
+tee < fifo/il_S1_summary_P4 fifo/il_S1_eltcalc_P4 fifo/il_S1_summarycalc_P4 fifo/il_S1_pltcalc_P4 work/il_S1_summaryaalcalc/P4.bin work/il_S1_summaryleccalc/P4.bin > /dev/null & pid67=$!
+tee < fifo/il_S2_summary_P4 fifo/il_S2_eltcalc_P4 fifo/il_S2_summarycalc_P4 fifo/il_S2_pltcalc_P4 work/il_S2_summaryaalcalc/P4.bin work/il_S2_summaryleccalc/P4.bin > /dev/null & pid68=$!
+tee < fifo/il_S1_summary_P5 fifo/il_S1_eltcalc_P5 fifo/il_S1_summarycalc_P5 fifo/il_S1_pltcalc_P5 work/il_S1_summaryaalcalc/P5.bin work/il_S1_summaryleccalc/P5.bin > /dev/null & pid69=$!
+tee < fifo/il_S2_summary_P5 fifo/il_S2_eltcalc_P5 fifo/il_S2_summarycalc_P5 fifo/il_S2_pltcalc_P5 work/il_S2_summaryaalcalc/P5.bin work/il_S2_summaryleccalc/P5.bin > /dev/null & pid70=$!
+tee < fifo/il_S1_summary_P6 fifo/il_S1_eltcalc_P6 fifo/il_S1_summarycalc_P6 fifo/il_S1_pltcalc_P6 work/il_S1_summaryaalcalc/P6.bin work/il_S1_summaryleccalc/P6.bin > /dev/null & pid71=$!
+tee < fifo/il_S2_summary_P6 fifo/il_S2_eltcalc_P6 fifo/il_S2_summarycalc_P6 fifo/il_S2_pltcalc_P6 work/il_S2_summaryaalcalc/P6.bin work/il_S2_summaryleccalc/P6.bin > /dev/null & pid72=$!
+tee < fifo/il_S1_summary_P7 fifo/il_S1_eltcalc_P7 fifo/il_S1_summarycalc_P7 fifo/il_S1_pltcalc_P7 work/il_S1_summaryaalcalc/P7.bin work/il_S1_summaryleccalc/P7.bin > /dev/null & pid73=$!
+tee < fifo/il_S2_summary_P7 fifo/il_S2_eltcalc_P7 fifo/il_S2_summarycalc_P7 fifo/il_S2_pltcalc_P7 work/il_S2_summaryaalcalc/P7.bin work/il_S2_summaryleccalc/P7.bin > /dev/null & pid74=$!
+tee < fifo/il_S1_summary_P8 fifo/il_S1_eltcalc_P8 fifo/il_S1_summarycalc_P8 fifo/il_S1_pltcalc_P8 work/il_S1_summaryaalcalc/P8.bin work/il_S1_summaryleccalc/P8.bin > /dev/null & pid75=$!
+tee < fifo/il_S2_summary_P8 fifo/il_S2_eltcalc_P8 fifo/il_S2_summarycalc_P8 fifo/il_S2_pltcalc_P8 work/il_S2_summaryaalcalc/P8.bin work/il_S2_summaryleccalc/P8.bin > /dev/null & pid76=$!
+tee < fifo/il_S1_summary_P9 fifo/il_S1_eltcalc_P9 fifo/il_S1_summarycalc_P9 fifo/il_S1_pltcalc_P9 work/il_S1_summaryaalcalc/P9.bin work/il_S1_summaryleccalc/P9.bin > /dev/null & pid77=$!
+tee < fifo/il_S2_summary_P9 fifo/il_S2_eltcalc_P9 fifo/il_S2_summarycalc_P9 fifo/il_S2_pltcalc_P9 work/il_S2_summaryaalcalc/P9.bin work/il_S2_summaryleccalc/P9.bin > /dev/null & pid78=$!
+tee < fifo/il_S1_summary_P10 fifo/il_S1_eltcalc_P10 fifo/il_S1_summarycalc_P10 fifo/il_S1_pltcalc_P10 work/il_S1_summaryaalcalc/P10.bin work/il_S1_summaryleccalc/P10.bin > /dev/null & pid79=$!
+tee < fifo/il_S2_summary_P10 fifo/il_S2_eltcalc_P10 fifo/il_S2_summarycalc_P10 fifo/il_S2_pltcalc_P10 work/il_S2_summaryaalcalc/P10.bin work/il_S2_summaryleccalc/P10.bin > /dev/null & pid80=$!
+
+summarycalc -f  -1 fifo/il_S1_summary_P1 -2 fifo/il_S2_summary_P1 < fifo/il_P1 &
+summarycalc -f  -1 fifo/il_S1_summary_P2 -2 fifo/il_S2_summary_P2 < fifo/il_P2 &
+summarycalc -f  -1 fifo/il_S1_summary_P3 -2 fifo/il_S2_summary_P3 < fifo/il_P3 &
+summarycalc -f  -1 fifo/il_S1_summary_P4 -2 fifo/il_S2_summary_P4 < fifo/il_P4 &
+summarycalc -f  -1 fifo/il_S1_summary_P5 -2 fifo/il_S2_summary_P5 < fifo/il_P5 &
+summarycalc -f  -1 fifo/il_S1_summary_P6 -2 fifo/il_S2_summary_P6 < fifo/il_P6 &
+summarycalc -f  -1 fifo/il_S1_summary_P7 -2 fifo/il_S2_summary_P7 < fifo/il_P7 &
+summarycalc -f  -1 fifo/il_S1_summary_P8 -2 fifo/il_S2_summary_P8 < fifo/il_P8 &
+summarycalc -f  -1 fifo/il_S1_summary_P9 -2 fifo/il_S2_summary_P9 < fifo/il_P9 &
+summarycalc -f  -1 fifo/il_S1_summary_P10 -2 fifo/il_S2_summary_P10 < fifo/il_P10 &
+
+# --- Do ground up loss computes ---
+
+eltcalc < fifo/gul_S1_eltcalc_P1 > work/kat/gul_S1_eltcalc_P1 & pid81=$!
+summarycalctocsv < fifo/gul_S1_summarycalc_P1 > work/kat/gul_S1_summarycalc_P1 & pid82=$!
+pltcalc < fifo/gul_S1_pltcalc_P1 > work/kat/gul_S1_pltcalc_P1 & pid83=$!
+eltcalc < fifo/gul_S2_eltcalc_P1 > work/kat/gul_S2_eltcalc_P1 & pid84=$!
+summarycalctocsv < fifo/gul_S2_summarycalc_P1 > work/kat/gul_S2_summarycalc_P1 & pid85=$!
+pltcalc < fifo/gul_S2_pltcalc_P1 > work/kat/gul_S2_pltcalc_P1 & pid86=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P2 > work/kat/gul_S1_eltcalc_P2 & pid87=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P2 > work/kat/gul_S1_summarycalc_P2 & pid88=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P2 > work/kat/gul_S1_pltcalc_P2 & pid89=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P2 > work/kat/gul_S2_eltcalc_P2 & pid90=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P2 > work/kat/gul_S2_summarycalc_P2 & pid91=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P2 > work/kat/gul_S2_pltcalc_P2 & pid92=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P3 > work/kat/gul_S1_eltcalc_P3 & pid93=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P3 > work/kat/gul_S1_summarycalc_P3 & pid94=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P3 > work/kat/gul_S1_pltcalc_P3 & pid95=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P3 > work/kat/gul_S2_eltcalc_P3 & pid96=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P3 > work/kat/gul_S2_summarycalc_P3 & pid97=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P3 > work/kat/gul_S2_pltcalc_P3 & pid98=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P4 > work/kat/gul_S1_eltcalc_P4 & pid99=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P4 > work/kat/gul_S1_summarycalc_P4 & pid100=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P4 > work/kat/gul_S1_pltcalc_P4 & pid101=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P4 > work/kat/gul_S2_eltcalc_P4 & pid102=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P4 > work/kat/gul_S2_summarycalc_P4 & pid103=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P4 > work/kat/gul_S2_pltcalc_P4 & pid104=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P5 > work/kat/gul_S1_eltcalc_P5 & pid105=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P5 > work/kat/gul_S1_summarycalc_P5 & pid106=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P5 > work/kat/gul_S1_pltcalc_P5 & pid107=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P5 > work/kat/gul_S2_eltcalc_P5 & pid108=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P5 > work/kat/gul_S2_summarycalc_P5 & pid109=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P5 > work/kat/gul_S2_pltcalc_P5 & pid110=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P6 > work/kat/gul_S1_eltcalc_P6 & pid111=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P6 > work/kat/gul_S1_summarycalc_P6 & pid112=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P6 > work/kat/gul_S1_pltcalc_P6 & pid113=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P6 > work/kat/gul_S2_eltcalc_P6 & pid114=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P6 > work/kat/gul_S2_summarycalc_P6 & pid115=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P6 > work/kat/gul_S2_pltcalc_P6 & pid116=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P7 > work/kat/gul_S1_eltcalc_P7 & pid117=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P7 > work/kat/gul_S1_summarycalc_P7 & pid118=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P7 > work/kat/gul_S1_pltcalc_P7 & pid119=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P7 > work/kat/gul_S2_eltcalc_P7 & pid120=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P7 > work/kat/gul_S2_summarycalc_P7 & pid121=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P7 > work/kat/gul_S2_pltcalc_P7 & pid122=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P8 > work/kat/gul_S1_eltcalc_P8 & pid123=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P8 > work/kat/gul_S1_summarycalc_P8 & pid124=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P8 > work/kat/gul_S1_pltcalc_P8 & pid125=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P8 > work/kat/gul_S2_eltcalc_P8 & pid126=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P8 > work/kat/gul_S2_summarycalc_P8 & pid127=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P8 > work/kat/gul_S2_pltcalc_P8 & pid128=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P9 > work/kat/gul_S1_eltcalc_P9 & pid129=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P9 > work/kat/gul_S1_summarycalc_P9 & pid130=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P9 > work/kat/gul_S1_pltcalc_P9 & pid131=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P9 > work/kat/gul_S2_eltcalc_P9 & pid132=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P9 > work/kat/gul_S2_summarycalc_P9 & pid133=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P9 > work/kat/gul_S2_pltcalc_P9 & pid134=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P10 > work/kat/gul_S1_eltcalc_P10 & pid135=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P10 > work/kat/gul_S1_summarycalc_P10 & pid136=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P10 > work/kat/gul_S1_pltcalc_P10 & pid137=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P10 > work/kat/gul_S2_eltcalc_P10 & pid138=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P10 > work/kat/gul_S2_summarycalc_P10 & pid139=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P10 > work/kat/gul_S2_pltcalc_P10 & pid140=$!
+
+tee < fifo/gul_S1_summary_P1 fifo/gul_S1_eltcalc_P1 fifo/gul_S1_summarycalc_P1 fifo/gul_S1_pltcalc_P1 work/gul_S1_summaryaalcalc/P1.bin work/gul_S1_summaryleccalc/P1.bin > /dev/null & pid141=$!
+tee < fifo/gul_S2_summary_P1 fifo/gul_S2_eltcalc_P1 fifo/gul_S2_summarycalc_P1 fifo/gul_S2_pltcalc_P1 work/gul_S2_summaryaalcalc/P1.bin work/gul_S2_summaryleccalc/P1.bin > /dev/null & pid142=$!
+tee < fifo/gul_S1_summary_P2 fifo/gul_S1_eltcalc_P2 fifo/gul_S1_summarycalc_P2 fifo/gul_S1_pltcalc_P2 work/gul_S1_summaryaalcalc/P2.bin work/gul_S1_summaryleccalc/P2.bin > /dev/null & pid143=$!
+tee < fifo/gul_S2_summary_P2 fifo/gul_S2_eltcalc_P2 fifo/gul_S2_summarycalc_P2 fifo/gul_S2_pltcalc_P2 work/gul_S2_summaryaalcalc/P2.bin work/gul_S2_summaryleccalc/P2.bin > /dev/null & pid144=$!
+tee < fifo/gul_S1_summary_P3 fifo/gul_S1_eltcalc_P3 fifo/gul_S1_summarycalc_P3 fifo/gul_S1_pltcalc_P3 work/gul_S1_summaryaalcalc/P3.bin work/gul_S1_summaryleccalc/P3.bin > /dev/null & pid145=$!
+tee < fifo/gul_S2_summary_P3 fifo/gul_S2_eltcalc_P3 fifo/gul_S2_summarycalc_P3 fifo/gul_S2_pltcalc_P3 work/gul_S2_summaryaalcalc/P3.bin work/gul_S2_summaryleccalc/P3.bin > /dev/null & pid146=$!
+tee < fifo/gul_S1_summary_P4 fifo/gul_S1_eltcalc_P4 fifo/gul_S1_summarycalc_P4 fifo/gul_S1_pltcalc_P4 work/gul_S1_summaryaalcalc/P4.bin work/gul_S1_summaryleccalc/P4.bin > /dev/null & pid147=$!
+tee < fifo/gul_S2_summary_P4 fifo/gul_S2_eltcalc_P4 fifo/gul_S2_summarycalc_P4 fifo/gul_S2_pltcalc_P4 work/gul_S2_summaryaalcalc/P4.bin work/gul_S2_summaryleccalc/P4.bin > /dev/null & pid148=$!
+tee < fifo/gul_S1_summary_P5 fifo/gul_S1_eltcalc_P5 fifo/gul_S1_summarycalc_P5 fifo/gul_S1_pltcalc_P5 work/gul_S1_summaryaalcalc/P5.bin work/gul_S1_summaryleccalc/P5.bin > /dev/null & pid149=$!
+tee < fifo/gul_S2_summary_P5 fifo/gul_S2_eltcalc_P5 fifo/gul_S2_summarycalc_P5 fifo/gul_S2_pltcalc_P5 work/gul_S2_summaryaalcalc/P5.bin work/gul_S2_summaryleccalc/P5.bin > /dev/null & pid150=$!
+tee < fifo/gul_S1_summary_P6 fifo/gul_S1_eltcalc_P6 fifo/gul_S1_summarycalc_P6 fifo/gul_S1_pltcalc_P6 work/gul_S1_summaryaalcalc/P6.bin work/gul_S1_summaryleccalc/P6.bin > /dev/null & pid151=$!
+tee < fifo/gul_S2_summary_P6 fifo/gul_S2_eltcalc_P6 fifo/gul_S2_summarycalc_P6 fifo/gul_S2_pltcalc_P6 work/gul_S2_summaryaalcalc/P6.bin work/gul_S2_summaryleccalc/P6.bin > /dev/null & pid152=$!
+tee < fifo/gul_S1_summary_P7 fifo/gul_S1_eltcalc_P7 fifo/gul_S1_summarycalc_P7 fifo/gul_S1_pltcalc_P7 work/gul_S1_summaryaalcalc/P7.bin work/gul_S1_summaryleccalc/P7.bin > /dev/null & pid153=$!
+tee < fifo/gul_S2_summary_P7 fifo/gul_S2_eltcalc_P7 fifo/gul_S2_summarycalc_P7 fifo/gul_S2_pltcalc_P7 work/gul_S2_summaryaalcalc/P7.bin work/gul_S2_summaryleccalc/P7.bin > /dev/null & pid154=$!
+tee < fifo/gul_S1_summary_P8 fifo/gul_S1_eltcalc_P8 fifo/gul_S1_summarycalc_P8 fifo/gul_S1_pltcalc_P8 work/gul_S1_summaryaalcalc/P8.bin work/gul_S1_summaryleccalc/P8.bin > /dev/null & pid155=$!
+tee < fifo/gul_S2_summary_P8 fifo/gul_S2_eltcalc_P8 fifo/gul_S2_summarycalc_P8 fifo/gul_S2_pltcalc_P8 work/gul_S2_summaryaalcalc/P8.bin work/gul_S2_summaryleccalc/P8.bin > /dev/null & pid156=$!
+tee < fifo/gul_S1_summary_P9 fifo/gul_S1_eltcalc_P9 fifo/gul_S1_summarycalc_P9 fifo/gul_S1_pltcalc_P9 work/gul_S1_summaryaalcalc/P9.bin work/gul_S1_summaryleccalc/P9.bin > /dev/null & pid157=$!
+tee < fifo/gul_S2_summary_P9 fifo/gul_S2_eltcalc_P9 fifo/gul_S2_summarycalc_P9 fifo/gul_S2_pltcalc_P9 work/gul_S2_summaryaalcalc/P9.bin work/gul_S2_summaryleccalc/P9.bin > /dev/null & pid158=$!
+tee < fifo/gul_S1_summary_P10 fifo/gul_S1_eltcalc_P10 fifo/gul_S1_summarycalc_P10 fifo/gul_S1_pltcalc_P10 work/gul_S1_summaryaalcalc/P10.bin work/gul_S1_summaryleccalc/P10.bin > /dev/null & pid159=$!
+tee < fifo/gul_S2_summary_P10 fifo/gul_S2_eltcalc_P10 fifo/gul_S2_summarycalc_P10 fifo/gul_S2_pltcalc_P10 work/gul_S2_summaryaalcalc/P10.bin work/gul_S2_summaryleccalc/P10.bin > /dev/null & pid160=$!
+
+summarycalc -i  -1 fifo/gul_S1_summary_P1 -2 fifo/gul_S2_summary_P1 < fifo/gul_P1 &
+summarycalc -i  -1 fifo/gul_S1_summary_P2 -2 fifo/gul_S2_summary_P2 < fifo/gul_P2 &
+summarycalc -i  -1 fifo/gul_S1_summary_P3 -2 fifo/gul_S2_summary_P3 < fifo/gul_P3 &
+summarycalc -i  -1 fifo/gul_S1_summary_P4 -2 fifo/gul_S2_summary_P4 < fifo/gul_P4 &
+summarycalc -i  -1 fifo/gul_S1_summary_P5 -2 fifo/gul_S2_summary_P5 < fifo/gul_P5 &
+summarycalc -i  -1 fifo/gul_S1_summary_P6 -2 fifo/gul_S2_summary_P6 < fifo/gul_P6 &
+summarycalc -i  -1 fifo/gul_S1_summary_P7 -2 fifo/gul_S2_summary_P7 < fifo/gul_P7 &
+summarycalc -i  -1 fifo/gul_S1_summary_P8 -2 fifo/gul_S2_summary_P8 < fifo/gul_P8 &
+summarycalc -i  -1 fifo/gul_S1_summary_P9 -2 fifo/gul_S2_summary_P9 < fifo/gul_P9 &
+summarycalc -i  -1 fifo/gul_S1_summary_P10 -2 fifo/gul_S2_summary_P10 < fifo/gul_P10 &
+
+eve 1 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee fifo/gul_P1 | fmcalc -a2 > fifo/il_P1  &
+eve 2 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee fifo/gul_P2 | fmcalc -a2 > fifo/il_P2  &
+eve 3 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee fifo/gul_P3 | fmcalc -a2 > fifo/il_P3  &
+eve 4 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee fifo/gul_P4 | fmcalc -a2 > fifo/il_P4  &
+eve 5 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee fifo/gul_P5 | fmcalc -a2 > fifo/il_P5  &
+eve 6 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee fifo/gul_P6 | fmcalc -a2 > fifo/il_P6  &
+eve 7 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee fifo/gul_P7 | fmcalc -a2 > fifo/il_P7  &
+eve 8 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee fifo/gul_P8 | fmcalc -a2 > fifo/il_P8  &
+eve 9 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee fifo/gul_P9 | fmcalc -a2 > fifo/il_P9  &
+eve 10 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee fifo/gul_P10 | fmcalc -a2 > fifo/il_P10  &
+
+wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 $pid13 $pid14 $pid15 $pid16 $pid17 $pid18 $pid19 $pid20 $pid21 $pid22 $pid23 $pid24 $pid25 $pid26 $pid27 $pid28 $pid29 $pid30 $pid31 $pid32 $pid33 $pid34 $pid35 $pid36 $pid37 $pid38 $pid39 $pid40 $pid41 $pid42 $pid43 $pid44 $pid45 $pid46 $pid47 $pid48 $pid49 $pid50 $pid51 $pid52 $pid53 $pid54 $pid55 $pid56 $pid57 $pid58 $pid59 $pid60 $pid61 $pid62 $pid63 $pid64 $pid65 $pid66 $pid67 $pid68 $pid69 $pid70 $pid71 $pid72 $pid73 $pid74 $pid75 $pid76 $pid77 $pid78 $pid79 $pid80 $pid81 $pid82 $pid83 $pid84 $pid85 $pid86 $pid87 $pid88 $pid89 $pid90 $pid91 $pid92 $pid93 $pid94 $pid95 $pid96 $pid97 $pid98 $pid99 $pid100 $pid101 $pid102 $pid103 $pid104 $pid105 $pid106 $pid107 $pid108 $pid109 $pid110 $pid111 $pid112 $pid113 $pid114 $pid115 $pid116 $pid117 $pid118 $pid119 $pid120 $pid121 $pid122 $pid123 $pid124 $pid125 $pid126 $pid127 $pid128 $pid129 $pid130 $pid131 $pid132 $pid133 $pid134 $pid135 $pid136 $pid137 $pid138 $pid139 $pid140 $pid141 $pid142 $pid143 $pid144 $pid145 $pid146 $pid147 $pid148 $pid149 $pid150 $pid151 $pid152 $pid153 $pid154 $pid155 $pid156 $pid157 $pid158 $pid159 $pid160
+
+
+# --- Do insured loss kats ---
+
+kat -s work/kat/il_S1_eltcalc_P1 work/kat/il_S1_eltcalc_P2 work/kat/il_S1_eltcalc_P3 work/kat/il_S1_eltcalc_P4 work/kat/il_S1_eltcalc_P5 work/kat/il_S1_eltcalc_P6 work/kat/il_S1_eltcalc_P7 work/kat/il_S1_eltcalc_P8 work/kat/il_S1_eltcalc_P9 work/kat/il_S1_eltcalc_P10 > output/il_S1_eltcalc.csv & kpid1=$!
+kat work/kat/il_S1_pltcalc_P1 work/kat/il_S1_pltcalc_P2 work/kat/il_S1_pltcalc_P3 work/kat/il_S1_pltcalc_P4 work/kat/il_S1_pltcalc_P5 work/kat/il_S1_pltcalc_P6 work/kat/il_S1_pltcalc_P7 work/kat/il_S1_pltcalc_P8 work/kat/il_S1_pltcalc_P9 work/kat/il_S1_pltcalc_P10 > output/il_S1_pltcalc.csv & kpid2=$!
+kat work/kat/il_S1_summarycalc_P1 work/kat/il_S1_summarycalc_P2 work/kat/il_S1_summarycalc_P3 work/kat/il_S1_summarycalc_P4 work/kat/il_S1_summarycalc_P5 work/kat/il_S1_summarycalc_P6 work/kat/il_S1_summarycalc_P7 work/kat/il_S1_summarycalc_P8 work/kat/il_S1_summarycalc_P9 work/kat/il_S1_summarycalc_P10 > output/il_S1_summarycalc.csv & kpid3=$!
+kat -s work/kat/il_S2_eltcalc_P1 work/kat/il_S2_eltcalc_P2 work/kat/il_S2_eltcalc_P3 work/kat/il_S2_eltcalc_P4 work/kat/il_S2_eltcalc_P5 work/kat/il_S2_eltcalc_P6 work/kat/il_S2_eltcalc_P7 work/kat/il_S2_eltcalc_P8 work/kat/il_S2_eltcalc_P9 work/kat/il_S2_eltcalc_P10 > output/il_S2_eltcalc.csv & kpid4=$!
+kat work/kat/il_S2_pltcalc_P1 work/kat/il_S2_pltcalc_P2 work/kat/il_S2_pltcalc_P3 work/kat/il_S2_pltcalc_P4 work/kat/il_S2_pltcalc_P5 work/kat/il_S2_pltcalc_P6 work/kat/il_S2_pltcalc_P7 work/kat/il_S2_pltcalc_P8 work/kat/il_S2_pltcalc_P9 work/kat/il_S2_pltcalc_P10 > output/il_S2_pltcalc.csv & kpid5=$!
+kat work/kat/il_S2_summarycalc_P1 work/kat/il_S2_summarycalc_P2 work/kat/il_S2_summarycalc_P3 work/kat/il_S2_summarycalc_P4 work/kat/il_S2_summarycalc_P5 work/kat/il_S2_summarycalc_P6 work/kat/il_S2_summarycalc_P7 work/kat/il_S2_summarycalc_P8 work/kat/il_S2_summarycalc_P9 work/kat/il_S2_summarycalc_P10 > output/il_S2_summarycalc.csv & kpid6=$!
+
+# --- Do ground up loss kats ---
+
+kat -s work/kat/gul_S1_eltcalc_P1 work/kat/gul_S1_eltcalc_P2 work/kat/gul_S1_eltcalc_P3 work/kat/gul_S1_eltcalc_P4 work/kat/gul_S1_eltcalc_P5 work/kat/gul_S1_eltcalc_P6 work/kat/gul_S1_eltcalc_P7 work/kat/gul_S1_eltcalc_P8 work/kat/gul_S1_eltcalc_P9 work/kat/gul_S1_eltcalc_P10 > output/gul_S1_eltcalc.csv & kpid7=$!
+kat work/kat/gul_S1_pltcalc_P1 work/kat/gul_S1_pltcalc_P2 work/kat/gul_S1_pltcalc_P3 work/kat/gul_S1_pltcalc_P4 work/kat/gul_S1_pltcalc_P5 work/kat/gul_S1_pltcalc_P6 work/kat/gul_S1_pltcalc_P7 work/kat/gul_S1_pltcalc_P8 work/kat/gul_S1_pltcalc_P9 work/kat/gul_S1_pltcalc_P10 > output/gul_S1_pltcalc.csv & kpid8=$!
+kat work/kat/gul_S1_summarycalc_P1 work/kat/gul_S1_summarycalc_P2 work/kat/gul_S1_summarycalc_P3 work/kat/gul_S1_summarycalc_P4 work/kat/gul_S1_summarycalc_P5 work/kat/gul_S1_summarycalc_P6 work/kat/gul_S1_summarycalc_P7 work/kat/gul_S1_summarycalc_P8 work/kat/gul_S1_summarycalc_P9 work/kat/gul_S1_summarycalc_P10 > output/gul_S1_summarycalc.csv & kpid9=$!
+kat -s work/kat/gul_S2_eltcalc_P1 work/kat/gul_S2_eltcalc_P2 work/kat/gul_S2_eltcalc_P3 work/kat/gul_S2_eltcalc_P4 work/kat/gul_S2_eltcalc_P5 work/kat/gul_S2_eltcalc_P6 work/kat/gul_S2_eltcalc_P7 work/kat/gul_S2_eltcalc_P8 work/kat/gul_S2_eltcalc_P9 work/kat/gul_S2_eltcalc_P10 > output/gul_S2_eltcalc.csv & kpid10=$!
+kat work/kat/gul_S2_pltcalc_P1 work/kat/gul_S2_pltcalc_P2 work/kat/gul_S2_pltcalc_P3 work/kat/gul_S2_pltcalc_P4 work/kat/gul_S2_pltcalc_P5 work/kat/gul_S2_pltcalc_P6 work/kat/gul_S2_pltcalc_P7 work/kat/gul_S2_pltcalc_P8 work/kat/gul_S2_pltcalc_P9 work/kat/gul_S2_pltcalc_P10 > output/gul_S2_pltcalc.csv & kpid11=$!
+kat work/kat/gul_S2_summarycalc_P1 work/kat/gul_S2_summarycalc_P2 work/kat/gul_S2_summarycalc_P3 work/kat/gul_S2_summarycalc_P4 work/kat/gul_S2_summarycalc_P5 work/kat/gul_S2_summarycalc_P6 work/kat/gul_S2_summarycalc_P7 work/kat/gul_S2_summarycalc_P8 work/kat/gul_S2_summarycalc_P9 work/kat/gul_S2_summarycalc_P10 > output/gul_S2_summarycalc.csv & kpid12=$!
+wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpid11 $kpid12
+
+
+aalcalc -Kil_S1_summaryaalcalc > output/il_S1_aalcalc.csv & lpid1=$!
+ordleccalc -r -Kil_S1_summaryleccalc -F -S -s -M -m -W -w -O output/il_S1_ept.csv -o output/il_S1_psept.csv & lpid2=$!
+aalcalc -Kil_S2_summaryaalcalc > output/il_S2_aalcalc.csv & lpid3=$!
+ordleccalc -r -Kil_S2_summaryleccalc -F -S -s -M -m -W -w -O output/il_S2_ept.csv -o output/il_S2_psept.csv & lpid4=$!
+aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv & lpid5=$!
+ordleccalc -r -Kgul_S1_summaryleccalc -F -S -s -M -m -W -w -O output/gul_S1_ept.csv -o output/gul_S1_psept.csv & lpid6=$!
+aalcalc -Kgul_S2_summaryaalcalc > output/gul_S2_aalcalc.csv & lpid7=$!
+ordleccalc -r -Kgul_S2_summaryleccalc -F -S -s -M -m -W -w -O output/gul_S2_ept.csv -o output/gul_S2_psept.csv & lpid8=$!
+wait $lpid1 $lpid2 $lpid3 $lpid4 $lpid5 $lpid6 $lpid7 $lpid8
+
+rm -R -f work/*
+rm -R -f fifo/*

--- a/tests/model_execution/itm_kparse_reference/gul_il_ord_psept_lec_1_output_10_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_il_ord_psept_lec_1_output_10_partition.sh
@@ -1,0 +1,295 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+
+rm -R -f fifo/*
+rm -R -f work/*
+mkdir work/kat/
+
+mkdir work/gul_S1_summaryleccalc
+mkdir work/gul_S1_summaryaalcalc
+mkdir work/il_S1_summaryleccalc
+mkdir work/il_S1_summaryaalcalc
+
+mkfifo fifo/gul_P1
+mkfifo fifo/gul_P2
+mkfifo fifo/gul_P3
+mkfifo fifo/gul_P4
+mkfifo fifo/gul_P5
+mkfifo fifo/gul_P6
+mkfifo fifo/gul_P7
+mkfifo fifo/gul_P8
+mkfifo fifo/gul_P9
+mkfifo fifo/gul_P10
+
+mkfifo fifo/gul_S1_summary_P1
+mkfifo fifo/gul_S1_eltcalc_P1
+mkfifo fifo/gul_S1_summarycalc_P1
+mkfifo fifo/gul_S1_pltcalc_P1
+
+mkfifo fifo/gul_S1_summary_P2
+mkfifo fifo/gul_S1_eltcalc_P2
+mkfifo fifo/gul_S1_summarycalc_P2
+mkfifo fifo/gul_S1_pltcalc_P2
+
+mkfifo fifo/gul_S1_summary_P3
+mkfifo fifo/gul_S1_eltcalc_P3
+mkfifo fifo/gul_S1_summarycalc_P3
+mkfifo fifo/gul_S1_pltcalc_P3
+
+mkfifo fifo/gul_S1_summary_P4
+mkfifo fifo/gul_S1_eltcalc_P4
+mkfifo fifo/gul_S1_summarycalc_P4
+mkfifo fifo/gul_S1_pltcalc_P4
+
+mkfifo fifo/gul_S1_summary_P5
+mkfifo fifo/gul_S1_eltcalc_P5
+mkfifo fifo/gul_S1_summarycalc_P5
+mkfifo fifo/gul_S1_pltcalc_P5
+
+mkfifo fifo/gul_S1_summary_P6
+mkfifo fifo/gul_S1_eltcalc_P6
+mkfifo fifo/gul_S1_summarycalc_P6
+mkfifo fifo/gul_S1_pltcalc_P6
+
+mkfifo fifo/gul_S1_summary_P7
+mkfifo fifo/gul_S1_eltcalc_P7
+mkfifo fifo/gul_S1_summarycalc_P7
+mkfifo fifo/gul_S1_pltcalc_P7
+
+mkfifo fifo/gul_S1_summary_P8
+mkfifo fifo/gul_S1_eltcalc_P8
+mkfifo fifo/gul_S1_summarycalc_P8
+mkfifo fifo/gul_S1_pltcalc_P8
+
+mkfifo fifo/gul_S1_summary_P9
+mkfifo fifo/gul_S1_eltcalc_P9
+mkfifo fifo/gul_S1_summarycalc_P9
+mkfifo fifo/gul_S1_pltcalc_P9
+
+mkfifo fifo/gul_S1_summary_P10
+mkfifo fifo/gul_S1_eltcalc_P10
+mkfifo fifo/gul_S1_summarycalc_P10
+mkfifo fifo/gul_S1_pltcalc_P10
+
+mkfifo fifo/il_P1
+mkfifo fifo/il_P2
+mkfifo fifo/il_P3
+mkfifo fifo/il_P4
+mkfifo fifo/il_P5
+mkfifo fifo/il_P6
+mkfifo fifo/il_P7
+mkfifo fifo/il_P8
+mkfifo fifo/il_P9
+mkfifo fifo/il_P10
+
+mkfifo fifo/il_S1_summary_P1
+mkfifo fifo/il_S1_eltcalc_P1
+mkfifo fifo/il_S1_summarycalc_P1
+mkfifo fifo/il_S1_pltcalc_P1
+
+mkfifo fifo/il_S1_summary_P2
+mkfifo fifo/il_S1_eltcalc_P2
+mkfifo fifo/il_S1_summarycalc_P2
+mkfifo fifo/il_S1_pltcalc_P2
+
+mkfifo fifo/il_S1_summary_P3
+mkfifo fifo/il_S1_eltcalc_P3
+mkfifo fifo/il_S1_summarycalc_P3
+mkfifo fifo/il_S1_pltcalc_P3
+
+mkfifo fifo/il_S1_summary_P4
+mkfifo fifo/il_S1_eltcalc_P4
+mkfifo fifo/il_S1_summarycalc_P4
+mkfifo fifo/il_S1_pltcalc_P4
+
+mkfifo fifo/il_S1_summary_P5
+mkfifo fifo/il_S1_eltcalc_P5
+mkfifo fifo/il_S1_summarycalc_P5
+mkfifo fifo/il_S1_pltcalc_P5
+
+mkfifo fifo/il_S1_summary_P6
+mkfifo fifo/il_S1_eltcalc_P6
+mkfifo fifo/il_S1_summarycalc_P6
+mkfifo fifo/il_S1_pltcalc_P6
+
+mkfifo fifo/il_S1_summary_P7
+mkfifo fifo/il_S1_eltcalc_P7
+mkfifo fifo/il_S1_summarycalc_P7
+mkfifo fifo/il_S1_pltcalc_P7
+
+mkfifo fifo/il_S1_summary_P8
+mkfifo fifo/il_S1_eltcalc_P8
+mkfifo fifo/il_S1_summarycalc_P8
+mkfifo fifo/il_S1_pltcalc_P8
+
+mkfifo fifo/il_S1_summary_P9
+mkfifo fifo/il_S1_eltcalc_P9
+mkfifo fifo/il_S1_summarycalc_P9
+mkfifo fifo/il_S1_pltcalc_P9
+
+mkfifo fifo/il_S1_summary_P10
+mkfifo fifo/il_S1_eltcalc_P10
+mkfifo fifo/il_S1_summarycalc_P10
+mkfifo fifo/il_S1_pltcalc_P10
+
+
+
+# --- Do insured loss computes ---
+
+eltcalc < fifo/il_S1_eltcalc_P1 > work/kat/il_S1_eltcalc_P1 & pid1=$!
+summarycalctocsv < fifo/il_S1_summarycalc_P1 > work/kat/il_S1_summarycalc_P1 & pid2=$!
+pltcalc < fifo/il_S1_pltcalc_P1 > work/kat/il_S1_pltcalc_P1 & pid3=$!
+eltcalc -s < fifo/il_S1_eltcalc_P2 > work/kat/il_S1_eltcalc_P2 & pid4=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P2 > work/kat/il_S1_summarycalc_P2 & pid5=$!
+pltcalc -s < fifo/il_S1_pltcalc_P2 > work/kat/il_S1_pltcalc_P2 & pid6=$!
+eltcalc -s < fifo/il_S1_eltcalc_P3 > work/kat/il_S1_eltcalc_P3 & pid7=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P3 > work/kat/il_S1_summarycalc_P3 & pid8=$!
+pltcalc -s < fifo/il_S1_pltcalc_P3 > work/kat/il_S1_pltcalc_P3 & pid9=$!
+eltcalc -s < fifo/il_S1_eltcalc_P4 > work/kat/il_S1_eltcalc_P4 & pid10=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P4 > work/kat/il_S1_summarycalc_P4 & pid11=$!
+pltcalc -s < fifo/il_S1_pltcalc_P4 > work/kat/il_S1_pltcalc_P4 & pid12=$!
+eltcalc -s < fifo/il_S1_eltcalc_P5 > work/kat/il_S1_eltcalc_P5 & pid13=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P5 > work/kat/il_S1_summarycalc_P5 & pid14=$!
+pltcalc -s < fifo/il_S1_pltcalc_P5 > work/kat/il_S1_pltcalc_P5 & pid15=$!
+eltcalc -s < fifo/il_S1_eltcalc_P6 > work/kat/il_S1_eltcalc_P6 & pid16=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P6 > work/kat/il_S1_summarycalc_P6 & pid17=$!
+pltcalc -s < fifo/il_S1_pltcalc_P6 > work/kat/il_S1_pltcalc_P6 & pid18=$!
+eltcalc -s < fifo/il_S1_eltcalc_P7 > work/kat/il_S1_eltcalc_P7 & pid19=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P7 > work/kat/il_S1_summarycalc_P7 & pid20=$!
+pltcalc -s < fifo/il_S1_pltcalc_P7 > work/kat/il_S1_pltcalc_P7 & pid21=$!
+eltcalc -s < fifo/il_S1_eltcalc_P8 > work/kat/il_S1_eltcalc_P8 & pid22=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P8 > work/kat/il_S1_summarycalc_P8 & pid23=$!
+pltcalc -s < fifo/il_S1_pltcalc_P8 > work/kat/il_S1_pltcalc_P8 & pid24=$!
+eltcalc -s < fifo/il_S1_eltcalc_P9 > work/kat/il_S1_eltcalc_P9 & pid25=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P9 > work/kat/il_S1_summarycalc_P9 & pid26=$!
+pltcalc -s < fifo/il_S1_pltcalc_P9 > work/kat/il_S1_pltcalc_P9 & pid27=$!
+eltcalc -s < fifo/il_S1_eltcalc_P10 > work/kat/il_S1_eltcalc_P10 & pid28=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P10 > work/kat/il_S1_summarycalc_P10 & pid29=$!
+pltcalc -s < fifo/il_S1_pltcalc_P10 > work/kat/il_S1_pltcalc_P10 & pid30=$!
+
+tee < fifo/il_S1_summary_P1 fifo/il_S1_eltcalc_P1 fifo/il_S1_summarycalc_P1 fifo/il_S1_pltcalc_P1 work/il_S1_summaryaalcalc/P1.bin work/il_S1_summaryleccalc/P1.bin > /dev/null & pid31=$!
+tee < fifo/il_S1_summary_P2 fifo/il_S1_eltcalc_P2 fifo/il_S1_summarycalc_P2 fifo/il_S1_pltcalc_P2 work/il_S1_summaryaalcalc/P2.bin work/il_S1_summaryleccalc/P2.bin > /dev/null & pid32=$!
+tee < fifo/il_S1_summary_P3 fifo/il_S1_eltcalc_P3 fifo/il_S1_summarycalc_P3 fifo/il_S1_pltcalc_P3 work/il_S1_summaryaalcalc/P3.bin work/il_S1_summaryleccalc/P3.bin > /dev/null & pid33=$!
+tee < fifo/il_S1_summary_P4 fifo/il_S1_eltcalc_P4 fifo/il_S1_summarycalc_P4 fifo/il_S1_pltcalc_P4 work/il_S1_summaryaalcalc/P4.bin work/il_S1_summaryleccalc/P4.bin > /dev/null & pid34=$!
+tee < fifo/il_S1_summary_P5 fifo/il_S1_eltcalc_P5 fifo/il_S1_summarycalc_P5 fifo/il_S1_pltcalc_P5 work/il_S1_summaryaalcalc/P5.bin work/il_S1_summaryleccalc/P5.bin > /dev/null & pid35=$!
+tee < fifo/il_S1_summary_P6 fifo/il_S1_eltcalc_P6 fifo/il_S1_summarycalc_P6 fifo/il_S1_pltcalc_P6 work/il_S1_summaryaalcalc/P6.bin work/il_S1_summaryleccalc/P6.bin > /dev/null & pid36=$!
+tee < fifo/il_S1_summary_P7 fifo/il_S1_eltcalc_P7 fifo/il_S1_summarycalc_P7 fifo/il_S1_pltcalc_P7 work/il_S1_summaryaalcalc/P7.bin work/il_S1_summaryleccalc/P7.bin > /dev/null & pid37=$!
+tee < fifo/il_S1_summary_P8 fifo/il_S1_eltcalc_P8 fifo/il_S1_summarycalc_P8 fifo/il_S1_pltcalc_P8 work/il_S1_summaryaalcalc/P8.bin work/il_S1_summaryleccalc/P8.bin > /dev/null & pid38=$!
+tee < fifo/il_S1_summary_P9 fifo/il_S1_eltcalc_P9 fifo/il_S1_summarycalc_P9 fifo/il_S1_pltcalc_P9 work/il_S1_summaryaalcalc/P9.bin work/il_S1_summaryleccalc/P9.bin > /dev/null & pid39=$!
+tee < fifo/il_S1_summary_P10 fifo/il_S1_eltcalc_P10 fifo/il_S1_summarycalc_P10 fifo/il_S1_pltcalc_P10 work/il_S1_summaryaalcalc/P10.bin work/il_S1_summaryleccalc/P10.bin > /dev/null & pid40=$!
+
+summarycalc -f  -1 fifo/il_S1_summary_P1 < fifo/il_P1 &
+summarycalc -f  -1 fifo/il_S1_summary_P2 < fifo/il_P2 &
+summarycalc -f  -1 fifo/il_S1_summary_P3 < fifo/il_P3 &
+summarycalc -f  -1 fifo/il_S1_summary_P4 < fifo/il_P4 &
+summarycalc -f  -1 fifo/il_S1_summary_P5 < fifo/il_P5 &
+summarycalc -f  -1 fifo/il_S1_summary_P6 < fifo/il_P6 &
+summarycalc -f  -1 fifo/il_S1_summary_P7 < fifo/il_P7 &
+summarycalc -f  -1 fifo/il_S1_summary_P8 < fifo/il_P8 &
+summarycalc -f  -1 fifo/il_S1_summary_P9 < fifo/il_P9 &
+summarycalc -f  -1 fifo/il_S1_summary_P10 < fifo/il_P10 &
+
+# --- Do ground up loss computes ---
+
+eltcalc < fifo/gul_S1_eltcalc_P1 > work/kat/gul_S1_eltcalc_P1 & pid41=$!
+summarycalctocsv < fifo/gul_S1_summarycalc_P1 > work/kat/gul_S1_summarycalc_P1 & pid42=$!
+pltcalc < fifo/gul_S1_pltcalc_P1 > work/kat/gul_S1_pltcalc_P1 & pid43=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P2 > work/kat/gul_S1_eltcalc_P2 & pid44=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P2 > work/kat/gul_S1_summarycalc_P2 & pid45=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P2 > work/kat/gul_S1_pltcalc_P2 & pid46=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P3 > work/kat/gul_S1_eltcalc_P3 & pid47=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P3 > work/kat/gul_S1_summarycalc_P3 & pid48=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P3 > work/kat/gul_S1_pltcalc_P3 & pid49=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P4 > work/kat/gul_S1_eltcalc_P4 & pid50=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P4 > work/kat/gul_S1_summarycalc_P4 & pid51=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P4 > work/kat/gul_S1_pltcalc_P4 & pid52=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P5 > work/kat/gul_S1_eltcalc_P5 & pid53=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P5 > work/kat/gul_S1_summarycalc_P5 & pid54=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P5 > work/kat/gul_S1_pltcalc_P5 & pid55=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P6 > work/kat/gul_S1_eltcalc_P6 & pid56=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P6 > work/kat/gul_S1_summarycalc_P6 & pid57=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P6 > work/kat/gul_S1_pltcalc_P6 & pid58=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P7 > work/kat/gul_S1_eltcalc_P7 & pid59=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P7 > work/kat/gul_S1_summarycalc_P7 & pid60=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P7 > work/kat/gul_S1_pltcalc_P7 & pid61=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P8 > work/kat/gul_S1_eltcalc_P8 & pid62=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P8 > work/kat/gul_S1_summarycalc_P8 & pid63=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P8 > work/kat/gul_S1_pltcalc_P8 & pid64=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P9 > work/kat/gul_S1_eltcalc_P9 & pid65=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P9 > work/kat/gul_S1_summarycalc_P9 & pid66=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P9 > work/kat/gul_S1_pltcalc_P9 & pid67=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P10 > work/kat/gul_S1_eltcalc_P10 & pid68=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P10 > work/kat/gul_S1_summarycalc_P10 & pid69=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P10 > work/kat/gul_S1_pltcalc_P10 & pid70=$!
+
+tee < fifo/gul_S1_summary_P1 fifo/gul_S1_eltcalc_P1 fifo/gul_S1_summarycalc_P1 fifo/gul_S1_pltcalc_P1 work/gul_S1_summaryaalcalc/P1.bin work/gul_S1_summaryleccalc/P1.bin > /dev/null & pid71=$!
+tee < fifo/gul_S1_summary_P2 fifo/gul_S1_eltcalc_P2 fifo/gul_S1_summarycalc_P2 fifo/gul_S1_pltcalc_P2 work/gul_S1_summaryaalcalc/P2.bin work/gul_S1_summaryleccalc/P2.bin > /dev/null & pid72=$!
+tee < fifo/gul_S1_summary_P3 fifo/gul_S1_eltcalc_P3 fifo/gul_S1_summarycalc_P3 fifo/gul_S1_pltcalc_P3 work/gul_S1_summaryaalcalc/P3.bin work/gul_S1_summaryleccalc/P3.bin > /dev/null & pid73=$!
+tee < fifo/gul_S1_summary_P4 fifo/gul_S1_eltcalc_P4 fifo/gul_S1_summarycalc_P4 fifo/gul_S1_pltcalc_P4 work/gul_S1_summaryaalcalc/P4.bin work/gul_S1_summaryleccalc/P4.bin > /dev/null & pid74=$!
+tee < fifo/gul_S1_summary_P5 fifo/gul_S1_eltcalc_P5 fifo/gul_S1_summarycalc_P5 fifo/gul_S1_pltcalc_P5 work/gul_S1_summaryaalcalc/P5.bin work/gul_S1_summaryleccalc/P5.bin > /dev/null & pid75=$!
+tee < fifo/gul_S1_summary_P6 fifo/gul_S1_eltcalc_P6 fifo/gul_S1_summarycalc_P6 fifo/gul_S1_pltcalc_P6 work/gul_S1_summaryaalcalc/P6.bin work/gul_S1_summaryleccalc/P6.bin > /dev/null & pid76=$!
+tee < fifo/gul_S1_summary_P7 fifo/gul_S1_eltcalc_P7 fifo/gul_S1_summarycalc_P7 fifo/gul_S1_pltcalc_P7 work/gul_S1_summaryaalcalc/P7.bin work/gul_S1_summaryleccalc/P7.bin > /dev/null & pid77=$!
+tee < fifo/gul_S1_summary_P8 fifo/gul_S1_eltcalc_P8 fifo/gul_S1_summarycalc_P8 fifo/gul_S1_pltcalc_P8 work/gul_S1_summaryaalcalc/P8.bin work/gul_S1_summaryleccalc/P8.bin > /dev/null & pid78=$!
+tee < fifo/gul_S1_summary_P9 fifo/gul_S1_eltcalc_P9 fifo/gul_S1_summarycalc_P9 fifo/gul_S1_pltcalc_P9 work/gul_S1_summaryaalcalc/P9.bin work/gul_S1_summaryleccalc/P9.bin > /dev/null & pid79=$!
+tee < fifo/gul_S1_summary_P10 fifo/gul_S1_eltcalc_P10 fifo/gul_S1_summarycalc_P10 fifo/gul_S1_pltcalc_P10 work/gul_S1_summaryaalcalc/P10.bin work/gul_S1_summaryleccalc/P10.bin > /dev/null & pid80=$!
+
+summarycalc -i  -1 fifo/gul_S1_summary_P1 < fifo/gul_P1 &
+summarycalc -i  -1 fifo/gul_S1_summary_P2 < fifo/gul_P2 &
+summarycalc -i  -1 fifo/gul_S1_summary_P3 < fifo/gul_P3 &
+summarycalc -i  -1 fifo/gul_S1_summary_P4 < fifo/gul_P4 &
+summarycalc -i  -1 fifo/gul_S1_summary_P5 < fifo/gul_P5 &
+summarycalc -i  -1 fifo/gul_S1_summary_P6 < fifo/gul_P6 &
+summarycalc -i  -1 fifo/gul_S1_summary_P7 < fifo/gul_P7 &
+summarycalc -i  -1 fifo/gul_S1_summary_P8 < fifo/gul_P8 &
+summarycalc -i  -1 fifo/gul_S1_summary_P9 < fifo/gul_P9 &
+summarycalc -i  -1 fifo/gul_S1_summary_P10 < fifo/gul_P10 &
+
+eve 1 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee fifo/gul_P1 | fmcalc -a2 > fifo/il_P1  &
+eve 2 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee fifo/gul_P2 | fmcalc -a2 > fifo/il_P2  &
+eve 3 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee fifo/gul_P3 | fmcalc -a2 > fifo/il_P3  &
+eve 4 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee fifo/gul_P4 | fmcalc -a2 > fifo/il_P4  &
+eve 5 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee fifo/gul_P5 | fmcalc -a2 > fifo/il_P5  &
+eve 6 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee fifo/gul_P6 | fmcalc -a2 > fifo/il_P6  &
+eve 7 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee fifo/gul_P7 | fmcalc -a2 > fifo/il_P7  &
+eve 8 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee fifo/gul_P8 | fmcalc -a2 > fifo/il_P8  &
+eve 9 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee fifo/gul_P9 | fmcalc -a2 > fifo/il_P9  &
+eve 10 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee fifo/gul_P10 | fmcalc -a2 > fifo/il_P10  &
+
+wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 $pid13 $pid14 $pid15 $pid16 $pid17 $pid18 $pid19 $pid20 $pid21 $pid22 $pid23 $pid24 $pid25 $pid26 $pid27 $pid28 $pid29 $pid30 $pid31 $pid32 $pid33 $pid34 $pid35 $pid36 $pid37 $pid38 $pid39 $pid40 $pid41 $pid42 $pid43 $pid44 $pid45 $pid46 $pid47 $pid48 $pid49 $pid50 $pid51 $pid52 $pid53 $pid54 $pid55 $pid56 $pid57 $pid58 $pid59 $pid60 $pid61 $pid62 $pid63 $pid64 $pid65 $pid66 $pid67 $pid68 $pid69 $pid70 $pid71 $pid72 $pid73 $pid74 $pid75 $pid76 $pid77 $pid78 $pid79 $pid80
+
+
+# --- Do insured loss kats ---
+
+kat -s work/kat/il_S1_eltcalc_P1 work/kat/il_S1_eltcalc_P2 work/kat/il_S1_eltcalc_P3 work/kat/il_S1_eltcalc_P4 work/kat/il_S1_eltcalc_P5 work/kat/il_S1_eltcalc_P6 work/kat/il_S1_eltcalc_P7 work/kat/il_S1_eltcalc_P8 work/kat/il_S1_eltcalc_P9 work/kat/il_S1_eltcalc_P10 > output/il_S1_eltcalc.csv & kpid1=$!
+kat work/kat/il_S1_pltcalc_P1 work/kat/il_S1_pltcalc_P2 work/kat/il_S1_pltcalc_P3 work/kat/il_S1_pltcalc_P4 work/kat/il_S1_pltcalc_P5 work/kat/il_S1_pltcalc_P6 work/kat/il_S1_pltcalc_P7 work/kat/il_S1_pltcalc_P8 work/kat/il_S1_pltcalc_P9 work/kat/il_S1_pltcalc_P10 > output/il_S1_pltcalc.csv & kpid2=$!
+kat work/kat/il_S1_summarycalc_P1 work/kat/il_S1_summarycalc_P2 work/kat/il_S1_summarycalc_P3 work/kat/il_S1_summarycalc_P4 work/kat/il_S1_summarycalc_P5 work/kat/il_S1_summarycalc_P6 work/kat/il_S1_summarycalc_P7 work/kat/il_S1_summarycalc_P8 work/kat/il_S1_summarycalc_P9 work/kat/il_S1_summarycalc_P10 > output/il_S1_summarycalc.csv & kpid3=$!
+
+# --- Do ground up loss kats ---
+
+kat -s work/kat/gul_S1_eltcalc_P1 work/kat/gul_S1_eltcalc_P2 work/kat/gul_S1_eltcalc_P3 work/kat/gul_S1_eltcalc_P4 work/kat/gul_S1_eltcalc_P5 work/kat/gul_S1_eltcalc_P6 work/kat/gul_S1_eltcalc_P7 work/kat/gul_S1_eltcalc_P8 work/kat/gul_S1_eltcalc_P9 work/kat/gul_S1_eltcalc_P10 > output/gul_S1_eltcalc.csv & kpid4=$!
+kat work/kat/gul_S1_pltcalc_P1 work/kat/gul_S1_pltcalc_P2 work/kat/gul_S1_pltcalc_P3 work/kat/gul_S1_pltcalc_P4 work/kat/gul_S1_pltcalc_P5 work/kat/gul_S1_pltcalc_P6 work/kat/gul_S1_pltcalc_P7 work/kat/gul_S1_pltcalc_P8 work/kat/gul_S1_pltcalc_P9 work/kat/gul_S1_pltcalc_P10 > output/gul_S1_pltcalc.csv & kpid5=$!
+kat work/kat/gul_S1_summarycalc_P1 work/kat/gul_S1_summarycalc_P2 work/kat/gul_S1_summarycalc_P3 work/kat/gul_S1_summarycalc_P4 work/kat/gul_S1_summarycalc_P5 work/kat/gul_S1_summarycalc_P6 work/kat/gul_S1_summarycalc_P7 work/kat/gul_S1_summarycalc_P8 work/kat/gul_S1_summarycalc_P9 work/kat/gul_S1_summarycalc_P10 > output/gul_S1_summarycalc.csv & kpid6=$!
+wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
+
+
+aalcalc -Kil_S1_summaryaalcalc > output/il_S1_aalcalc.csv & lpid1=$!
+ordleccalc -r -Kil_S1_summaryleccalc -W -w -o output/il_S1_psept.csv & lpid2=$!
+leccalc -r -Kil_S1_summaryleccalc -F output/il_S1_leccalc_full_uncertainty_aep.csv -f output/il_S1_leccalc_full_uncertainty_oep.csv -S output/il_S1_leccalc_sample_mean_aep.csv -s output/il_S1_leccalc_sample_mean_oep.csv -W output/il_S1_leccalc_wheatsheaf_aep.csv -M output/il_S1_leccalc_wheatsheaf_mean_aep.csv -m output/il_S1_leccalc_wheatsheaf_mean_oep.csv -w output/il_S1_leccalc_wheatsheaf_oep.csv & lpid3=$!
+aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv & lpid4=$!
+ordleccalc  -Kgul_S1_summaryleccalc -W -w -o output/gul_S1_psept.csv & lpid5=$!
+leccalc -r -Kgul_S1_summaryleccalc -F output/gul_S1_leccalc_full_uncertainty_aep.csv -f output/gul_S1_leccalc_full_uncertainty_oep.csv -S output/gul_S1_leccalc_sample_mean_aep.csv -s output/gul_S1_leccalc_sample_mean_oep.csv -W output/gul_S1_leccalc_wheatsheaf_aep.csv -M output/gul_S1_leccalc_wheatsheaf_mean_aep.csv -m output/gul_S1_leccalc_wheatsheaf_mean_oep.csv -w output/gul_S1_leccalc_wheatsheaf_oep.csv & lpid6=$!
+wait $lpid1 $lpid2 $lpid3 $lpid4 $lpid5 $lpid6
+
+rm -R -f work/*
+rm -R -f fifo/*

--- a/tests/model_execution/itm_kparse_reference/gul_ord_ept_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_ord_ept_1_output_1_partition.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+
+rm -R -f fifo/*
+rm -R -f work/*
+mkdir work/kat/
+
+mkdir work/gul_S1_summaryleccalc
+
+mkfifo fifo/gul_P1
+
+mkfifo fifo/gul_S1_summary_P1
+
+
+
+# --- Do ground up loss computes ---
+
+
+tee < fifo/gul_S1_summary_P1 work/gul_S1_summaryleccalc/P1.bin > /dev/null & pid1=$!
+
+summarycalc -i  -1 fifo/gul_S1_summary_P1 < fifo/gul_P1 &
+
+eve 1 1 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P1  &
+
+wait $pid1
+
+
+# --- Do ground up loss kats ---
+
+
+ordleccalc -r -Kgul_S1_summaryleccalc -F -f -S -s -M -m -O output/gul_S1_ept.csv & lpid1=$!
+wait $lpid1
+
+rm -R -f work/*
+rm -R -f fifo/*

--- a/tests/model_execution/itm_kparse_reference/gul_ord_ept_1_output_20_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_ord_ept_1_output_20_partition.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+
+rm -R -f fifo/*
+rm -R -f work/*
+mkdir work/kat/
+
+mkdir work/gul_S1_summaryleccalc
+
+mkfifo fifo/gul_P1
+mkfifo fifo/gul_P2
+mkfifo fifo/gul_P3
+mkfifo fifo/gul_P4
+mkfifo fifo/gul_P5
+mkfifo fifo/gul_P6
+mkfifo fifo/gul_P7
+mkfifo fifo/gul_P8
+mkfifo fifo/gul_P9
+mkfifo fifo/gul_P10
+mkfifo fifo/gul_P11
+mkfifo fifo/gul_P12
+mkfifo fifo/gul_P13
+mkfifo fifo/gul_P14
+mkfifo fifo/gul_P15
+mkfifo fifo/gul_P16
+mkfifo fifo/gul_P17
+mkfifo fifo/gul_P18
+mkfifo fifo/gul_P19
+mkfifo fifo/gul_P20
+
+mkfifo fifo/gul_S1_summary_P1
+
+mkfifo fifo/gul_S1_summary_P2
+
+mkfifo fifo/gul_S1_summary_P3
+
+mkfifo fifo/gul_S1_summary_P4
+
+mkfifo fifo/gul_S1_summary_P5
+
+mkfifo fifo/gul_S1_summary_P6
+
+mkfifo fifo/gul_S1_summary_P7
+
+mkfifo fifo/gul_S1_summary_P8
+
+mkfifo fifo/gul_S1_summary_P9
+
+mkfifo fifo/gul_S1_summary_P10
+
+mkfifo fifo/gul_S1_summary_P11
+
+mkfifo fifo/gul_S1_summary_P12
+
+mkfifo fifo/gul_S1_summary_P13
+
+mkfifo fifo/gul_S1_summary_P14
+
+mkfifo fifo/gul_S1_summary_P15
+
+mkfifo fifo/gul_S1_summary_P16
+
+mkfifo fifo/gul_S1_summary_P17
+
+mkfifo fifo/gul_S1_summary_P18
+
+mkfifo fifo/gul_S1_summary_P19
+
+mkfifo fifo/gul_S1_summary_P20
+
+
+
+# --- Do ground up loss computes ---
+
+
+tee < fifo/gul_S1_summary_P1 work/gul_S1_summaryleccalc/P1.bin > /dev/null & pid1=$!
+tee < fifo/gul_S1_summary_P2 work/gul_S1_summaryleccalc/P2.bin > /dev/null & pid2=$!
+tee < fifo/gul_S1_summary_P3 work/gul_S1_summaryleccalc/P3.bin > /dev/null & pid3=$!
+tee < fifo/gul_S1_summary_P4 work/gul_S1_summaryleccalc/P4.bin > /dev/null & pid4=$!
+tee < fifo/gul_S1_summary_P5 work/gul_S1_summaryleccalc/P5.bin > /dev/null & pid5=$!
+tee < fifo/gul_S1_summary_P6 work/gul_S1_summaryleccalc/P6.bin > /dev/null & pid6=$!
+tee < fifo/gul_S1_summary_P7 work/gul_S1_summaryleccalc/P7.bin > /dev/null & pid7=$!
+tee < fifo/gul_S1_summary_P8 work/gul_S1_summaryleccalc/P8.bin > /dev/null & pid8=$!
+tee < fifo/gul_S1_summary_P9 work/gul_S1_summaryleccalc/P9.bin > /dev/null & pid9=$!
+tee < fifo/gul_S1_summary_P10 work/gul_S1_summaryleccalc/P10.bin > /dev/null & pid10=$!
+tee < fifo/gul_S1_summary_P11 work/gul_S1_summaryleccalc/P11.bin > /dev/null & pid11=$!
+tee < fifo/gul_S1_summary_P12 work/gul_S1_summaryleccalc/P12.bin > /dev/null & pid12=$!
+tee < fifo/gul_S1_summary_P13 work/gul_S1_summaryleccalc/P13.bin > /dev/null & pid13=$!
+tee < fifo/gul_S1_summary_P14 work/gul_S1_summaryleccalc/P14.bin > /dev/null & pid14=$!
+tee < fifo/gul_S1_summary_P15 work/gul_S1_summaryleccalc/P15.bin > /dev/null & pid15=$!
+tee < fifo/gul_S1_summary_P16 work/gul_S1_summaryleccalc/P16.bin > /dev/null & pid16=$!
+tee < fifo/gul_S1_summary_P17 work/gul_S1_summaryleccalc/P17.bin > /dev/null & pid17=$!
+tee < fifo/gul_S1_summary_P18 work/gul_S1_summaryleccalc/P18.bin > /dev/null & pid18=$!
+tee < fifo/gul_S1_summary_P19 work/gul_S1_summaryleccalc/P19.bin > /dev/null & pid19=$!
+tee < fifo/gul_S1_summary_P20 work/gul_S1_summaryleccalc/P20.bin > /dev/null & pid20=$!
+
+summarycalc -i  -1 fifo/gul_S1_summary_P1 < fifo/gul_P1 &
+summarycalc -i  -1 fifo/gul_S1_summary_P2 < fifo/gul_P2 &
+summarycalc -i  -1 fifo/gul_S1_summary_P3 < fifo/gul_P3 &
+summarycalc -i  -1 fifo/gul_S1_summary_P4 < fifo/gul_P4 &
+summarycalc -i  -1 fifo/gul_S1_summary_P5 < fifo/gul_P5 &
+summarycalc -i  -1 fifo/gul_S1_summary_P6 < fifo/gul_P6 &
+summarycalc -i  -1 fifo/gul_S1_summary_P7 < fifo/gul_P7 &
+summarycalc -i  -1 fifo/gul_S1_summary_P8 < fifo/gul_P8 &
+summarycalc -i  -1 fifo/gul_S1_summary_P9 < fifo/gul_P9 &
+summarycalc -i  -1 fifo/gul_S1_summary_P10 < fifo/gul_P10 &
+summarycalc -i  -1 fifo/gul_S1_summary_P11 < fifo/gul_P11 &
+summarycalc -i  -1 fifo/gul_S1_summary_P12 < fifo/gul_P12 &
+summarycalc -i  -1 fifo/gul_S1_summary_P13 < fifo/gul_P13 &
+summarycalc -i  -1 fifo/gul_S1_summary_P14 < fifo/gul_P14 &
+summarycalc -i  -1 fifo/gul_S1_summary_P15 < fifo/gul_P15 &
+summarycalc -i  -1 fifo/gul_S1_summary_P16 < fifo/gul_P16 &
+summarycalc -i  -1 fifo/gul_S1_summary_P17 < fifo/gul_P17 &
+summarycalc -i  -1 fifo/gul_S1_summary_P18 < fifo/gul_P18 &
+summarycalc -i  -1 fifo/gul_S1_summary_P19 < fifo/gul_P19 &
+summarycalc -i  -1 fifo/gul_S1_summary_P20 < fifo/gul_P20 &
+
+eve 1 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P1  &
+eve 2 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P2  &
+eve 3 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P3  &
+eve 4 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P4  &
+eve 5 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P5  &
+eve 6 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P6  &
+eve 7 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P7  &
+eve 8 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P8  &
+eve 9 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P9  &
+eve 10 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P10  &
+eve 11 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P11  &
+eve 12 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P12  &
+eve 13 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P13  &
+eve 14 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P14  &
+eve 15 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P15  &
+eve 16 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P16  &
+eve 17 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P17  &
+eve 18 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P18  &
+eve 19 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P19  &
+eve 20 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P20  &
+
+wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 $pid13 $pid14 $pid15 $pid16 $pid17 $pid18 $pid19 $pid20
+
+
+# --- Do ground up loss kats ---
+
+
+ordleccalc -r -Kgul_S1_summaryleccalc -F -f -S -s -M -m -O output/gul_S1_ept.csv & lpid1=$!
+wait $lpid1
+
+rm -R -f work/*
+rm -R -f fifo/*

--- a/tests/model_execution/itm_kparse_reference/gul_ord_ept_psept_lec_2_output_10_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_ord_ept_psept_lec_2_output_10_partition.sh
@@ -1,0 +1,256 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+
+rm -R -f fifo/*
+rm -R -f work/*
+mkdir work/kat/
+
+mkdir work/gul_S1_summaryleccalc
+mkdir work/gul_S1_summaryaalcalc
+mkdir work/gul_S2_summaryleccalc
+mkdir work/gul_S2_summaryaalcalc
+
+mkfifo fifo/gul_P1
+mkfifo fifo/gul_P2
+mkfifo fifo/gul_P3
+mkfifo fifo/gul_P4
+mkfifo fifo/gul_P5
+mkfifo fifo/gul_P6
+mkfifo fifo/gul_P7
+mkfifo fifo/gul_P8
+mkfifo fifo/gul_P9
+mkfifo fifo/gul_P10
+
+mkfifo fifo/gul_S1_summary_P1
+mkfifo fifo/gul_S1_eltcalc_P1
+mkfifo fifo/gul_S1_summarycalc_P1
+mkfifo fifo/gul_S1_pltcalc_P1
+mkfifo fifo/gul_S2_summary_P1
+mkfifo fifo/gul_S2_eltcalc_P1
+mkfifo fifo/gul_S2_summarycalc_P1
+mkfifo fifo/gul_S2_pltcalc_P1
+
+mkfifo fifo/gul_S1_summary_P2
+mkfifo fifo/gul_S1_eltcalc_P2
+mkfifo fifo/gul_S1_summarycalc_P2
+mkfifo fifo/gul_S1_pltcalc_P2
+mkfifo fifo/gul_S2_summary_P2
+mkfifo fifo/gul_S2_eltcalc_P2
+mkfifo fifo/gul_S2_summarycalc_P2
+mkfifo fifo/gul_S2_pltcalc_P2
+
+mkfifo fifo/gul_S1_summary_P3
+mkfifo fifo/gul_S1_eltcalc_P3
+mkfifo fifo/gul_S1_summarycalc_P3
+mkfifo fifo/gul_S1_pltcalc_P3
+mkfifo fifo/gul_S2_summary_P3
+mkfifo fifo/gul_S2_eltcalc_P3
+mkfifo fifo/gul_S2_summarycalc_P3
+mkfifo fifo/gul_S2_pltcalc_P3
+
+mkfifo fifo/gul_S1_summary_P4
+mkfifo fifo/gul_S1_eltcalc_P4
+mkfifo fifo/gul_S1_summarycalc_P4
+mkfifo fifo/gul_S1_pltcalc_P4
+mkfifo fifo/gul_S2_summary_P4
+mkfifo fifo/gul_S2_eltcalc_P4
+mkfifo fifo/gul_S2_summarycalc_P4
+mkfifo fifo/gul_S2_pltcalc_P4
+
+mkfifo fifo/gul_S1_summary_P5
+mkfifo fifo/gul_S1_eltcalc_P5
+mkfifo fifo/gul_S1_summarycalc_P5
+mkfifo fifo/gul_S1_pltcalc_P5
+mkfifo fifo/gul_S2_summary_P5
+mkfifo fifo/gul_S2_eltcalc_P5
+mkfifo fifo/gul_S2_summarycalc_P5
+mkfifo fifo/gul_S2_pltcalc_P5
+
+mkfifo fifo/gul_S1_summary_P6
+mkfifo fifo/gul_S1_eltcalc_P6
+mkfifo fifo/gul_S1_summarycalc_P6
+mkfifo fifo/gul_S1_pltcalc_P6
+mkfifo fifo/gul_S2_summary_P6
+mkfifo fifo/gul_S2_eltcalc_P6
+mkfifo fifo/gul_S2_summarycalc_P6
+mkfifo fifo/gul_S2_pltcalc_P6
+
+mkfifo fifo/gul_S1_summary_P7
+mkfifo fifo/gul_S1_eltcalc_P7
+mkfifo fifo/gul_S1_summarycalc_P7
+mkfifo fifo/gul_S1_pltcalc_P7
+mkfifo fifo/gul_S2_summary_P7
+mkfifo fifo/gul_S2_eltcalc_P7
+mkfifo fifo/gul_S2_summarycalc_P7
+mkfifo fifo/gul_S2_pltcalc_P7
+
+mkfifo fifo/gul_S1_summary_P8
+mkfifo fifo/gul_S1_eltcalc_P8
+mkfifo fifo/gul_S1_summarycalc_P8
+mkfifo fifo/gul_S1_pltcalc_P8
+mkfifo fifo/gul_S2_summary_P8
+mkfifo fifo/gul_S2_eltcalc_P8
+mkfifo fifo/gul_S2_summarycalc_P8
+mkfifo fifo/gul_S2_pltcalc_P8
+
+mkfifo fifo/gul_S1_summary_P9
+mkfifo fifo/gul_S1_eltcalc_P9
+mkfifo fifo/gul_S1_summarycalc_P9
+mkfifo fifo/gul_S1_pltcalc_P9
+mkfifo fifo/gul_S2_summary_P9
+mkfifo fifo/gul_S2_eltcalc_P9
+mkfifo fifo/gul_S2_summarycalc_P9
+mkfifo fifo/gul_S2_pltcalc_P9
+
+mkfifo fifo/gul_S1_summary_P10
+mkfifo fifo/gul_S1_eltcalc_P10
+mkfifo fifo/gul_S1_summarycalc_P10
+mkfifo fifo/gul_S1_pltcalc_P10
+mkfifo fifo/gul_S2_summary_P10
+mkfifo fifo/gul_S2_eltcalc_P10
+mkfifo fifo/gul_S2_summarycalc_P10
+mkfifo fifo/gul_S2_pltcalc_P10
+
+
+
+# --- Do ground up loss computes ---
+
+eltcalc < fifo/gul_S1_eltcalc_P1 > work/kat/gul_S1_eltcalc_P1 & pid1=$!
+summarycalctocsv < fifo/gul_S1_summarycalc_P1 > work/kat/gul_S1_summarycalc_P1 & pid2=$!
+pltcalc < fifo/gul_S1_pltcalc_P1 > work/kat/gul_S1_pltcalc_P1 & pid3=$!
+eltcalc < fifo/gul_S2_eltcalc_P1 > work/kat/gul_S2_eltcalc_P1 & pid4=$!
+summarycalctocsv < fifo/gul_S2_summarycalc_P1 > work/kat/gul_S2_summarycalc_P1 & pid5=$!
+pltcalc < fifo/gul_S2_pltcalc_P1 > work/kat/gul_S2_pltcalc_P1 & pid6=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P2 > work/kat/gul_S1_eltcalc_P2 & pid7=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P2 > work/kat/gul_S1_summarycalc_P2 & pid8=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P2 > work/kat/gul_S1_pltcalc_P2 & pid9=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P2 > work/kat/gul_S2_eltcalc_P2 & pid10=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P2 > work/kat/gul_S2_summarycalc_P2 & pid11=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P2 > work/kat/gul_S2_pltcalc_P2 & pid12=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P3 > work/kat/gul_S1_eltcalc_P3 & pid13=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P3 > work/kat/gul_S1_summarycalc_P3 & pid14=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P3 > work/kat/gul_S1_pltcalc_P3 & pid15=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P3 > work/kat/gul_S2_eltcalc_P3 & pid16=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P3 > work/kat/gul_S2_summarycalc_P3 & pid17=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P3 > work/kat/gul_S2_pltcalc_P3 & pid18=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P4 > work/kat/gul_S1_eltcalc_P4 & pid19=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P4 > work/kat/gul_S1_summarycalc_P4 & pid20=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P4 > work/kat/gul_S1_pltcalc_P4 & pid21=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P4 > work/kat/gul_S2_eltcalc_P4 & pid22=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P4 > work/kat/gul_S2_summarycalc_P4 & pid23=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P4 > work/kat/gul_S2_pltcalc_P4 & pid24=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P5 > work/kat/gul_S1_eltcalc_P5 & pid25=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P5 > work/kat/gul_S1_summarycalc_P5 & pid26=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P5 > work/kat/gul_S1_pltcalc_P5 & pid27=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P5 > work/kat/gul_S2_eltcalc_P5 & pid28=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P5 > work/kat/gul_S2_summarycalc_P5 & pid29=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P5 > work/kat/gul_S2_pltcalc_P5 & pid30=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P6 > work/kat/gul_S1_eltcalc_P6 & pid31=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P6 > work/kat/gul_S1_summarycalc_P6 & pid32=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P6 > work/kat/gul_S1_pltcalc_P6 & pid33=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P6 > work/kat/gul_S2_eltcalc_P6 & pid34=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P6 > work/kat/gul_S2_summarycalc_P6 & pid35=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P6 > work/kat/gul_S2_pltcalc_P6 & pid36=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P7 > work/kat/gul_S1_eltcalc_P7 & pid37=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P7 > work/kat/gul_S1_summarycalc_P7 & pid38=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P7 > work/kat/gul_S1_pltcalc_P7 & pid39=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P7 > work/kat/gul_S2_eltcalc_P7 & pid40=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P7 > work/kat/gul_S2_summarycalc_P7 & pid41=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P7 > work/kat/gul_S2_pltcalc_P7 & pid42=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P8 > work/kat/gul_S1_eltcalc_P8 & pid43=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P8 > work/kat/gul_S1_summarycalc_P8 & pid44=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P8 > work/kat/gul_S1_pltcalc_P8 & pid45=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P8 > work/kat/gul_S2_eltcalc_P8 & pid46=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P8 > work/kat/gul_S2_summarycalc_P8 & pid47=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P8 > work/kat/gul_S2_pltcalc_P8 & pid48=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P9 > work/kat/gul_S1_eltcalc_P9 & pid49=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P9 > work/kat/gul_S1_summarycalc_P9 & pid50=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P9 > work/kat/gul_S1_pltcalc_P9 & pid51=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P9 > work/kat/gul_S2_eltcalc_P9 & pid52=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P9 > work/kat/gul_S2_summarycalc_P9 & pid53=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P9 > work/kat/gul_S2_pltcalc_P9 & pid54=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P10 > work/kat/gul_S1_eltcalc_P10 & pid55=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P10 > work/kat/gul_S1_summarycalc_P10 & pid56=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P10 > work/kat/gul_S1_pltcalc_P10 & pid57=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P10 > work/kat/gul_S2_eltcalc_P10 & pid58=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P10 > work/kat/gul_S2_summarycalc_P10 & pid59=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P10 > work/kat/gul_S2_pltcalc_P10 & pid60=$!
+
+tee < fifo/gul_S1_summary_P1 fifo/gul_S1_eltcalc_P1 fifo/gul_S1_summarycalc_P1 fifo/gul_S1_pltcalc_P1 work/gul_S1_summaryaalcalc/P1.bin work/gul_S1_summaryleccalc/P1.bin > /dev/null & pid61=$!
+tee < fifo/gul_S2_summary_P1 fifo/gul_S2_eltcalc_P1 fifo/gul_S2_summarycalc_P1 fifo/gul_S2_pltcalc_P1 work/gul_S2_summaryaalcalc/P1.bin work/gul_S2_summaryleccalc/P1.bin > /dev/null & pid62=$!
+tee < fifo/gul_S1_summary_P2 fifo/gul_S1_eltcalc_P2 fifo/gul_S1_summarycalc_P2 fifo/gul_S1_pltcalc_P2 work/gul_S1_summaryaalcalc/P2.bin work/gul_S1_summaryleccalc/P2.bin > /dev/null & pid63=$!
+tee < fifo/gul_S2_summary_P2 fifo/gul_S2_eltcalc_P2 fifo/gul_S2_summarycalc_P2 fifo/gul_S2_pltcalc_P2 work/gul_S2_summaryaalcalc/P2.bin work/gul_S2_summaryleccalc/P2.bin > /dev/null & pid64=$!
+tee < fifo/gul_S1_summary_P3 fifo/gul_S1_eltcalc_P3 fifo/gul_S1_summarycalc_P3 fifo/gul_S1_pltcalc_P3 work/gul_S1_summaryaalcalc/P3.bin work/gul_S1_summaryleccalc/P3.bin > /dev/null & pid65=$!
+tee < fifo/gul_S2_summary_P3 fifo/gul_S2_eltcalc_P3 fifo/gul_S2_summarycalc_P3 fifo/gul_S2_pltcalc_P3 work/gul_S2_summaryaalcalc/P3.bin work/gul_S2_summaryleccalc/P3.bin > /dev/null & pid66=$!
+tee < fifo/gul_S1_summary_P4 fifo/gul_S1_eltcalc_P4 fifo/gul_S1_summarycalc_P4 fifo/gul_S1_pltcalc_P4 work/gul_S1_summaryaalcalc/P4.bin work/gul_S1_summaryleccalc/P4.bin > /dev/null & pid67=$!
+tee < fifo/gul_S2_summary_P4 fifo/gul_S2_eltcalc_P4 fifo/gul_S2_summarycalc_P4 fifo/gul_S2_pltcalc_P4 work/gul_S2_summaryaalcalc/P4.bin work/gul_S2_summaryleccalc/P4.bin > /dev/null & pid68=$!
+tee < fifo/gul_S1_summary_P5 fifo/gul_S1_eltcalc_P5 fifo/gul_S1_summarycalc_P5 fifo/gul_S1_pltcalc_P5 work/gul_S1_summaryaalcalc/P5.bin work/gul_S1_summaryleccalc/P5.bin > /dev/null & pid69=$!
+tee < fifo/gul_S2_summary_P5 fifo/gul_S2_eltcalc_P5 fifo/gul_S2_summarycalc_P5 fifo/gul_S2_pltcalc_P5 work/gul_S2_summaryaalcalc/P5.bin work/gul_S2_summaryleccalc/P5.bin > /dev/null & pid70=$!
+tee < fifo/gul_S1_summary_P6 fifo/gul_S1_eltcalc_P6 fifo/gul_S1_summarycalc_P6 fifo/gul_S1_pltcalc_P6 work/gul_S1_summaryaalcalc/P6.bin work/gul_S1_summaryleccalc/P6.bin > /dev/null & pid71=$!
+tee < fifo/gul_S2_summary_P6 fifo/gul_S2_eltcalc_P6 fifo/gul_S2_summarycalc_P6 fifo/gul_S2_pltcalc_P6 work/gul_S2_summaryaalcalc/P6.bin work/gul_S2_summaryleccalc/P6.bin > /dev/null & pid72=$!
+tee < fifo/gul_S1_summary_P7 fifo/gul_S1_eltcalc_P7 fifo/gul_S1_summarycalc_P7 fifo/gul_S1_pltcalc_P7 work/gul_S1_summaryaalcalc/P7.bin work/gul_S1_summaryleccalc/P7.bin > /dev/null & pid73=$!
+tee < fifo/gul_S2_summary_P7 fifo/gul_S2_eltcalc_P7 fifo/gul_S2_summarycalc_P7 fifo/gul_S2_pltcalc_P7 work/gul_S2_summaryaalcalc/P7.bin work/gul_S2_summaryleccalc/P7.bin > /dev/null & pid74=$!
+tee < fifo/gul_S1_summary_P8 fifo/gul_S1_eltcalc_P8 fifo/gul_S1_summarycalc_P8 fifo/gul_S1_pltcalc_P8 work/gul_S1_summaryaalcalc/P8.bin work/gul_S1_summaryleccalc/P8.bin > /dev/null & pid75=$!
+tee < fifo/gul_S2_summary_P8 fifo/gul_S2_eltcalc_P8 fifo/gul_S2_summarycalc_P8 fifo/gul_S2_pltcalc_P8 work/gul_S2_summaryaalcalc/P8.bin work/gul_S2_summaryleccalc/P8.bin > /dev/null & pid76=$!
+tee < fifo/gul_S1_summary_P9 fifo/gul_S1_eltcalc_P9 fifo/gul_S1_summarycalc_P9 fifo/gul_S1_pltcalc_P9 work/gul_S1_summaryaalcalc/P9.bin work/gul_S1_summaryleccalc/P9.bin > /dev/null & pid77=$!
+tee < fifo/gul_S2_summary_P9 fifo/gul_S2_eltcalc_P9 fifo/gul_S2_summarycalc_P9 fifo/gul_S2_pltcalc_P9 work/gul_S2_summaryaalcalc/P9.bin work/gul_S2_summaryleccalc/P9.bin > /dev/null & pid78=$!
+tee < fifo/gul_S1_summary_P10 fifo/gul_S1_eltcalc_P10 fifo/gul_S1_summarycalc_P10 fifo/gul_S1_pltcalc_P10 work/gul_S1_summaryaalcalc/P10.bin work/gul_S1_summaryleccalc/P10.bin > /dev/null & pid79=$!
+tee < fifo/gul_S2_summary_P10 fifo/gul_S2_eltcalc_P10 fifo/gul_S2_summarycalc_P10 fifo/gul_S2_pltcalc_P10 work/gul_S2_summaryaalcalc/P10.bin work/gul_S2_summaryleccalc/P10.bin > /dev/null & pid80=$!
+
+summarycalc -i  -1 fifo/gul_S1_summary_P1 -2 fifo/gul_S2_summary_P1 < fifo/gul_P1 &
+summarycalc -i  -1 fifo/gul_S1_summary_P2 -2 fifo/gul_S2_summary_P2 < fifo/gul_P2 &
+summarycalc -i  -1 fifo/gul_S1_summary_P3 -2 fifo/gul_S2_summary_P3 < fifo/gul_P3 &
+summarycalc -i  -1 fifo/gul_S1_summary_P4 -2 fifo/gul_S2_summary_P4 < fifo/gul_P4 &
+summarycalc -i  -1 fifo/gul_S1_summary_P5 -2 fifo/gul_S2_summary_P5 < fifo/gul_P5 &
+summarycalc -i  -1 fifo/gul_S1_summary_P6 -2 fifo/gul_S2_summary_P6 < fifo/gul_P6 &
+summarycalc -i  -1 fifo/gul_S1_summary_P7 -2 fifo/gul_S2_summary_P7 < fifo/gul_P7 &
+summarycalc -i  -1 fifo/gul_S1_summary_P8 -2 fifo/gul_S2_summary_P8 < fifo/gul_P8 &
+summarycalc -i  -1 fifo/gul_S1_summary_P9 -2 fifo/gul_S2_summary_P9 < fifo/gul_P9 &
+summarycalc -i  -1 fifo/gul_S1_summary_P10 -2 fifo/gul_S2_summary_P10 < fifo/gul_P10 &
+
+eve 1 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P1  &
+eve 2 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P2  &
+eve 3 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P3  &
+eve 4 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P4  &
+eve 5 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P5  &
+eve 6 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P6  &
+eve 7 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P7  &
+eve 8 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P8  &
+eve 9 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P9  &
+eve 10 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P10  &
+
+wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 $pid13 $pid14 $pid15 $pid16 $pid17 $pid18 $pid19 $pid20 $pid21 $pid22 $pid23 $pid24 $pid25 $pid26 $pid27 $pid28 $pid29 $pid30 $pid31 $pid32 $pid33 $pid34 $pid35 $pid36 $pid37 $pid38 $pid39 $pid40 $pid41 $pid42 $pid43 $pid44 $pid45 $pid46 $pid47 $pid48 $pid49 $pid50 $pid51 $pid52 $pid53 $pid54 $pid55 $pid56 $pid57 $pid58 $pid59 $pid60 $pid61 $pid62 $pid63 $pid64 $pid65 $pid66 $pid67 $pid68 $pid69 $pid70 $pid71 $pid72 $pid73 $pid74 $pid75 $pid76 $pid77 $pid78 $pid79 $pid80
+
+
+# --- Do ground up loss kats ---
+
+kat -s work/kat/gul_S1_eltcalc_P1 work/kat/gul_S1_eltcalc_P2 work/kat/gul_S1_eltcalc_P3 work/kat/gul_S1_eltcalc_P4 work/kat/gul_S1_eltcalc_P5 work/kat/gul_S1_eltcalc_P6 work/kat/gul_S1_eltcalc_P7 work/kat/gul_S1_eltcalc_P8 work/kat/gul_S1_eltcalc_P9 work/kat/gul_S1_eltcalc_P10 > output/gul_S1_eltcalc.csv & kpid1=$!
+kat work/kat/gul_S1_pltcalc_P1 work/kat/gul_S1_pltcalc_P2 work/kat/gul_S1_pltcalc_P3 work/kat/gul_S1_pltcalc_P4 work/kat/gul_S1_pltcalc_P5 work/kat/gul_S1_pltcalc_P6 work/kat/gul_S1_pltcalc_P7 work/kat/gul_S1_pltcalc_P8 work/kat/gul_S1_pltcalc_P9 work/kat/gul_S1_pltcalc_P10 > output/gul_S1_pltcalc.csv & kpid2=$!
+kat work/kat/gul_S1_summarycalc_P1 work/kat/gul_S1_summarycalc_P2 work/kat/gul_S1_summarycalc_P3 work/kat/gul_S1_summarycalc_P4 work/kat/gul_S1_summarycalc_P5 work/kat/gul_S1_summarycalc_P6 work/kat/gul_S1_summarycalc_P7 work/kat/gul_S1_summarycalc_P8 work/kat/gul_S1_summarycalc_P9 work/kat/gul_S1_summarycalc_P10 > output/gul_S1_summarycalc.csv & kpid3=$!
+kat -s work/kat/gul_S2_eltcalc_P1 work/kat/gul_S2_eltcalc_P2 work/kat/gul_S2_eltcalc_P3 work/kat/gul_S2_eltcalc_P4 work/kat/gul_S2_eltcalc_P5 work/kat/gul_S2_eltcalc_P6 work/kat/gul_S2_eltcalc_P7 work/kat/gul_S2_eltcalc_P8 work/kat/gul_S2_eltcalc_P9 work/kat/gul_S2_eltcalc_P10 > output/gul_S2_eltcalc.csv & kpid4=$!
+kat work/kat/gul_S2_pltcalc_P1 work/kat/gul_S2_pltcalc_P2 work/kat/gul_S2_pltcalc_P3 work/kat/gul_S2_pltcalc_P4 work/kat/gul_S2_pltcalc_P5 work/kat/gul_S2_pltcalc_P6 work/kat/gul_S2_pltcalc_P7 work/kat/gul_S2_pltcalc_P8 work/kat/gul_S2_pltcalc_P9 work/kat/gul_S2_pltcalc_P10 > output/gul_S2_pltcalc.csv & kpid5=$!
+kat work/kat/gul_S2_summarycalc_P1 work/kat/gul_S2_summarycalc_P2 work/kat/gul_S2_summarycalc_P3 work/kat/gul_S2_summarycalc_P4 work/kat/gul_S2_summarycalc_P5 work/kat/gul_S2_summarycalc_P6 work/kat/gul_S2_summarycalc_P7 work/kat/gul_S2_summarycalc_P8 work/kat/gul_S2_summarycalc_P9 work/kat/gul_S2_summarycalc_P10 > output/gul_S2_summarycalc.csv & kpid6=$!
+wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
+
+
+aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv & lpid1=$!
+ordleccalc -r -Kgul_S1_summaryleccalc -F -S -s -M -m -W -w -O output/gul_S1_ept.csv -o output/gul_S1_psept.csv & lpid2=$!
+leccalc -r -Kgul_S1_summaryleccalc -F output/gul_S1_leccalc_full_uncertainty_aep.csv -f output/gul_S1_leccalc_full_uncertainty_oep.csv -S output/gul_S1_leccalc_sample_mean_aep.csv -s output/gul_S1_leccalc_sample_mean_oep.csv -W output/gul_S1_leccalc_wheatsheaf_aep.csv -M output/gul_S1_leccalc_wheatsheaf_mean_aep.csv -m output/gul_S1_leccalc_wheatsheaf_mean_oep.csv -w output/gul_S1_leccalc_wheatsheaf_oep.csv & lpid3=$!
+aalcalc -Kgul_S2_summaryaalcalc > output/gul_S2_aalcalc.csv & lpid4=$!
+ordleccalc -r -Kgul_S2_summaryleccalc -F -S -s -M -m -W -w -O output/gul_S2_ept.csv -o output/gul_S2_psept.csv & lpid5=$!
+leccalc -r -Kgul_S2_summaryleccalc -F output/gul_S2_leccalc_full_uncertainty_aep.csv -f output/gul_S2_leccalc_full_uncertainty_oep.csv -S output/gul_S2_leccalc_sample_mean_aep.csv -s output/gul_S2_leccalc_sample_mean_oep.csv -W output/gul_S2_leccalc_wheatsheaf_aep.csv -M output/gul_S2_leccalc_wheatsheaf_mean_aep.csv -m output/gul_S2_leccalc_wheatsheaf_mean_oep.csv -w output/gul_S2_leccalc_wheatsheaf_oep.csv & lpid6=$!
+wait $lpid1 $lpid2 $lpid3 $lpid4 $lpid5 $lpid6
+
+rm -R -f work/*
+rm -R -f fifo/*

--- a/tests/model_execution/itm_kparse_reference/gul_ord_psept_2_output_10_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_ord_psept_2_output_10_partition.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+
+rm -R -f fifo/*
+rm -R -f work/*
+mkdir work/kat/
+
+mkdir work/gul_S1_summaryleccalc
+mkdir work/gul_S2_summaryleccalc
+
+mkfifo fifo/gul_P1
+mkfifo fifo/gul_P2
+mkfifo fifo/gul_P3
+mkfifo fifo/gul_P4
+mkfifo fifo/gul_P5
+mkfifo fifo/gul_P6
+mkfifo fifo/gul_P7
+mkfifo fifo/gul_P8
+mkfifo fifo/gul_P9
+mkfifo fifo/gul_P10
+
+mkfifo fifo/gul_S1_summary_P1
+mkfifo fifo/gul_S2_summary_P1
+
+mkfifo fifo/gul_S1_summary_P2
+mkfifo fifo/gul_S2_summary_P2
+
+mkfifo fifo/gul_S1_summary_P3
+mkfifo fifo/gul_S2_summary_P3
+
+mkfifo fifo/gul_S1_summary_P4
+mkfifo fifo/gul_S2_summary_P4
+
+mkfifo fifo/gul_S1_summary_P5
+mkfifo fifo/gul_S2_summary_P5
+
+mkfifo fifo/gul_S1_summary_P6
+mkfifo fifo/gul_S2_summary_P6
+
+mkfifo fifo/gul_S1_summary_P7
+mkfifo fifo/gul_S2_summary_P7
+
+mkfifo fifo/gul_S1_summary_P8
+mkfifo fifo/gul_S2_summary_P8
+
+mkfifo fifo/gul_S1_summary_P9
+mkfifo fifo/gul_S2_summary_P9
+
+mkfifo fifo/gul_S1_summary_P10
+mkfifo fifo/gul_S2_summary_P10
+
+
+
+# --- Do ground up loss computes ---
+
+
+tee < fifo/gul_S1_summary_P1 work/gul_S1_summaryleccalc/P1.bin > /dev/null & pid1=$!
+tee < fifo/gul_S2_summary_P1 work/gul_S2_summaryleccalc/P1.bin > /dev/null & pid2=$!
+tee < fifo/gul_S1_summary_P2 work/gul_S1_summaryleccalc/P2.bin > /dev/null & pid3=$!
+tee < fifo/gul_S2_summary_P2 work/gul_S2_summaryleccalc/P2.bin > /dev/null & pid4=$!
+tee < fifo/gul_S1_summary_P3 work/gul_S1_summaryleccalc/P3.bin > /dev/null & pid5=$!
+tee < fifo/gul_S2_summary_P3 work/gul_S2_summaryleccalc/P3.bin > /dev/null & pid6=$!
+tee < fifo/gul_S1_summary_P4 work/gul_S1_summaryleccalc/P4.bin > /dev/null & pid7=$!
+tee < fifo/gul_S2_summary_P4 work/gul_S2_summaryleccalc/P4.bin > /dev/null & pid8=$!
+tee < fifo/gul_S1_summary_P5 work/gul_S1_summaryleccalc/P5.bin > /dev/null & pid9=$!
+tee < fifo/gul_S2_summary_P5 work/gul_S2_summaryleccalc/P5.bin > /dev/null & pid10=$!
+tee < fifo/gul_S1_summary_P6 work/gul_S1_summaryleccalc/P6.bin > /dev/null & pid11=$!
+tee < fifo/gul_S2_summary_P6 work/gul_S2_summaryleccalc/P6.bin > /dev/null & pid12=$!
+tee < fifo/gul_S1_summary_P7 work/gul_S1_summaryleccalc/P7.bin > /dev/null & pid13=$!
+tee < fifo/gul_S2_summary_P7 work/gul_S2_summaryleccalc/P7.bin > /dev/null & pid14=$!
+tee < fifo/gul_S1_summary_P8 work/gul_S1_summaryleccalc/P8.bin > /dev/null & pid15=$!
+tee < fifo/gul_S2_summary_P8 work/gul_S2_summaryleccalc/P8.bin > /dev/null & pid16=$!
+tee < fifo/gul_S1_summary_P9 work/gul_S1_summaryleccalc/P9.bin > /dev/null & pid17=$!
+tee < fifo/gul_S2_summary_P9 work/gul_S2_summaryleccalc/P9.bin > /dev/null & pid18=$!
+tee < fifo/gul_S1_summary_P10 work/gul_S1_summaryleccalc/P10.bin > /dev/null & pid19=$!
+tee < fifo/gul_S2_summary_P10 work/gul_S2_summaryleccalc/P10.bin > /dev/null & pid20=$!
+
+summarycalc -i  -1 fifo/gul_S1_summary_P1 -2 fifo/gul_S2_summary_P1 < fifo/gul_P1 &
+summarycalc -i  -1 fifo/gul_S1_summary_P2 -2 fifo/gul_S2_summary_P2 < fifo/gul_P2 &
+summarycalc -i  -1 fifo/gul_S1_summary_P3 -2 fifo/gul_S2_summary_P3 < fifo/gul_P3 &
+summarycalc -i  -1 fifo/gul_S1_summary_P4 -2 fifo/gul_S2_summary_P4 < fifo/gul_P4 &
+summarycalc -i  -1 fifo/gul_S1_summary_P5 -2 fifo/gul_S2_summary_P5 < fifo/gul_P5 &
+summarycalc -i  -1 fifo/gul_S1_summary_P6 -2 fifo/gul_S2_summary_P6 < fifo/gul_P6 &
+summarycalc -i  -1 fifo/gul_S1_summary_P7 -2 fifo/gul_S2_summary_P7 < fifo/gul_P7 &
+summarycalc -i  -1 fifo/gul_S1_summary_P8 -2 fifo/gul_S2_summary_P8 < fifo/gul_P8 &
+summarycalc -i  -1 fifo/gul_S1_summary_P9 -2 fifo/gul_S2_summary_P9 < fifo/gul_P9 &
+summarycalc -i  -1 fifo/gul_S1_summary_P10 -2 fifo/gul_S2_summary_P10 < fifo/gul_P10 &
+
+eve 1 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P1  &
+eve 2 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P2  &
+eve 3 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P3  &
+eve 4 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P4  &
+eve 5 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P5  &
+eve 6 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P6  &
+eve 7 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P7  &
+eve 8 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P8  &
+eve 9 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P9  &
+eve 10 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > fifo/gul_P10  &
+
+wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 $pid13 $pid14 $pid15 $pid16 $pid17 $pid18 $pid19 $pid20
+
+
+# --- Do ground up loss kats ---
+
+
+ordleccalc  -Kgul_S1_summaryleccalc -W -w -o output/gul_S1_psept.csv & lpid1=$!
+ordleccalc -r -Kgul_S2_summaryleccalc -W -w -o output/gul_S2_psept.csv & lpid2=$!
+wait $lpid1 $lpid2
+
+rm -R -f work/*
+rm -R -f fifo/*

--- a/tests/model_execution/kparse_input/analysis_settings_5.json
+++ b/tests/model_execution/kparse_input/analysis_settings_5.json
@@ -1,0 +1,58 @@
+{
+  "analysis_settings": {
+    "source_tag": "test_source",
+    "analysis_tag": "test_analysis",
+    "module_supplier_id": "OasisIM",
+    "model_version_id": "1",
+    "number_of_samples": 0,
+    "gul_threshold": 0,
+    "model_settings": {
+      "use_random_number_file": true,
+      "event_occurrence_file_id": 1
+    },
+    "gul_output": true,
+    "gul_summaries": [
+      {
+        "id": 1,
+        "summarycalc": true,
+        "eltcalc": true,
+        "aalcalc": true,
+        "pltcalc": true
+      }
+    ],
+    "il_output": true,    
+    "il_summaries": [
+      {
+        "id": 1,
+        "ord_output": {
+          "ept_full_uncertainty_aep": true,
+          "ept_full_uncertainty_oep": false,
+          "ept_mean_sample_aep": true,
+          "ept_mean_sample_oep": true,
+          "ept_per_sample_mean_aep": true,
+          "ept_per_sample_mean_oep": true,
+          "psept_aep": false,
+          "psept_oep": false,
+          "return_period_file": false
+        }
+      }
+    ],
+    "ri_output": true,    
+    "ri_summaries": [
+      {
+        "id": 1,
+        "ord_output": {
+          "ept_full_uncertainty_aep": true,
+          "ept_full_uncertainty_oep": true,
+          "ept_mean_sample_aep": true,
+          "ept_mean_sample_oep": true,
+          "ept_per_sample_mean_aep": true,
+          "ept_per_sample_mean_oep": true,
+          "psept_aep": true,
+          "psept_oep": true,
+          "return_period_file": true
+        }
+      }
+    ]
+  }
+}

--- a/tests/model_execution/kparse_input/gul_il_ord_ept_psept_2_output.json
+++ b/tests/model_execution/kparse_input/gul_il_ord_ept_psept_2_output.json
@@ -1,0 +1,92 @@
+{
+  "analysis_settings": {
+    "source_tag": "test_source",
+    "analysis_tag": "test_analysis",
+    "module_supplier_id": "OasisIM",
+    "model_version_id": "1",
+    "number_of_samples": 0,
+    "gul_threshold": 0,
+    "model_settings": {
+      "use_random_number_file": true,
+      "event_occurrence_file_id": 1
+    },
+    "gul_output": true,
+    "gul_summaries": [
+      {
+        "id": 1,
+        "summarycalc": true,
+        "eltcalc": true,
+        "aalcalc": true,
+        "pltcalc": true,
+        "ord_output": {
+          "ept_full_uncertainty_aep": true,
+          "ept_full_uncertainty_oep": false,
+          "ept_mean_sample_aep": true,
+          "ept_mean_sample_oep": true,
+          "ept_per_sample_mean_aep": true,
+          "ept_per_sample_mean_oep": true,
+          "psept_aep": true,
+          "psept_oep": true,
+          "return_period_file": true
+        }
+      },
+      {
+        "id": 2,
+        "summarycalc": true,
+        "eltcalc": true,
+        "aalcalc": true,
+        "pltcalc": true,
+        "ord_output": {
+          "ept_full_uncertainty_aep": true,
+          "ept_full_uncertainty_oep": false,
+          "ept_mean_sample_aep": true,
+          "ept_mean_sample_oep": true,
+          "ept_per_sample_mean_aep": true,
+          "ept_per_sample_mean_oep": true,
+          "psept_aep": true,
+          "psept_oep": true,
+          "return_period_file": true
+        }
+      }
+    ],
+    "il_output": true,
+    "il_summaries": [
+      {
+        "id": 1,
+        "summarycalc": true,
+        "eltcalc": true,
+        "aalcalc": true,
+        "pltcalc": true,
+        "ord_output": {
+          "ept_full_uncertainty_aep": true,
+          "ept_full_uncertainty_oep": false,
+          "ept_mean_sample_aep": true,
+          "ept_mean_sample_oep": true,
+          "ept_per_sample_mean_aep": true,
+          "ept_per_sample_mean_oep": true,
+          "psept_aep": true,
+          "psept_oep": true,
+          "return_period_file": true
+        }
+      },
+      {
+        "id": 2,
+        "summarycalc": true,
+        "eltcalc": true,
+        "aalcalc": true,
+        "pltcalc": true,
+        "ord_output": {
+          "ept_full_uncertainty_aep": true,
+          "ept_full_uncertainty_oep": false,
+          "ept_mean_sample_aep": true,
+          "ept_mean_sample_oep": true,
+          "ept_per_sample_mean_aep": true,
+          "ept_per_sample_mean_oep": true,
+          "psept_aep": true,
+          "psept_oep": true,
+          "return_period_file": true
+        }
+      }
+    ]
+  }
+}

--- a/tests/model_execution/kparse_input/gul_il_ord_psept_lec_1_output.json
+++ b/tests/model_execution/kparse_input/gul_il_ord_psept_lec_1_output.json
@@ -1,0 +1,80 @@
+{
+  "analysis_settings": {
+    "source_tag": "test_source",
+    "analysis_tag": "test_analysis",
+    "module_supplier_id": "OasisIM",
+    "model_version_id": "1",
+    "number_of_samples": 0,
+    "gul_threshold": 0,
+    "model_settings": {
+      "use_random_number_file": true,
+      "event_occurrence_file_id": 1
+    },
+    "gul_output": true,
+    "gul_summaries": [
+      {
+        "id": 1,
+        "summarycalc": true,
+        "eltcalc": true,
+        "aalcalc": true,
+        "pltcalc": true,
+        "lec_output":true,
+        "leccalc": {
+            "return_period_file": true,
+            "full_uncertainty_aep": true,
+            "full_uncertainty_oep": true,
+            "wheatsheaf_aep": true,
+            "wheatsheaf_oep": true,
+            "wheatsheaf_mean_aep": true,
+            "wheatsheaf_mean_oep": true,
+            "sample_mean_aep": true,
+            "sample_mean_oep": true
+        },        
+        "ord_output": {
+          "ept_full_uncertainty_aep": false,
+          "ept_full_uncertainty_oep": false,
+          "ept_mean_sample_aep": false,
+          "ept_mean_sample_oep": false,
+          "ept_per_sample_mean_aep": false,
+          "ept_per_sample_mean_oep": false,
+          "psept_aep": true,
+          "psept_oep": true,
+          "return_period_file": false
+        }
+      }
+    ],
+    "il_output": true,
+    "il_summaries": [
+      {
+        "id": 1,
+        "summarycalc": true,
+        "eltcalc": true,
+        "aalcalc": true,
+        "pltcalc": true,
+        "lec_output":true,
+        "leccalc": {
+            "return_period_file": true,
+            "full_uncertainty_aep": true,
+            "full_uncertainty_oep": true,
+            "wheatsheaf_aep": true,
+            "wheatsheaf_oep": true,
+            "wheatsheaf_mean_aep": true,
+            "wheatsheaf_mean_oep": true,
+            "sample_mean_aep": true,
+            "sample_mean_oep": true
+        },        
+        "ord_output": {
+          "ept_full_uncertainty_aep": false,
+          "ept_full_uncertainty_oep": false,
+          "ept_mean_sample_aep": false,
+          "ept_mean_sample_oep": false,
+          "ept_per_sample_mean_aep": false,
+          "ept_per_sample_mean_oep": false,
+          "psept_aep": true,
+          "psept_oep": true,
+          "return_period_file": true
+        }
+      }
+    ]    
+  }
+}

--- a/tests/model_execution/kparse_input/gul_ord_ept_1_output.json
+++ b/tests/model_execution/kparse_input/gul_ord_ept_1_output.json
@@ -1,0 +1,30 @@
+{
+  "analysis_settings": {
+    "source_tag": "test_source",
+    "analysis_tag": "test_analysis",
+    "module_supplier_id": "OasisIM",
+    "model_version_id": "1",
+    "number_of_samples": 0,
+    "gul_threshold": 0,
+    "model_settings": {
+      "use_random_number_file": true,
+      "event_occurrence_file_id": 1
+    },
+    "gul_output": true,
+    "gul_summaries": [
+      {
+        "id": 1,
+        "ord_output": {
+          "ept_full_uncertainty_aep": true,
+          "ept_full_uncertainty_oep": true,
+          "ept_mean_sample_aep": true,
+          "ept_mean_sample_oep": true,
+          "ept_per_sample_mean_aep": true,
+          "ept_per_sample_mean_oep": true,
+          "return_period_file": true
+        }
+      }  
+    ],
+    "il_output": false
+  }
+}

--- a/tests/model_execution/kparse_input/gul_ord_ept_psept_lec_2_output.json
+++ b/tests/model_execution/kparse_input/gul_ord_ept_psept_lec_2_output.json
@@ -1,0 +1,78 @@
+{
+  "analysis_settings": {
+    "source_tag": "test_source",
+    "analysis_tag": "test_analysis",
+    "module_supplier_id": "OasisIM",
+    "model_version_id": "1",
+    "number_of_samples": 0,
+    "gul_threshold": 0,
+    "model_settings": {
+      "use_random_number_file": true,
+      "event_occurrence_file_id": 1
+    },
+    "gul_output": true,
+    "gul_summaries": [
+      {
+        "id": 1,
+        "summarycalc": true,
+        "eltcalc": true,
+        "aalcalc": true,
+        "pltcalc": true,
+        "lec_output":true,
+        "leccalc": {
+          "return_period_file": true,
+          "full_uncertainty_aep": true,
+          "full_uncertainty_oep": true,
+          "wheatsheaf_aep": true,
+          "wheatsheaf_oep": true,
+          "wheatsheaf_mean_aep": true,
+          "wheatsheaf_mean_oep": true,
+          "sample_mean_aep": true,
+          "sample_mean_oep": true
+        },
+        "ord_output": {
+          "ept_full_uncertainty_aep": true,
+          "ept_full_uncertainty_oep": false,
+          "ept_mean_sample_aep": true,
+          "ept_mean_sample_oep": true,
+          "ept_per_sample_mean_aep": true,
+          "ept_per_sample_mean_oep": true,
+          "psept_aep": true,
+          "psept_oep": true,
+          "return_period_file": true
+        }
+      },
+      {
+        "id": 2,
+        "summarycalc": true,
+        "eltcalc": true,
+        "aalcalc": true,
+        "pltcalc": true,
+        "lec_output":true,
+        "leccalc": {
+          "return_period_file": true,
+          "full_uncertainty_aep": true,
+          "full_uncertainty_oep": true,
+          "wheatsheaf_aep": true,
+          "wheatsheaf_oep": true,
+          "wheatsheaf_mean_aep": true,
+          "wheatsheaf_mean_oep": true,
+          "sample_mean_aep": true,
+          "sample_mean_oep": true
+        },        
+        "ord_output": {
+          "ept_full_uncertainty_aep": true,
+          "ept_full_uncertainty_oep": false,
+          "ept_mean_sample_aep": true,
+          "ept_mean_sample_oep": true,
+          "ept_per_sample_mean_aep": true,
+          "ept_per_sample_mean_oep": true,
+          "psept_aep": true,
+          "psept_oep": true,
+          "return_period_file": true
+        }
+      }
+    ],
+    "il_output": false
+  }
+}

--- a/tests/model_execution/kparse_input/gul_ord_psept_2_output.json
+++ b/tests/model_execution/kparse_input/gul_ord_psept_2_output.json
@@ -1,0 +1,34 @@
+{
+  "analysis_settings": {
+    "source_tag": "test_source",
+    "analysis_tag": "test_analysis",
+    "module_supplier_id": "OasisIM",
+    "model_version_id": "1",
+    "number_of_samples": 0,
+    "gul_threshold": 0,
+    "model_settings": {
+      "use_random_number_file": true,
+      "event_occurrence_file_id": 1
+    },
+    "gul_output": true,
+    "gul_summaries": [
+      {
+        "id": 1,
+        "ord_output": {
+          "psept_aep": true,
+          "psept_oep": true,
+          "return_period_file": false
+        }
+      },
+      {
+        "id": 2,
+        "ord_output": {
+          "psept_aep": true,
+          "psept_oep": true,
+          "return_period_file": true
+        }
+      } 
+    ],
+    "il_output": false
+  }
+}

--- a/tests/model_execution/lb_kparse_reference/analysis_settings_5_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/analysis_settings_5_1_reins_layer_1_partition.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+
+rm -R -f fifo/*
+rm -R -f work/*
+mkdir work/kat/
+
+fmpy -a2 --create-financial-structure-files
+fmpy -a2 --create-financial-structure-files -p RI_1
+mkdir work/gul_S1_summaryaalcalc
+mkdir work/il_S1_summaryleccalc
+mkdir work/ri_S1_summaryleccalc
+
+mkfifo fifo/gul_P1
+mkfifo fifo/gul_P2
+
+mkfifo fifo/gul_S1_summary_P1
+mkfifo fifo/gul_S1_eltcalc_P1
+mkfifo fifo/gul_S1_summarycalc_P1
+mkfifo fifo/gul_S1_pltcalc_P1
+
+mkfifo fifo/gul_S1_summary_P2
+mkfifo fifo/gul_S1_eltcalc_P2
+mkfifo fifo/gul_S1_summarycalc_P2
+mkfifo fifo/gul_S1_pltcalc_P2
+
+mkfifo fifo/il_P1
+mkfifo fifo/il_P2
+
+mkfifo fifo/il_S1_summary_P1
+
+mkfifo fifo/il_S1_summary_P2
+
+mkfifo fifo/ri_P1
+mkfifo fifo/ri_P2
+
+mkfifo fifo/ri_S1_summary_P1
+
+mkfifo fifo/ri_S1_summary_P2
+
+mkfifo fifo/gul_lb_P1
+mkfifo fifo/gul_lb_P2
+
+mkfifo fifo/lb_il_P1
+mkfifo fifo/lb_il_P2
+
+
+
+# --- Do reinsurance loss computes ---
+
+
+tee < fifo/ri_S1_summary_P1 work/ri_S1_summaryleccalc/P1.bin > /dev/null & pid1=$!
+tee < fifo/ri_S1_summary_P2 work/ri_S1_summaryleccalc/P2.bin > /dev/null & pid2=$!
+
+summarycalc -f -p RI_1 -1 fifo/ri_S1_summary_P1 < fifo/ri_P1 &
+summarycalc -f -p RI_1 -1 fifo/ri_S1_summary_P2 < fifo/ri_P2 &
+
+# --- Do insured loss computes ---
+
+
+tee < fifo/il_S1_summary_P1 work/il_S1_summaryleccalc/P1.bin > /dev/null & pid3=$!
+tee < fifo/il_S1_summary_P2 work/il_S1_summaryleccalc/P2.bin > /dev/null & pid4=$!
+
+summarycalc -f  -1 fifo/il_S1_summary_P1 < fifo/il_P1 &
+summarycalc -f  -1 fifo/il_S1_summary_P2 < fifo/il_P2 &
+
+# --- Do ground up loss computes ---
+
+eltcalc < fifo/gul_S1_eltcalc_P1 > work/kat/gul_S1_eltcalc_P1 & pid5=$!
+summarycalctocsv < fifo/gul_S1_summarycalc_P1 > work/kat/gul_S1_summarycalc_P1 & pid6=$!
+pltcalc < fifo/gul_S1_pltcalc_P1 > work/kat/gul_S1_pltcalc_P1 & pid7=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P2 > work/kat/gul_S1_eltcalc_P2 & pid8=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P2 > work/kat/gul_S1_summarycalc_P2 & pid9=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P2 > work/kat/gul_S1_pltcalc_P2 & pid10=$!
+
+tee < fifo/gul_S1_summary_P1 fifo/gul_S1_eltcalc_P1 fifo/gul_S1_summarycalc_P1 fifo/gul_S1_pltcalc_P1 work/gul_S1_summaryaalcalc/P1.bin > /dev/null & pid11=$!
+tee < fifo/gul_S1_summary_P2 fifo/gul_S1_eltcalc_P2 fifo/gul_S1_summarycalc_P2 fifo/gul_S1_pltcalc_P2 work/gul_S1_summaryaalcalc/P2.bin > /dev/null & pid12=$!
+
+summarycalc -i  -1 fifo/gul_S1_summary_P1 < fifo/gul_P1 &
+summarycalc -i  -1 fifo/gul_S1_summary_P2 < fifo/gul_P2 &
+
+eve 1 2 | getmodel | gulcalc -S0 -L0 -r -a0 -i - | tee fifo/gul_P1 > fifo/gul_lb_P1  &
+eve 2 2 | getmodel | gulcalc -S0 -L0 -r -a0 -i - | tee fifo/gul_P2 > fifo/gul_lb_P2  &
+load_balancer -i fifo/gul_lb_P1 fifo/gul_lb_P2 -o fifo/lb_il_P1 fifo/lb_il_P2 &
+fmpy -a2 < fifo/lb_il_P1 | tee fifo/il_P1 | fmpy -a2 -n -p RI_1 > fifo/ri_P1 &
+fmpy -a2 < fifo/lb_il_P2 | tee fifo/il_P2 | fmpy -a2 -n -p RI_1 > fifo/ri_P2 &
+
+wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12
+
+
+# --- Do reinsurance loss kats ---
+
+
+# --- Do insured loss kats ---
+
+
+# --- Do ground up loss kats ---
+
+kat -s work/kat/gul_S1_eltcalc_P1 work/kat/gul_S1_eltcalc_P2 > output/gul_S1_eltcalc.csv & kpid1=$!
+kat work/kat/gul_S1_pltcalc_P1 work/kat/gul_S1_pltcalc_P2 > output/gul_S1_pltcalc.csv & kpid2=$!
+kat work/kat/gul_S1_summarycalc_P1 work/kat/gul_S1_summarycalc_P2 > output/gul_S1_summarycalc.csv & kpid3=$!
+wait $kpid1 $kpid2 $kpid3
+
+
+ordleccalc -r -Kri_S1_summaryleccalc -F -f -S -s -M -m -W -w -O output/ri_S1_ept.csv -o output/ri_S1_psept.csv & lpid1=$!
+ordleccalc  -Kil_S1_summaryleccalc -F -S -s -M -m -O output/il_S1_ept.csv & lpid2=$!
+aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv & lpid3=$!
+wait $lpid1 $lpid2 $lpid3
+
+rm -R -f work/*
+rm -R -f fifo/*

--- a/tests/model_execution/lb_kparse_reference/gul_il_ord_ept_psept_2_output_10_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_il_ord_ept_psept_2_output_10_partition.sh
@@ -1,0 +1,335 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+
+rm -R -f fifo/*
+rm -R -f work/*
+mkdir work/kat/
+
+fmpy -a2 --create-financial-structure-files
+mkdir work/gul_S1_summaryleccalc
+mkdir work/gul_S1_summaryaalcalc
+mkdir work/gul_S2_summaryleccalc
+mkdir work/gul_S2_summaryaalcalc
+mkdir work/il_S1_summaryleccalc
+mkdir work/il_S1_summaryaalcalc
+mkdir work/il_S2_summaryleccalc
+mkdir work/il_S2_summaryaalcalc
+
+mkfifo fifo/gul_P1
+mkfifo fifo/gul_P2
+mkfifo fifo/gul_P3
+mkfifo fifo/gul_P4
+mkfifo fifo/gul_P5
+mkfifo fifo/gul_P6
+
+mkfifo fifo/gul_S1_summary_P1
+mkfifo fifo/gul_S1_eltcalc_P1
+mkfifo fifo/gul_S1_summarycalc_P1
+mkfifo fifo/gul_S1_pltcalc_P1
+mkfifo fifo/gul_S2_summary_P1
+mkfifo fifo/gul_S2_eltcalc_P1
+mkfifo fifo/gul_S2_summarycalc_P1
+mkfifo fifo/gul_S2_pltcalc_P1
+
+mkfifo fifo/gul_S1_summary_P2
+mkfifo fifo/gul_S1_eltcalc_P2
+mkfifo fifo/gul_S1_summarycalc_P2
+mkfifo fifo/gul_S1_pltcalc_P2
+mkfifo fifo/gul_S2_summary_P2
+mkfifo fifo/gul_S2_eltcalc_P2
+mkfifo fifo/gul_S2_summarycalc_P2
+mkfifo fifo/gul_S2_pltcalc_P2
+
+mkfifo fifo/gul_S1_summary_P3
+mkfifo fifo/gul_S1_eltcalc_P3
+mkfifo fifo/gul_S1_summarycalc_P3
+mkfifo fifo/gul_S1_pltcalc_P3
+mkfifo fifo/gul_S2_summary_P3
+mkfifo fifo/gul_S2_eltcalc_P3
+mkfifo fifo/gul_S2_summarycalc_P3
+mkfifo fifo/gul_S2_pltcalc_P3
+
+mkfifo fifo/gul_S1_summary_P4
+mkfifo fifo/gul_S1_eltcalc_P4
+mkfifo fifo/gul_S1_summarycalc_P4
+mkfifo fifo/gul_S1_pltcalc_P4
+mkfifo fifo/gul_S2_summary_P4
+mkfifo fifo/gul_S2_eltcalc_P4
+mkfifo fifo/gul_S2_summarycalc_P4
+mkfifo fifo/gul_S2_pltcalc_P4
+
+mkfifo fifo/gul_S1_summary_P5
+mkfifo fifo/gul_S1_eltcalc_P5
+mkfifo fifo/gul_S1_summarycalc_P5
+mkfifo fifo/gul_S1_pltcalc_P5
+mkfifo fifo/gul_S2_summary_P5
+mkfifo fifo/gul_S2_eltcalc_P5
+mkfifo fifo/gul_S2_summarycalc_P5
+mkfifo fifo/gul_S2_pltcalc_P5
+
+mkfifo fifo/gul_S1_summary_P6
+mkfifo fifo/gul_S1_eltcalc_P6
+mkfifo fifo/gul_S1_summarycalc_P6
+mkfifo fifo/gul_S1_pltcalc_P6
+mkfifo fifo/gul_S2_summary_P6
+mkfifo fifo/gul_S2_eltcalc_P6
+mkfifo fifo/gul_S2_summarycalc_P6
+mkfifo fifo/gul_S2_pltcalc_P6
+
+mkfifo fifo/il_P1
+mkfifo fifo/il_P2
+mkfifo fifo/il_P3
+mkfifo fifo/il_P4
+mkfifo fifo/il_P5
+mkfifo fifo/il_P6
+
+mkfifo fifo/il_S1_summary_P1
+mkfifo fifo/il_S1_eltcalc_P1
+mkfifo fifo/il_S1_summarycalc_P1
+mkfifo fifo/il_S1_pltcalc_P1
+mkfifo fifo/il_S2_summary_P1
+mkfifo fifo/il_S2_eltcalc_P1
+mkfifo fifo/il_S2_summarycalc_P1
+mkfifo fifo/il_S2_pltcalc_P1
+
+mkfifo fifo/il_S1_summary_P2
+mkfifo fifo/il_S1_eltcalc_P2
+mkfifo fifo/il_S1_summarycalc_P2
+mkfifo fifo/il_S1_pltcalc_P2
+mkfifo fifo/il_S2_summary_P2
+mkfifo fifo/il_S2_eltcalc_P2
+mkfifo fifo/il_S2_summarycalc_P2
+mkfifo fifo/il_S2_pltcalc_P2
+
+mkfifo fifo/il_S1_summary_P3
+mkfifo fifo/il_S1_eltcalc_P3
+mkfifo fifo/il_S1_summarycalc_P3
+mkfifo fifo/il_S1_pltcalc_P3
+mkfifo fifo/il_S2_summary_P3
+mkfifo fifo/il_S2_eltcalc_P3
+mkfifo fifo/il_S2_summarycalc_P3
+mkfifo fifo/il_S2_pltcalc_P3
+
+mkfifo fifo/il_S1_summary_P4
+mkfifo fifo/il_S1_eltcalc_P4
+mkfifo fifo/il_S1_summarycalc_P4
+mkfifo fifo/il_S1_pltcalc_P4
+mkfifo fifo/il_S2_summary_P4
+mkfifo fifo/il_S2_eltcalc_P4
+mkfifo fifo/il_S2_summarycalc_P4
+mkfifo fifo/il_S2_pltcalc_P4
+
+mkfifo fifo/il_S1_summary_P5
+mkfifo fifo/il_S1_eltcalc_P5
+mkfifo fifo/il_S1_summarycalc_P5
+mkfifo fifo/il_S1_pltcalc_P5
+mkfifo fifo/il_S2_summary_P5
+mkfifo fifo/il_S2_eltcalc_P5
+mkfifo fifo/il_S2_summarycalc_P5
+mkfifo fifo/il_S2_pltcalc_P5
+
+mkfifo fifo/il_S1_summary_P6
+mkfifo fifo/il_S1_eltcalc_P6
+mkfifo fifo/il_S1_summarycalc_P6
+mkfifo fifo/il_S1_pltcalc_P6
+mkfifo fifo/il_S2_summary_P6
+mkfifo fifo/il_S2_eltcalc_P6
+mkfifo fifo/il_S2_summarycalc_P6
+mkfifo fifo/il_S2_pltcalc_P6
+
+mkfifo fifo/gul_lb_P1
+mkfifo fifo/gul_lb_P2
+mkfifo fifo/gul_lb_P3
+mkfifo fifo/gul_lb_P4
+mkfifo fifo/gul_lb_P5
+mkfifo fifo/gul_lb_P6
+
+mkfifo fifo/lb_il_P1
+mkfifo fifo/lb_il_P2
+mkfifo fifo/lb_il_P3
+mkfifo fifo/lb_il_P4
+mkfifo fifo/lb_il_P5
+mkfifo fifo/lb_il_P6
+
+
+
+# --- Do insured loss computes ---
+
+eltcalc < fifo/il_S1_eltcalc_P1 > work/kat/il_S1_eltcalc_P1 & pid1=$!
+summarycalctocsv < fifo/il_S1_summarycalc_P1 > work/kat/il_S1_summarycalc_P1 & pid2=$!
+pltcalc < fifo/il_S1_pltcalc_P1 > work/kat/il_S1_pltcalc_P1 & pid3=$!
+eltcalc < fifo/il_S2_eltcalc_P1 > work/kat/il_S2_eltcalc_P1 & pid4=$!
+summarycalctocsv < fifo/il_S2_summarycalc_P1 > work/kat/il_S2_summarycalc_P1 & pid5=$!
+pltcalc < fifo/il_S2_pltcalc_P1 > work/kat/il_S2_pltcalc_P1 & pid6=$!
+eltcalc -s < fifo/il_S1_eltcalc_P2 > work/kat/il_S1_eltcalc_P2 & pid7=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P2 > work/kat/il_S1_summarycalc_P2 & pid8=$!
+pltcalc -s < fifo/il_S1_pltcalc_P2 > work/kat/il_S1_pltcalc_P2 & pid9=$!
+eltcalc -s < fifo/il_S2_eltcalc_P2 > work/kat/il_S2_eltcalc_P2 & pid10=$!
+summarycalctocsv -s < fifo/il_S2_summarycalc_P2 > work/kat/il_S2_summarycalc_P2 & pid11=$!
+pltcalc -s < fifo/il_S2_pltcalc_P2 > work/kat/il_S2_pltcalc_P2 & pid12=$!
+eltcalc -s < fifo/il_S1_eltcalc_P3 > work/kat/il_S1_eltcalc_P3 & pid13=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P3 > work/kat/il_S1_summarycalc_P3 & pid14=$!
+pltcalc -s < fifo/il_S1_pltcalc_P3 > work/kat/il_S1_pltcalc_P3 & pid15=$!
+eltcalc -s < fifo/il_S2_eltcalc_P3 > work/kat/il_S2_eltcalc_P3 & pid16=$!
+summarycalctocsv -s < fifo/il_S2_summarycalc_P3 > work/kat/il_S2_summarycalc_P3 & pid17=$!
+pltcalc -s < fifo/il_S2_pltcalc_P3 > work/kat/il_S2_pltcalc_P3 & pid18=$!
+eltcalc -s < fifo/il_S1_eltcalc_P4 > work/kat/il_S1_eltcalc_P4 & pid19=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P4 > work/kat/il_S1_summarycalc_P4 & pid20=$!
+pltcalc -s < fifo/il_S1_pltcalc_P4 > work/kat/il_S1_pltcalc_P4 & pid21=$!
+eltcalc -s < fifo/il_S2_eltcalc_P4 > work/kat/il_S2_eltcalc_P4 & pid22=$!
+summarycalctocsv -s < fifo/il_S2_summarycalc_P4 > work/kat/il_S2_summarycalc_P4 & pid23=$!
+pltcalc -s < fifo/il_S2_pltcalc_P4 > work/kat/il_S2_pltcalc_P4 & pid24=$!
+eltcalc -s < fifo/il_S1_eltcalc_P5 > work/kat/il_S1_eltcalc_P5 & pid25=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P5 > work/kat/il_S1_summarycalc_P5 & pid26=$!
+pltcalc -s < fifo/il_S1_pltcalc_P5 > work/kat/il_S1_pltcalc_P5 & pid27=$!
+eltcalc -s < fifo/il_S2_eltcalc_P5 > work/kat/il_S2_eltcalc_P5 & pid28=$!
+summarycalctocsv -s < fifo/il_S2_summarycalc_P5 > work/kat/il_S2_summarycalc_P5 & pid29=$!
+pltcalc -s < fifo/il_S2_pltcalc_P5 > work/kat/il_S2_pltcalc_P5 & pid30=$!
+eltcalc -s < fifo/il_S1_eltcalc_P6 > work/kat/il_S1_eltcalc_P6 & pid31=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P6 > work/kat/il_S1_summarycalc_P6 & pid32=$!
+pltcalc -s < fifo/il_S1_pltcalc_P6 > work/kat/il_S1_pltcalc_P6 & pid33=$!
+eltcalc -s < fifo/il_S2_eltcalc_P6 > work/kat/il_S2_eltcalc_P6 & pid34=$!
+summarycalctocsv -s < fifo/il_S2_summarycalc_P6 > work/kat/il_S2_summarycalc_P6 & pid35=$!
+pltcalc -s < fifo/il_S2_pltcalc_P6 > work/kat/il_S2_pltcalc_P6 & pid36=$!
+
+tee < fifo/il_S1_summary_P1 fifo/il_S1_eltcalc_P1 fifo/il_S1_summarycalc_P1 fifo/il_S1_pltcalc_P1 work/il_S1_summaryaalcalc/P1.bin work/il_S1_summaryleccalc/P1.bin > /dev/null & pid37=$!
+tee < fifo/il_S2_summary_P1 fifo/il_S2_eltcalc_P1 fifo/il_S2_summarycalc_P1 fifo/il_S2_pltcalc_P1 work/il_S2_summaryaalcalc/P1.bin work/il_S2_summaryleccalc/P1.bin > /dev/null & pid38=$!
+tee < fifo/il_S1_summary_P2 fifo/il_S1_eltcalc_P2 fifo/il_S1_summarycalc_P2 fifo/il_S1_pltcalc_P2 work/il_S1_summaryaalcalc/P2.bin work/il_S1_summaryleccalc/P2.bin > /dev/null & pid39=$!
+tee < fifo/il_S2_summary_P2 fifo/il_S2_eltcalc_P2 fifo/il_S2_summarycalc_P2 fifo/il_S2_pltcalc_P2 work/il_S2_summaryaalcalc/P2.bin work/il_S2_summaryleccalc/P2.bin > /dev/null & pid40=$!
+tee < fifo/il_S1_summary_P3 fifo/il_S1_eltcalc_P3 fifo/il_S1_summarycalc_P3 fifo/il_S1_pltcalc_P3 work/il_S1_summaryaalcalc/P3.bin work/il_S1_summaryleccalc/P3.bin > /dev/null & pid41=$!
+tee < fifo/il_S2_summary_P3 fifo/il_S2_eltcalc_P3 fifo/il_S2_summarycalc_P3 fifo/il_S2_pltcalc_P3 work/il_S2_summaryaalcalc/P3.bin work/il_S2_summaryleccalc/P3.bin > /dev/null & pid42=$!
+tee < fifo/il_S1_summary_P4 fifo/il_S1_eltcalc_P4 fifo/il_S1_summarycalc_P4 fifo/il_S1_pltcalc_P4 work/il_S1_summaryaalcalc/P4.bin work/il_S1_summaryleccalc/P4.bin > /dev/null & pid43=$!
+tee < fifo/il_S2_summary_P4 fifo/il_S2_eltcalc_P4 fifo/il_S2_summarycalc_P4 fifo/il_S2_pltcalc_P4 work/il_S2_summaryaalcalc/P4.bin work/il_S2_summaryleccalc/P4.bin > /dev/null & pid44=$!
+tee < fifo/il_S1_summary_P5 fifo/il_S1_eltcalc_P5 fifo/il_S1_summarycalc_P5 fifo/il_S1_pltcalc_P5 work/il_S1_summaryaalcalc/P5.bin work/il_S1_summaryleccalc/P5.bin > /dev/null & pid45=$!
+tee < fifo/il_S2_summary_P5 fifo/il_S2_eltcalc_P5 fifo/il_S2_summarycalc_P5 fifo/il_S2_pltcalc_P5 work/il_S2_summaryaalcalc/P5.bin work/il_S2_summaryleccalc/P5.bin > /dev/null & pid46=$!
+tee < fifo/il_S1_summary_P6 fifo/il_S1_eltcalc_P6 fifo/il_S1_summarycalc_P6 fifo/il_S1_pltcalc_P6 work/il_S1_summaryaalcalc/P6.bin work/il_S1_summaryleccalc/P6.bin > /dev/null & pid47=$!
+tee < fifo/il_S2_summary_P6 fifo/il_S2_eltcalc_P6 fifo/il_S2_summarycalc_P6 fifo/il_S2_pltcalc_P6 work/il_S2_summaryaalcalc/P6.bin work/il_S2_summaryleccalc/P6.bin > /dev/null & pid48=$!
+
+summarycalc -f  -1 fifo/il_S1_summary_P1 -2 fifo/il_S2_summary_P1 < fifo/il_P1 &
+summarycalc -f  -1 fifo/il_S1_summary_P2 -2 fifo/il_S2_summary_P2 < fifo/il_P2 &
+summarycalc -f  -1 fifo/il_S1_summary_P3 -2 fifo/il_S2_summary_P3 < fifo/il_P3 &
+summarycalc -f  -1 fifo/il_S1_summary_P4 -2 fifo/il_S2_summary_P4 < fifo/il_P4 &
+summarycalc -f  -1 fifo/il_S1_summary_P5 -2 fifo/il_S2_summary_P5 < fifo/il_P5 &
+summarycalc -f  -1 fifo/il_S1_summary_P6 -2 fifo/il_S2_summary_P6 < fifo/il_P6 &
+
+# --- Do ground up loss computes ---
+
+eltcalc < fifo/gul_S1_eltcalc_P1 > work/kat/gul_S1_eltcalc_P1 & pid49=$!
+summarycalctocsv < fifo/gul_S1_summarycalc_P1 > work/kat/gul_S1_summarycalc_P1 & pid50=$!
+pltcalc < fifo/gul_S1_pltcalc_P1 > work/kat/gul_S1_pltcalc_P1 & pid51=$!
+eltcalc < fifo/gul_S2_eltcalc_P1 > work/kat/gul_S2_eltcalc_P1 & pid52=$!
+summarycalctocsv < fifo/gul_S2_summarycalc_P1 > work/kat/gul_S2_summarycalc_P1 & pid53=$!
+pltcalc < fifo/gul_S2_pltcalc_P1 > work/kat/gul_S2_pltcalc_P1 & pid54=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P2 > work/kat/gul_S1_eltcalc_P2 & pid55=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P2 > work/kat/gul_S1_summarycalc_P2 & pid56=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P2 > work/kat/gul_S1_pltcalc_P2 & pid57=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P2 > work/kat/gul_S2_eltcalc_P2 & pid58=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P2 > work/kat/gul_S2_summarycalc_P2 & pid59=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P2 > work/kat/gul_S2_pltcalc_P2 & pid60=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P3 > work/kat/gul_S1_eltcalc_P3 & pid61=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P3 > work/kat/gul_S1_summarycalc_P3 & pid62=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P3 > work/kat/gul_S1_pltcalc_P3 & pid63=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P3 > work/kat/gul_S2_eltcalc_P3 & pid64=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P3 > work/kat/gul_S2_summarycalc_P3 & pid65=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P3 > work/kat/gul_S2_pltcalc_P3 & pid66=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P4 > work/kat/gul_S1_eltcalc_P4 & pid67=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P4 > work/kat/gul_S1_summarycalc_P4 & pid68=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P4 > work/kat/gul_S1_pltcalc_P4 & pid69=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P4 > work/kat/gul_S2_eltcalc_P4 & pid70=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P4 > work/kat/gul_S2_summarycalc_P4 & pid71=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P4 > work/kat/gul_S2_pltcalc_P4 & pid72=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P5 > work/kat/gul_S1_eltcalc_P5 & pid73=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P5 > work/kat/gul_S1_summarycalc_P5 & pid74=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P5 > work/kat/gul_S1_pltcalc_P5 & pid75=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P5 > work/kat/gul_S2_eltcalc_P5 & pid76=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P5 > work/kat/gul_S2_summarycalc_P5 & pid77=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P5 > work/kat/gul_S2_pltcalc_P5 & pid78=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P6 > work/kat/gul_S1_eltcalc_P6 & pid79=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P6 > work/kat/gul_S1_summarycalc_P6 & pid80=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P6 > work/kat/gul_S1_pltcalc_P6 & pid81=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P6 > work/kat/gul_S2_eltcalc_P6 & pid82=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P6 > work/kat/gul_S2_summarycalc_P6 & pid83=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P6 > work/kat/gul_S2_pltcalc_P6 & pid84=$!
+
+tee < fifo/gul_S1_summary_P1 fifo/gul_S1_eltcalc_P1 fifo/gul_S1_summarycalc_P1 fifo/gul_S1_pltcalc_P1 work/gul_S1_summaryaalcalc/P1.bin work/gul_S1_summaryleccalc/P1.bin > /dev/null & pid85=$!
+tee < fifo/gul_S2_summary_P1 fifo/gul_S2_eltcalc_P1 fifo/gul_S2_summarycalc_P1 fifo/gul_S2_pltcalc_P1 work/gul_S2_summaryaalcalc/P1.bin work/gul_S2_summaryleccalc/P1.bin > /dev/null & pid86=$!
+tee < fifo/gul_S1_summary_P2 fifo/gul_S1_eltcalc_P2 fifo/gul_S1_summarycalc_P2 fifo/gul_S1_pltcalc_P2 work/gul_S1_summaryaalcalc/P2.bin work/gul_S1_summaryleccalc/P2.bin > /dev/null & pid87=$!
+tee < fifo/gul_S2_summary_P2 fifo/gul_S2_eltcalc_P2 fifo/gul_S2_summarycalc_P2 fifo/gul_S2_pltcalc_P2 work/gul_S2_summaryaalcalc/P2.bin work/gul_S2_summaryleccalc/P2.bin > /dev/null & pid88=$!
+tee < fifo/gul_S1_summary_P3 fifo/gul_S1_eltcalc_P3 fifo/gul_S1_summarycalc_P3 fifo/gul_S1_pltcalc_P3 work/gul_S1_summaryaalcalc/P3.bin work/gul_S1_summaryleccalc/P3.bin > /dev/null & pid89=$!
+tee < fifo/gul_S2_summary_P3 fifo/gul_S2_eltcalc_P3 fifo/gul_S2_summarycalc_P3 fifo/gul_S2_pltcalc_P3 work/gul_S2_summaryaalcalc/P3.bin work/gul_S2_summaryleccalc/P3.bin > /dev/null & pid90=$!
+tee < fifo/gul_S1_summary_P4 fifo/gul_S1_eltcalc_P4 fifo/gul_S1_summarycalc_P4 fifo/gul_S1_pltcalc_P4 work/gul_S1_summaryaalcalc/P4.bin work/gul_S1_summaryleccalc/P4.bin > /dev/null & pid91=$!
+tee < fifo/gul_S2_summary_P4 fifo/gul_S2_eltcalc_P4 fifo/gul_S2_summarycalc_P4 fifo/gul_S2_pltcalc_P4 work/gul_S2_summaryaalcalc/P4.bin work/gul_S2_summaryleccalc/P4.bin > /dev/null & pid92=$!
+tee < fifo/gul_S1_summary_P5 fifo/gul_S1_eltcalc_P5 fifo/gul_S1_summarycalc_P5 fifo/gul_S1_pltcalc_P5 work/gul_S1_summaryaalcalc/P5.bin work/gul_S1_summaryleccalc/P5.bin > /dev/null & pid93=$!
+tee < fifo/gul_S2_summary_P5 fifo/gul_S2_eltcalc_P5 fifo/gul_S2_summarycalc_P5 fifo/gul_S2_pltcalc_P5 work/gul_S2_summaryaalcalc/P5.bin work/gul_S2_summaryleccalc/P5.bin > /dev/null & pid94=$!
+tee < fifo/gul_S1_summary_P6 fifo/gul_S1_eltcalc_P6 fifo/gul_S1_summarycalc_P6 fifo/gul_S1_pltcalc_P6 work/gul_S1_summaryaalcalc/P6.bin work/gul_S1_summaryleccalc/P6.bin > /dev/null & pid95=$!
+tee < fifo/gul_S2_summary_P6 fifo/gul_S2_eltcalc_P6 fifo/gul_S2_summarycalc_P6 fifo/gul_S2_pltcalc_P6 work/gul_S2_summaryaalcalc/P6.bin work/gul_S2_summaryleccalc/P6.bin > /dev/null & pid96=$!
+
+summarycalc -i  -1 fifo/gul_S1_summary_P1 -2 fifo/gul_S2_summary_P1 < fifo/gul_P1 &
+summarycalc -i  -1 fifo/gul_S1_summary_P2 -2 fifo/gul_S2_summary_P2 < fifo/gul_P2 &
+summarycalc -i  -1 fifo/gul_S1_summary_P3 -2 fifo/gul_S2_summary_P3 < fifo/gul_P3 &
+summarycalc -i  -1 fifo/gul_S1_summary_P4 -2 fifo/gul_S2_summary_P4 < fifo/gul_P4 &
+summarycalc -i  -1 fifo/gul_S1_summary_P5 -2 fifo/gul_S2_summary_P5 < fifo/gul_P5 &
+summarycalc -i  -1 fifo/gul_S1_summary_P6 -2 fifo/gul_S2_summary_P6 < fifo/gul_P6 &
+
+eve 1 6 | getmodel | gulcalc -S0 -L0 -r -a0 -i - | tee fifo/gul_P1 > fifo/gul_lb_P1  &
+eve 2 6 | getmodel | gulcalc -S0 -L0 -r -a0 -i - | tee fifo/gul_P2 > fifo/gul_lb_P2  &
+eve 3 6 | getmodel | gulcalc -S0 -L0 -r -a0 -i - | tee fifo/gul_P3 > fifo/gul_lb_P3  &
+eve 4 6 | getmodel | gulcalc -S0 -L0 -r -a0 -i - | tee fifo/gul_P4 > fifo/gul_lb_P4  &
+eve 5 6 | getmodel | gulcalc -S0 -L0 -r -a0 -i - | tee fifo/gul_P5 > fifo/gul_lb_P5  &
+eve 6 6 | getmodel | gulcalc -S0 -L0 -r -a0 -i - | tee fifo/gul_P6 > fifo/gul_lb_P6  &
+load_balancer -i fifo/gul_lb_P1 fifo/gul_lb_P2 -o fifo/lb_il_P1 fifo/lb_il_P2 &
+load_balancer -i fifo/gul_lb_P3 fifo/gul_lb_P4 -o fifo/lb_il_P3 fifo/lb_il_P4 &
+load_balancer -i fifo/gul_lb_P5 fifo/gul_lb_P6 -o fifo/lb_il_P5 fifo/lb_il_P6 &
+fmpy -a2 < fifo/lb_il_P1 > fifo/il_P1 &
+fmpy -a2 < fifo/lb_il_P2 > fifo/il_P2 &
+fmpy -a2 < fifo/lb_il_P3 > fifo/il_P3 &
+fmpy -a2 < fifo/lb_il_P4 > fifo/il_P4 &
+fmpy -a2 < fifo/lb_il_P5 > fifo/il_P5 &
+fmpy -a2 < fifo/lb_il_P6 > fifo/il_P6 &
+
+wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 $pid13 $pid14 $pid15 $pid16 $pid17 $pid18 $pid19 $pid20 $pid21 $pid22 $pid23 $pid24 $pid25 $pid26 $pid27 $pid28 $pid29 $pid30 $pid31 $pid32 $pid33 $pid34 $pid35 $pid36 $pid37 $pid38 $pid39 $pid40 $pid41 $pid42 $pid43 $pid44 $pid45 $pid46 $pid47 $pid48 $pid49 $pid50 $pid51 $pid52 $pid53 $pid54 $pid55 $pid56 $pid57 $pid58 $pid59 $pid60 $pid61 $pid62 $pid63 $pid64 $pid65 $pid66 $pid67 $pid68 $pid69 $pid70 $pid71 $pid72 $pid73 $pid74 $pid75 $pid76 $pid77 $pid78 $pid79 $pid80 $pid81 $pid82 $pid83 $pid84 $pid85 $pid86 $pid87 $pid88 $pid89 $pid90 $pid91 $pid92 $pid93 $pid94 $pid95 $pid96
+
+
+# --- Do insured loss kats ---
+
+kat -s work/kat/il_S1_eltcalc_P1 work/kat/il_S1_eltcalc_P2 work/kat/il_S1_eltcalc_P3 work/kat/il_S1_eltcalc_P4 work/kat/il_S1_eltcalc_P5 work/kat/il_S1_eltcalc_P6 > output/il_S1_eltcalc.csv & kpid1=$!
+kat work/kat/il_S1_pltcalc_P1 work/kat/il_S1_pltcalc_P2 work/kat/il_S1_pltcalc_P3 work/kat/il_S1_pltcalc_P4 work/kat/il_S1_pltcalc_P5 work/kat/il_S1_pltcalc_P6 > output/il_S1_pltcalc.csv & kpid2=$!
+kat work/kat/il_S1_summarycalc_P1 work/kat/il_S1_summarycalc_P2 work/kat/il_S1_summarycalc_P3 work/kat/il_S1_summarycalc_P4 work/kat/il_S1_summarycalc_P5 work/kat/il_S1_summarycalc_P6 > output/il_S1_summarycalc.csv & kpid3=$!
+kat -s work/kat/il_S2_eltcalc_P1 work/kat/il_S2_eltcalc_P2 work/kat/il_S2_eltcalc_P3 work/kat/il_S2_eltcalc_P4 work/kat/il_S2_eltcalc_P5 work/kat/il_S2_eltcalc_P6 > output/il_S2_eltcalc.csv & kpid4=$!
+kat work/kat/il_S2_pltcalc_P1 work/kat/il_S2_pltcalc_P2 work/kat/il_S2_pltcalc_P3 work/kat/il_S2_pltcalc_P4 work/kat/il_S2_pltcalc_P5 work/kat/il_S2_pltcalc_P6 > output/il_S2_pltcalc.csv & kpid5=$!
+kat work/kat/il_S2_summarycalc_P1 work/kat/il_S2_summarycalc_P2 work/kat/il_S2_summarycalc_P3 work/kat/il_S2_summarycalc_P4 work/kat/il_S2_summarycalc_P5 work/kat/il_S2_summarycalc_P6 > output/il_S2_summarycalc.csv & kpid6=$!
+
+# --- Do ground up loss kats ---
+
+kat -s work/kat/gul_S1_eltcalc_P1 work/kat/gul_S1_eltcalc_P2 work/kat/gul_S1_eltcalc_P3 work/kat/gul_S1_eltcalc_P4 work/kat/gul_S1_eltcalc_P5 work/kat/gul_S1_eltcalc_P6 > output/gul_S1_eltcalc.csv & kpid7=$!
+kat work/kat/gul_S1_pltcalc_P1 work/kat/gul_S1_pltcalc_P2 work/kat/gul_S1_pltcalc_P3 work/kat/gul_S1_pltcalc_P4 work/kat/gul_S1_pltcalc_P5 work/kat/gul_S1_pltcalc_P6 > output/gul_S1_pltcalc.csv & kpid8=$!
+kat work/kat/gul_S1_summarycalc_P1 work/kat/gul_S1_summarycalc_P2 work/kat/gul_S1_summarycalc_P3 work/kat/gul_S1_summarycalc_P4 work/kat/gul_S1_summarycalc_P5 work/kat/gul_S1_summarycalc_P6 > output/gul_S1_summarycalc.csv & kpid9=$!
+kat -s work/kat/gul_S2_eltcalc_P1 work/kat/gul_S2_eltcalc_P2 work/kat/gul_S2_eltcalc_P3 work/kat/gul_S2_eltcalc_P4 work/kat/gul_S2_eltcalc_P5 work/kat/gul_S2_eltcalc_P6 > output/gul_S2_eltcalc.csv & kpid10=$!
+kat work/kat/gul_S2_pltcalc_P1 work/kat/gul_S2_pltcalc_P2 work/kat/gul_S2_pltcalc_P3 work/kat/gul_S2_pltcalc_P4 work/kat/gul_S2_pltcalc_P5 work/kat/gul_S2_pltcalc_P6 > output/gul_S2_pltcalc.csv & kpid11=$!
+kat work/kat/gul_S2_summarycalc_P1 work/kat/gul_S2_summarycalc_P2 work/kat/gul_S2_summarycalc_P3 work/kat/gul_S2_summarycalc_P4 work/kat/gul_S2_summarycalc_P5 work/kat/gul_S2_summarycalc_P6 > output/gul_S2_summarycalc.csv & kpid12=$!
+wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpid11 $kpid12
+
+
+aalcalc -Kil_S1_summaryaalcalc > output/il_S1_aalcalc.csv & lpid1=$!
+ordleccalc -r -Kil_S1_summaryleccalc -F -S -s -M -m -W -w -O output/il_S1_ept.csv -o output/il_S1_psept.csv & lpid2=$!
+aalcalc -Kil_S2_summaryaalcalc > output/il_S2_aalcalc.csv & lpid3=$!
+ordleccalc -r -Kil_S2_summaryleccalc -F -S -s -M -m -W -w -O output/il_S2_ept.csv -o output/il_S2_psept.csv & lpid4=$!
+aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv & lpid5=$!
+ordleccalc -r -Kgul_S1_summaryleccalc -F -S -s -M -m -W -w -O output/gul_S1_ept.csv -o output/gul_S1_psept.csv & lpid6=$!
+aalcalc -Kgul_S2_summaryaalcalc > output/gul_S2_aalcalc.csv & lpid7=$!
+ordleccalc -r -Kgul_S2_summaryleccalc -F -S -s -M -m -W -w -O output/gul_S2_ept.csv -o output/gul_S2_psept.csv & lpid8=$!
+wait $lpid1 $lpid2 $lpid3 $lpid4 $lpid5 $lpid6 $lpid7 $lpid8
+
+rm -R -f work/*
+rm -R -f fifo/*

--- a/tests/model_execution/lb_kparse_reference/gul_il_ord_psept_lec_1_output_10_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_il_ord_psept_lec_1_output_10_partition.sh
@@ -1,0 +1,227 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+
+rm -R -f fifo/*
+rm -R -f work/*
+mkdir work/kat/
+
+fmpy -a2 --create-financial-structure-files
+mkdir work/gul_S1_summaryleccalc
+mkdir work/gul_S1_summaryaalcalc
+mkdir work/il_S1_summaryleccalc
+mkdir work/il_S1_summaryaalcalc
+
+mkfifo fifo/gul_P1
+mkfifo fifo/gul_P2
+mkfifo fifo/gul_P3
+mkfifo fifo/gul_P4
+mkfifo fifo/gul_P5
+mkfifo fifo/gul_P6
+
+mkfifo fifo/gul_S1_summary_P1
+mkfifo fifo/gul_S1_eltcalc_P1
+mkfifo fifo/gul_S1_summarycalc_P1
+mkfifo fifo/gul_S1_pltcalc_P1
+
+mkfifo fifo/gul_S1_summary_P2
+mkfifo fifo/gul_S1_eltcalc_P2
+mkfifo fifo/gul_S1_summarycalc_P2
+mkfifo fifo/gul_S1_pltcalc_P2
+
+mkfifo fifo/gul_S1_summary_P3
+mkfifo fifo/gul_S1_eltcalc_P3
+mkfifo fifo/gul_S1_summarycalc_P3
+mkfifo fifo/gul_S1_pltcalc_P3
+
+mkfifo fifo/gul_S1_summary_P4
+mkfifo fifo/gul_S1_eltcalc_P4
+mkfifo fifo/gul_S1_summarycalc_P4
+mkfifo fifo/gul_S1_pltcalc_P4
+
+mkfifo fifo/gul_S1_summary_P5
+mkfifo fifo/gul_S1_eltcalc_P5
+mkfifo fifo/gul_S1_summarycalc_P5
+mkfifo fifo/gul_S1_pltcalc_P5
+
+mkfifo fifo/gul_S1_summary_P6
+mkfifo fifo/gul_S1_eltcalc_P6
+mkfifo fifo/gul_S1_summarycalc_P6
+mkfifo fifo/gul_S1_pltcalc_P6
+
+mkfifo fifo/il_P1
+mkfifo fifo/il_P2
+mkfifo fifo/il_P3
+mkfifo fifo/il_P4
+mkfifo fifo/il_P5
+mkfifo fifo/il_P6
+
+mkfifo fifo/il_S1_summary_P1
+mkfifo fifo/il_S1_eltcalc_P1
+mkfifo fifo/il_S1_summarycalc_P1
+mkfifo fifo/il_S1_pltcalc_P1
+
+mkfifo fifo/il_S1_summary_P2
+mkfifo fifo/il_S1_eltcalc_P2
+mkfifo fifo/il_S1_summarycalc_P2
+mkfifo fifo/il_S1_pltcalc_P2
+
+mkfifo fifo/il_S1_summary_P3
+mkfifo fifo/il_S1_eltcalc_P3
+mkfifo fifo/il_S1_summarycalc_P3
+mkfifo fifo/il_S1_pltcalc_P3
+
+mkfifo fifo/il_S1_summary_P4
+mkfifo fifo/il_S1_eltcalc_P4
+mkfifo fifo/il_S1_summarycalc_P4
+mkfifo fifo/il_S1_pltcalc_P4
+
+mkfifo fifo/il_S1_summary_P5
+mkfifo fifo/il_S1_eltcalc_P5
+mkfifo fifo/il_S1_summarycalc_P5
+mkfifo fifo/il_S1_pltcalc_P5
+
+mkfifo fifo/il_S1_summary_P6
+mkfifo fifo/il_S1_eltcalc_P6
+mkfifo fifo/il_S1_summarycalc_P6
+mkfifo fifo/il_S1_pltcalc_P6
+
+mkfifo fifo/gul_lb_P1
+mkfifo fifo/gul_lb_P2
+mkfifo fifo/gul_lb_P3
+mkfifo fifo/gul_lb_P4
+mkfifo fifo/gul_lb_P5
+mkfifo fifo/gul_lb_P6
+
+mkfifo fifo/lb_il_P1
+mkfifo fifo/lb_il_P2
+mkfifo fifo/lb_il_P3
+mkfifo fifo/lb_il_P4
+mkfifo fifo/lb_il_P5
+mkfifo fifo/lb_il_P6
+
+
+
+# --- Do insured loss computes ---
+
+eltcalc < fifo/il_S1_eltcalc_P1 > work/kat/il_S1_eltcalc_P1 & pid1=$!
+summarycalctocsv < fifo/il_S1_summarycalc_P1 > work/kat/il_S1_summarycalc_P1 & pid2=$!
+pltcalc < fifo/il_S1_pltcalc_P1 > work/kat/il_S1_pltcalc_P1 & pid3=$!
+eltcalc -s < fifo/il_S1_eltcalc_P2 > work/kat/il_S1_eltcalc_P2 & pid4=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P2 > work/kat/il_S1_summarycalc_P2 & pid5=$!
+pltcalc -s < fifo/il_S1_pltcalc_P2 > work/kat/il_S1_pltcalc_P2 & pid6=$!
+eltcalc -s < fifo/il_S1_eltcalc_P3 > work/kat/il_S1_eltcalc_P3 & pid7=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P3 > work/kat/il_S1_summarycalc_P3 & pid8=$!
+pltcalc -s < fifo/il_S1_pltcalc_P3 > work/kat/il_S1_pltcalc_P3 & pid9=$!
+eltcalc -s < fifo/il_S1_eltcalc_P4 > work/kat/il_S1_eltcalc_P4 & pid10=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P4 > work/kat/il_S1_summarycalc_P4 & pid11=$!
+pltcalc -s < fifo/il_S1_pltcalc_P4 > work/kat/il_S1_pltcalc_P4 & pid12=$!
+eltcalc -s < fifo/il_S1_eltcalc_P5 > work/kat/il_S1_eltcalc_P5 & pid13=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P5 > work/kat/il_S1_summarycalc_P5 & pid14=$!
+pltcalc -s < fifo/il_S1_pltcalc_P5 > work/kat/il_S1_pltcalc_P5 & pid15=$!
+eltcalc -s < fifo/il_S1_eltcalc_P6 > work/kat/il_S1_eltcalc_P6 & pid16=$!
+summarycalctocsv -s < fifo/il_S1_summarycalc_P6 > work/kat/il_S1_summarycalc_P6 & pid17=$!
+pltcalc -s < fifo/il_S1_pltcalc_P6 > work/kat/il_S1_pltcalc_P6 & pid18=$!
+
+tee < fifo/il_S1_summary_P1 fifo/il_S1_eltcalc_P1 fifo/il_S1_summarycalc_P1 fifo/il_S1_pltcalc_P1 work/il_S1_summaryaalcalc/P1.bin work/il_S1_summaryleccalc/P1.bin > /dev/null & pid19=$!
+tee < fifo/il_S1_summary_P2 fifo/il_S1_eltcalc_P2 fifo/il_S1_summarycalc_P2 fifo/il_S1_pltcalc_P2 work/il_S1_summaryaalcalc/P2.bin work/il_S1_summaryleccalc/P2.bin > /dev/null & pid20=$!
+tee < fifo/il_S1_summary_P3 fifo/il_S1_eltcalc_P3 fifo/il_S1_summarycalc_P3 fifo/il_S1_pltcalc_P3 work/il_S1_summaryaalcalc/P3.bin work/il_S1_summaryleccalc/P3.bin > /dev/null & pid21=$!
+tee < fifo/il_S1_summary_P4 fifo/il_S1_eltcalc_P4 fifo/il_S1_summarycalc_P4 fifo/il_S1_pltcalc_P4 work/il_S1_summaryaalcalc/P4.bin work/il_S1_summaryleccalc/P4.bin > /dev/null & pid22=$!
+tee < fifo/il_S1_summary_P5 fifo/il_S1_eltcalc_P5 fifo/il_S1_summarycalc_P5 fifo/il_S1_pltcalc_P5 work/il_S1_summaryaalcalc/P5.bin work/il_S1_summaryleccalc/P5.bin > /dev/null & pid23=$!
+tee < fifo/il_S1_summary_P6 fifo/il_S1_eltcalc_P6 fifo/il_S1_summarycalc_P6 fifo/il_S1_pltcalc_P6 work/il_S1_summaryaalcalc/P6.bin work/il_S1_summaryleccalc/P6.bin > /dev/null & pid24=$!
+
+summarycalc -f  -1 fifo/il_S1_summary_P1 < fifo/il_P1 &
+summarycalc -f  -1 fifo/il_S1_summary_P2 < fifo/il_P2 &
+summarycalc -f  -1 fifo/il_S1_summary_P3 < fifo/il_P3 &
+summarycalc -f  -1 fifo/il_S1_summary_P4 < fifo/il_P4 &
+summarycalc -f  -1 fifo/il_S1_summary_P5 < fifo/il_P5 &
+summarycalc -f  -1 fifo/il_S1_summary_P6 < fifo/il_P6 &
+
+# --- Do ground up loss computes ---
+
+eltcalc < fifo/gul_S1_eltcalc_P1 > work/kat/gul_S1_eltcalc_P1 & pid25=$!
+summarycalctocsv < fifo/gul_S1_summarycalc_P1 > work/kat/gul_S1_summarycalc_P1 & pid26=$!
+pltcalc < fifo/gul_S1_pltcalc_P1 > work/kat/gul_S1_pltcalc_P1 & pid27=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P2 > work/kat/gul_S1_eltcalc_P2 & pid28=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P2 > work/kat/gul_S1_summarycalc_P2 & pid29=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P2 > work/kat/gul_S1_pltcalc_P2 & pid30=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P3 > work/kat/gul_S1_eltcalc_P3 & pid31=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P3 > work/kat/gul_S1_summarycalc_P3 & pid32=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P3 > work/kat/gul_S1_pltcalc_P3 & pid33=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P4 > work/kat/gul_S1_eltcalc_P4 & pid34=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P4 > work/kat/gul_S1_summarycalc_P4 & pid35=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P4 > work/kat/gul_S1_pltcalc_P4 & pid36=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P5 > work/kat/gul_S1_eltcalc_P5 & pid37=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P5 > work/kat/gul_S1_summarycalc_P5 & pid38=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P5 > work/kat/gul_S1_pltcalc_P5 & pid39=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P6 > work/kat/gul_S1_eltcalc_P6 & pid40=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P6 > work/kat/gul_S1_summarycalc_P6 & pid41=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P6 > work/kat/gul_S1_pltcalc_P6 & pid42=$!
+
+tee < fifo/gul_S1_summary_P1 fifo/gul_S1_eltcalc_P1 fifo/gul_S1_summarycalc_P1 fifo/gul_S1_pltcalc_P1 work/gul_S1_summaryaalcalc/P1.bin work/gul_S1_summaryleccalc/P1.bin > /dev/null & pid43=$!
+tee < fifo/gul_S1_summary_P2 fifo/gul_S1_eltcalc_P2 fifo/gul_S1_summarycalc_P2 fifo/gul_S1_pltcalc_P2 work/gul_S1_summaryaalcalc/P2.bin work/gul_S1_summaryleccalc/P2.bin > /dev/null & pid44=$!
+tee < fifo/gul_S1_summary_P3 fifo/gul_S1_eltcalc_P3 fifo/gul_S1_summarycalc_P3 fifo/gul_S1_pltcalc_P3 work/gul_S1_summaryaalcalc/P3.bin work/gul_S1_summaryleccalc/P3.bin > /dev/null & pid45=$!
+tee < fifo/gul_S1_summary_P4 fifo/gul_S1_eltcalc_P4 fifo/gul_S1_summarycalc_P4 fifo/gul_S1_pltcalc_P4 work/gul_S1_summaryaalcalc/P4.bin work/gul_S1_summaryleccalc/P4.bin > /dev/null & pid46=$!
+tee < fifo/gul_S1_summary_P5 fifo/gul_S1_eltcalc_P5 fifo/gul_S1_summarycalc_P5 fifo/gul_S1_pltcalc_P5 work/gul_S1_summaryaalcalc/P5.bin work/gul_S1_summaryleccalc/P5.bin > /dev/null & pid47=$!
+tee < fifo/gul_S1_summary_P6 fifo/gul_S1_eltcalc_P6 fifo/gul_S1_summarycalc_P6 fifo/gul_S1_pltcalc_P6 work/gul_S1_summaryaalcalc/P6.bin work/gul_S1_summaryleccalc/P6.bin > /dev/null & pid48=$!
+
+summarycalc -i  -1 fifo/gul_S1_summary_P1 < fifo/gul_P1 &
+summarycalc -i  -1 fifo/gul_S1_summary_P2 < fifo/gul_P2 &
+summarycalc -i  -1 fifo/gul_S1_summary_P3 < fifo/gul_P3 &
+summarycalc -i  -1 fifo/gul_S1_summary_P4 < fifo/gul_P4 &
+summarycalc -i  -1 fifo/gul_S1_summary_P5 < fifo/gul_P5 &
+summarycalc -i  -1 fifo/gul_S1_summary_P6 < fifo/gul_P6 &
+
+eve 1 6 | getmodel | gulcalc -S0 -L0 -r -a0 -i - | tee fifo/gul_P1 > fifo/gul_lb_P1  &
+eve 2 6 | getmodel | gulcalc -S0 -L0 -r -a0 -i - | tee fifo/gul_P2 > fifo/gul_lb_P2  &
+eve 3 6 | getmodel | gulcalc -S0 -L0 -r -a0 -i - | tee fifo/gul_P3 > fifo/gul_lb_P3  &
+eve 4 6 | getmodel | gulcalc -S0 -L0 -r -a0 -i - | tee fifo/gul_P4 > fifo/gul_lb_P4  &
+eve 5 6 | getmodel | gulcalc -S0 -L0 -r -a0 -i - | tee fifo/gul_P5 > fifo/gul_lb_P5  &
+eve 6 6 | getmodel | gulcalc -S0 -L0 -r -a0 -i - | tee fifo/gul_P6 > fifo/gul_lb_P6  &
+load_balancer -i fifo/gul_lb_P1 fifo/gul_lb_P2 -o fifo/lb_il_P1 fifo/lb_il_P2 &
+load_balancer -i fifo/gul_lb_P3 fifo/gul_lb_P4 -o fifo/lb_il_P3 fifo/lb_il_P4 &
+load_balancer -i fifo/gul_lb_P5 fifo/gul_lb_P6 -o fifo/lb_il_P5 fifo/lb_il_P6 &
+fmpy -a2 < fifo/lb_il_P1 > fifo/il_P1 &
+fmpy -a2 < fifo/lb_il_P2 > fifo/il_P2 &
+fmpy -a2 < fifo/lb_il_P3 > fifo/il_P3 &
+fmpy -a2 < fifo/lb_il_P4 > fifo/il_P4 &
+fmpy -a2 < fifo/lb_il_P5 > fifo/il_P5 &
+fmpy -a2 < fifo/lb_il_P6 > fifo/il_P6 &
+
+wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 $pid13 $pid14 $pid15 $pid16 $pid17 $pid18 $pid19 $pid20 $pid21 $pid22 $pid23 $pid24 $pid25 $pid26 $pid27 $pid28 $pid29 $pid30 $pid31 $pid32 $pid33 $pid34 $pid35 $pid36 $pid37 $pid38 $pid39 $pid40 $pid41 $pid42 $pid43 $pid44 $pid45 $pid46 $pid47 $pid48
+
+
+# --- Do insured loss kats ---
+
+kat -s work/kat/il_S1_eltcalc_P1 work/kat/il_S1_eltcalc_P2 work/kat/il_S1_eltcalc_P3 work/kat/il_S1_eltcalc_P4 work/kat/il_S1_eltcalc_P5 work/kat/il_S1_eltcalc_P6 > output/il_S1_eltcalc.csv & kpid1=$!
+kat work/kat/il_S1_pltcalc_P1 work/kat/il_S1_pltcalc_P2 work/kat/il_S1_pltcalc_P3 work/kat/il_S1_pltcalc_P4 work/kat/il_S1_pltcalc_P5 work/kat/il_S1_pltcalc_P6 > output/il_S1_pltcalc.csv & kpid2=$!
+kat work/kat/il_S1_summarycalc_P1 work/kat/il_S1_summarycalc_P2 work/kat/il_S1_summarycalc_P3 work/kat/il_S1_summarycalc_P4 work/kat/il_S1_summarycalc_P5 work/kat/il_S1_summarycalc_P6 > output/il_S1_summarycalc.csv & kpid3=$!
+
+# --- Do ground up loss kats ---
+
+kat -s work/kat/gul_S1_eltcalc_P1 work/kat/gul_S1_eltcalc_P2 work/kat/gul_S1_eltcalc_P3 work/kat/gul_S1_eltcalc_P4 work/kat/gul_S1_eltcalc_P5 work/kat/gul_S1_eltcalc_P6 > output/gul_S1_eltcalc.csv & kpid4=$!
+kat work/kat/gul_S1_pltcalc_P1 work/kat/gul_S1_pltcalc_P2 work/kat/gul_S1_pltcalc_P3 work/kat/gul_S1_pltcalc_P4 work/kat/gul_S1_pltcalc_P5 work/kat/gul_S1_pltcalc_P6 > output/gul_S1_pltcalc.csv & kpid5=$!
+kat work/kat/gul_S1_summarycalc_P1 work/kat/gul_S1_summarycalc_P2 work/kat/gul_S1_summarycalc_P3 work/kat/gul_S1_summarycalc_P4 work/kat/gul_S1_summarycalc_P5 work/kat/gul_S1_summarycalc_P6 > output/gul_S1_summarycalc.csv & kpid6=$!
+wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
+
+
+aalcalc -Kil_S1_summaryaalcalc > output/il_S1_aalcalc.csv & lpid1=$!
+ordleccalc -r -Kil_S1_summaryleccalc -W -w -o output/il_S1_psept.csv & lpid2=$!
+leccalc -r -Kil_S1_summaryleccalc -F output/il_S1_leccalc_full_uncertainty_aep.csv -f output/il_S1_leccalc_full_uncertainty_oep.csv -S output/il_S1_leccalc_sample_mean_aep.csv -s output/il_S1_leccalc_sample_mean_oep.csv -W output/il_S1_leccalc_wheatsheaf_aep.csv -M output/il_S1_leccalc_wheatsheaf_mean_aep.csv -m output/il_S1_leccalc_wheatsheaf_mean_oep.csv -w output/il_S1_leccalc_wheatsheaf_oep.csv & lpid3=$!
+aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv & lpid4=$!
+ordleccalc  -Kgul_S1_summaryleccalc -W -w -o output/gul_S1_psept.csv & lpid5=$!
+leccalc -r -Kgul_S1_summaryleccalc -F output/gul_S1_leccalc_full_uncertainty_aep.csv -f output/gul_S1_leccalc_full_uncertainty_oep.csv -S output/gul_S1_leccalc_sample_mean_aep.csv -s output/gul_S1_leccalc_sample_mean_oep.csv -W output/gul_S1_leccalc_wheatsheaf_aep.csv -M output/gul_S1_leccalc_wheatsheaf_mean_aep.csv -m output/gul_S1_leccalc_wheatsheaf_mean_oep.csv -w output/gul_S1_leccalc_wheatsheaf_oep.csv & lpid6=$!
+wait $lpid1 $lpid2 $lpid3 $lpid4 $lpid5 $lpid6
+
+rm -R -f work/*
+rm -R -f fifo/*

--- a/tests/model_execution/lb_kparse_reference/gul_ord_ept_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_ord_ept_1_output_1_partition.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+
+rm -R -f fifo/*
+rm -R -f work/*
+mkdir work/kat/
+
+mkdir work/gul_S1_summaryleccalc
+
+mkfifo fifo/gul_P1
+
+mkfifo fifo/gul_S1_summary_P1
+
+
+
+# --- Do ground up loss computes ---
+
+
+tee < fifo/gul_S1_summary_P1 work/gul_S1_summaryleccalc/P1.bin > /dev/null & pid1=$!
+
+summarycalc -i  -1 fifo/gul_S1_summary_P1 < fifo/gul_P1 &
+
+eve 1 1 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P1  &
+
+wait $pid1
+
+
+# --- Do ground up loss kats ---
+
+
+ordleccalc -r -Kgul_S1_summaryleccalc -F -f -S -s -M -m -O output/gul_S1_ept.csv & lpid1=$!
+wait $lpid1
+
+rm -R -f work/*
+rm -R -f fifo/*

--- a/tests/model_execution/lb_kparse_reference/gul_ord_ept_1_output_20_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_ord_ept_1_output_20_partition.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+
+rm -R -f fifo/*
+rm -R -f work/*
+mkdir work/kat/
+
+mkdir work/gul_S1_summaryleccalc
+
+mkfifo fifo/gul_P1
+mkfifo fifo/gul_P2
+mkfifo fifo/gul_P3
+mkfifo fifo/gul_P4
+mkfifo fifo/gul_P5
+mkfifo fifo/gul_P6
+mkfifo fifo/gul_P7
+mkfifo fifo/gul_P8
+mkfifo fifo/gul_P9
+mkfifo fifo/gul_P10
+mkfifo fifo/gul_P11
+mkfifo fifo/gul_P12
+mkfifo fifo/gul_P13
+mkfifo fifo/gul_P14
+mkfifo fifo/gul_P15
+mkfifo fifo/gul_P16
+mkfifo fifo/gul_P17
+mkfifo fifo/gul_P18
+mkfifo fifo/gul_P19
+mkfifo fifo/gul_P20
+
+mkfifo fifo/gul_S1_summary_P1
+
+mkfifo fifo/gul_S1_summary_P2
+
+mkfifo fifo/gul_S1_summary_P3
+
+mkfifo fifo/gul_S1_summary_P4
+
+mkfifo fifo/gul_S1_summary_P5
+
+mkfifo fifo/gul_S1_summary_P6
+
+mkfifo fifo/gul_S1_summary_P7
+
+mkfifo fifo/gul_S1_summary_P8
+
+mkfifo fifo/gul_S1_summary_P9
+
+mkfifo fifo/gul_S1_summary_P10
+
+mkfifo fifo/gul_S1_summary_P11
+
+mkfifo fifo/gul_S1_summary_P12
+
+mkfifo fifo/gul_S1_summary_P13
+
+mkfifo fifo/gul_S1_summary_P14
+
+mkfifo fifo/gul_S1_summary_P15
+
+mkfifo fifo/gul_S1_summary_P16
+
+mkfifo fifo/gul_S1_summary_P17
+
+mkfifo fifo/gul_S1_summary_P18
+
+mkfifo fifo/gul_S1_summary_P19
+
+mkfifo fifo/gul_S1_summary_P20
+
+
+
+# --- Do ground up loss computes ---
+
+
+tee < fifo/gul_S1_summary_P1 work/gul_S1_summaryleccalc/P1.bin > /dev/null & pid1=$!
+tee < fifo/gul_S1_summary_P2 work/gul_S1_summaryleccalc/P2.bin > /dev/null & pid2=$!
+tee < fifo/gul_S1_summary_P3 work/gul_S1_summaryleccalc/P3.bin > /dev/null & pid3=$!
+tee < fifo/gul_S1_summary_P4 work/gul_S1_summaryleccalc/P4.bin > /dev/null & pid4=$!
+tee < fifo/gul_S1_summary_P5 work/gul_S1_summaryleccalc/P5.bin > /dev/null & pid5=$!
+tee < fifo/gul_S1_summary_P6 work/gul_S1_summaryleccalc/P6.bin > /dev/null & pid6=$!
+tee < fifo/gul_S1_summary_P7 work/gul_S1_summaryleccalc/P7.bin > /dev/null & pid7=$!
+tee < fifo/gul_S1_summary_P8 work/gul_S1_summaryleccalc/P8.bin > /dev/null & pid8=$!
+tee < fifo/gul_S1_summary_P9 work/gul_S1_summaryleccalc/P9.bin > /dev/null & pid9=$!
+tee < fifo/gul_S1_summary_P10 work/gul_S1_summaryleccalc/P10.bin > /dev/null & pid10=$!
+tee < fifo/gul_S1_summary_P11 work/gul_S1_summaryleccalc/P11.bin > /dev/null & pid11=$!
+tee < fifo/gul_S1_summary_P12 work/gul_S1_summaryleccalc/P12.bin > /dev/null & pid12=$!
+tee < fifo/gul_S1_summary_P13 work/gul_S1_summaryleccalc/P13.bin > /dev/null & pid13=$!
+tee < fifo/gul_S1_summary_P14 work/gul_S1_summaryleccalc/P14.bin > /dev/null & pid14=$!
+tee < fifo/gul_S1_summary_P15 work/gul_S1_summaryleccalc/P15.bin > /dev/null & pid15=$!
+tee < fifo/gul_S1_summary_P16 work/gul_S1_summaryleccalc/P16.bin > /dev/null & pid16=$!
+tee < fifo/gul_S1_summary_P17 work/gul_S1_summaryleccalc/P17.bin > /dev/null & pid17=$!
+tee < fifo/gul_S1_summary_P18 work/gul_S1_summaryleccalc/P18.bin > /dev/null & pid18=$!
+tee < fifo/gul_S1_summary_P19 work/gul_S1_summaryleccalc/P19.bin > /dev/null & pid19=$!
+tee < fifo/gul_S1_summary_P20 work/gul_S1_summaryleccalc/P20.bin > /dev/null & pid20=$!
+
+summarycalc -i  -1 fifo/gul_S1_summary_P1 < fifo/gul_P1 &
+summarycalc -i  -1 fifo/gul_S1_summary_P2 < fifo/gul_P2 &
+summarycalc -i  -1 fifo/gul_S1_summary_P3 < fifo/gul_P3 &
+summarycalc -i  -1 fifo/gul_S1_summary_P4 < fifo/gul_P4 &
+summarycalc -i  -1 fifo/gul_S1_summary_P5 < fifo/gul_P5 &
+summarycalc -i  -1 fifo/gul_S1_summary_P6 < fifo/gul_P6 &
+summarycalc -i  -1 fifo/gul_S1_summary_P7 < fifo/gul_P7 &
+summarycalc -i  -1 fifo/gul_S1_summary_P8 < fifo/gul_P8 &
+summarycalc -i  -1 fifo/gul_S1_summary_P9 < fifo/gul_P9 &
+summarycalc -i  -1 fifo/gul_S1_summary_P10 < fifo/gul_P10 &
+summarycalc -i  -1 fifo/gul_S1_summary_P11 < fifo/gul_P11 &
+summarycalc -i  -1 fifo/gul_S1_summary_P12 < fifo/gul_P12 &
+summarycalc -i  -1 fifo/gul_S1_summary_P13 < fifo/gul_P13 &
+summarycalc -i  -1 fifo/gul_S1_summary_P14 < fifo/gul_P14 &
+summarycalc -i  -1 fifo/gul_S1_summary_P15 < fifo/gul_P15 &
+summarycalc -i  -1 fifo/gul_S1_summary_P16 < fifo/gul_P16 &
+summarycalc -i  -1 fifo/gul_S1_summary_P17 < fifo/gul_P17 &
+summarycalc -i  -1 fifo/gul_S1_summary_P18 < fifo/gul_P18 &
+summarycalc -i  -1 fifo/gul_S1_summary_P19 < fifo/gul_P19 &
+summarycalc -i  -1 fifo/gul_S1_summary_P20 < fifo/gul_P20 &
+
+eve 1 20 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P1  &
+eve 2 20 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P2  &
+eve 3 20 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P3  &
+eve 4 20 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P4  &
+eve 5 20 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P5  &
+eve 6 20 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P6  &
+eve 7 20 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P7  &
+eve 8 20 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P8  &
+eve 9 20 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P9  &
+eve 10 20 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P10  &
+eve 11 20 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P11  &
+eve 12 20 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P12  &
+eve 13 20 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P13  &
+eve 14 20 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P14  &
+eve 15 20 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P15  &
+eve 16 20 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P16  &
+eve 17 20 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P17  &
+eve 18 20 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P18  &
+eve 19 20 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P19  &
+eve 20 20 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P20  &
+
+wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 $pid13 $pid14 $pid15 $pid16 $pid17 $pid18 $pid19 $pid20
+
+
+# --- Do ground up loss kats ---
+
+
+ordleccalc -r -Kgul_S1_summaryleccalc -F -f -S -s -M -m -O output/gul_S1_ept.csv & lpid1=$!
+wait $lpid1
+
+rm -R -f work/*
+rm -R -f fifo/*

--- a/tests/model_execution/lb_kparse_reference/gul_ord_ept_psept_lec_2_output_10_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_ord_ept_psept_lec_2_output_10_partition.sh
@@ -1,0 +1,256 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+
+rm -R -f fifo/*
+rm -R -f work/*
+mkdir work/kat/
+
+mkdir work/gul_S1_summaryleccalc
+mkdir work/gul_S1_summaryaalcalc
+mkdir work/gul_S2_summaryleccalc
+mkdir work/gul_S2_summaryaalcalc
+
+mkfifo fifo/gul_P1
+mkfifo fifo/gul_P2
+mkfifo fifo/gul_P3
+mkfifo fifo/gul_P4
+mkfifo fifo/gul_P5
+mkfifo fifo/gul_P6
+mkfifo fifo/gul_P7
+mkfifo fifo/gul_P8
+mkfifo fifo/gul_P9
+mkfifo fifo/gul_P10
+
+mkfifo fifo/gul_S1_summary_P1
+mkfifo fifo/gul_S1_eltcalc_P1
+mkfifo fifo/gul_S1_summarycalc_P1
+mkfifo fifo/gul_S1_pltcalc_P1
+mkfifo fifo/gul_S2_summary_P1
+mkfifo fifo/gul_S2_eltcalc_P1
+mkfifo fifo/gul_S2_summarycalc_P1
+mkfifo fifo/gul_S2_pltcalc_P1
+
+mkfifo fifo/gul_S1_summary_P2
+mkfifo fifo/gul_S1_eltcalc_P2
+mkfifo fifo/gul_S1_summarycalc_P2
+mkfifo fifo/gul_S1_pltcalc_P2
+mkfifo fifo/gul_S2_summary_P2
+mkfifo fifo/gul_S2_eltcalc_P2
+mkfifo fifo/gul_S2_summarycalc_P2
+mkfifo fifo/gul_S2_pltcalc_P2
+
+mkfifo fifo/gul_S1_summary_P3
+mkfifo fifo/gul_S1_eltcalc_P3
+mkfifo fifo/gul_S1_summarycalc_P3
+mkfifo fifo/gul_S1_pltcalc_P3
+mkfifo fifo/gul_S2_summary_P3
+mkfifo fifo/gul_S2_eltcalc_P3
+mkfifo fifo/gul_S2_summarycalc_P3
+mkfifo fifo/gul_S2_pltcalc_P3
+
+mkfifo fifo/gul_S1_summary_P4
+mkfifo fifo/gul_S1_eltcalc_P4
+mkfifo fifo/gul_S1_summarycalc_P4
+mkfifo fifo/gul_S1_pltcalc_P4
+mkfifo fifo/gul_S2_summary_P4
+mkfifo fifo/gul_S2_eltcalc_P4
+mkfifo fifo/gul_S2_summarycalc_P4
+mkfifo fifo/gul_S2_pltcalc_P4
+
+mkfifo fifo/gul_S1_summary_P5
+mkfifo fifo/gul_S1_eltcalc_P5
+mkfifo fifo/gul_S1_summarycalc_P5
+mkfifo fifo/gul_S1_pltcalc_P5
+mkfifo fifo/gul_S2_summary_P5
+mkfifo fifo/gul_S2_eltcalc_P5
+mkfifo fifo/gul_S2_summarycalc_P5
+mkfifo fifo/gul_S2_pltcalc_P5
+
+mkfifo fifo/gul_S1_summary_P6
+mkfifo fifo/gul_S1_eltcalc_P6
+mkfifo fifo/gul_S1_summarycalc_P6
+mkfifo fifo/gul_S1_pltcalc_P6
+mkfifo fifo/gul_S2_summary_P6
+mkfifo fifo/gul_S2_eltcalc_P6
+mkfifo fifo/gul_S2_summarycalc_P6
+mkfifo fifo/gul_S2_pltcalc_P6
+
+mkfifo fifo/gul_S1_summary_P7
+mkfifo fifo/gul_S1_eltcalc_P7
+mkfifo fifo/gul_S1_summarycalc_P7
+mkfifo fifo/gul_S1_pltcalc_P7
+mkfifo fifo/gul_S2_summary_P7
+mkfifo fifo/gul_S2_eltcalc_P7
+mkfifo fifo/gul_S2_summarycalc_P7
+mkfifo fifo/gul_S2_pltcalc_P7
+
+mkfifo fifo/gul_S1_summary_P8
+mkfifo fifo/gul_S1_eltcalc_P8
+mkfifo fifo/gul_S1_summarycalc_P8
+mkfifo fifo/gul_S1_pltcalc_P8
+mkfifo fifo/gul_S2_summary_P8
+mkfifo fifo/gul_S2_eltcalc_P8
+mkfifo fifo/gul_S2_summarycalc_P8
+mkfifo fifo/gul_S2_pltcalc_P8
+
+mkfifo fifo/gul_S1_summary_P9
+mkfifo fifo/gul_S1_eltcalc_P9
+mkfifo fifo/gul_S1_summarycalc_P9
+mkfifo fifo/gul_S1_pltcalc_P9
+mkfifo fifo/gul_S2_summary_P9
+mkfifo fifo/gul_S2_eltcalc_P9
+mkfifo fifo/gul_S2_summarycalc_P9
+mkfifo fifo/gul_S2_pltcalc_P9
+
+mkfifo fifo/gul_S1_summary_P10
+mkfifo fifo/gul_S1_eltcalc_P10
+mkfifo fifo/gul_S1_summarycalc_P10
+mkfifo fifo/gul_S1_pltcalc_P10
+mkfifo fifo/gul_S2_summary_P10
+mkfifo fifo/gul_S2_eltcalc_P10
+mkfifo fifo/gul_S2_summarycalc_P10
+mkfifo fifo/gul_S2_pltcalc_P10
+
+
+
+# --- Do ground up loss computes ---
+
+eltcalc < fifo/gul_S1_eltcalc_P1 > work/kat/gul_S1_eltcalc_P1 & pid1=$!
+summarycalctocsv < fifo/gul_S1_summarycalc_P1 > work/kat/gul_S1_summarycalc_P1 & pid2=$!
+pltcalc < fifo/gul_S1_pltcalc_P1 > work/kat/gul_S1_pltcalc_P1 & pid3=$!
+eltcalc < fifo/gul_S2_eltcalc_P1 > work/kat/gul_S2_eltcalc_P1 & pid4=$!
+summarycalctocsv < fifo/gul_S2_summarycalc_P1 > work/kat/gul_S2_summarycalc_P1 & pid5=$!
+pltcalc < fifo/gul_S2_pltcalc_P1 > work/kat/gul_S2_pltcalc_P1 & pid6=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P2 > work/kat/gul_S1_eltcalc_P2 & pid7=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P2 > work/kat/gul_S1_summarycalc_P2 & pid8=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P2 > work/kat/gul_S1_pltcalc_P2 & pid9=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P2 > work/kat/gul_S2_eltcalc_P2 & pid10=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P2 > work/kat/gul_S2_summarycalc_P2 & pid11=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P2 > work/kat/gul_S2_pltcalc_P2 & pid12=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P3 > work/kat/gul_S1_eltcalc_P3 & pid13=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P3 > work/kat/gul_S1_summarycalc_P3 & pid14=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P3 > work/kat/gul_S1_pltcalc_P3 & pid15=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P3 > work/kat/gul_S2_eltcalc_P3 & pid16=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P3 > work/kat/gul_S2_summarycalc_P3 & pid17=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P3 > work/kat/gul_S2_pltcalc_P3 & pid18=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P4 > work/kat/gul_S1_eltcalc_P4 & pid19=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P4 > work/kat/gul_S1_summarycalc_P4 & pid20=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P4 > work/kat/gul_S1_pltcalc_P4 & pid21=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P4 > work/kat/gul_S2_eltcalc_P4 & pid22=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P4 > work/kat/gul_S2_summarycalc_P4 & pid23=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P4 > work/kat/gul_S2_pltcalc_P4 & pid24=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P5 > work/kat/gul_S1_eltcalc_P5 & pid25=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P5 > work/kat/gul_S1_summarycalc_P5 & pid26=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P5 > work/kat/gul_S1_pltcalc_P5 & pid27=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P5 > work/kat/gul_S2_eltcalc_P5 & pid28=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P5 > work/kat/gul_S2_summarycalc_P5 & pid29=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P5 > work/kat/gul_S2_pltcalc_P5 & pid30=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P6 > work/kat/gul_S1_eltcalc_P6 & pid31=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P6 > work/kat/gul_S1_summarycalc_P6 & pid32=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P6 > work/kat/gul_S1_pltcalc_P6 & pid33=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P6 > work/kat/gul_S2_eltcalc_P6 & pid34=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P6 > work/kat/gul_S2_summarycalc_P6 & pid35=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P6 > work/kat/gul_S2_pltcalc_P6 & pid36=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P7 > work/kat/gul_S1_eltcalc_P7 & pid37=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P7 > work/kat/gul_S1_summarycalc_P7 & pid38=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P7 > work/kat/gul_S1_pltcalc_P7 & pid39=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P7 > work/kat/gul_S2_eltcalc_P7 & pid40=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P7 > work/kat/gul_S2_summarycalc_P7 & pid41=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P7 > work/kat/gul_S2_pltcalc_P7 & pid42=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P8 > work/kat/gul_S1_eltcalc_P8 & pid43=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P8 > work/kat/gul_S1_summarycalc_P8 & pid44=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P8 > work/kat/gul_S1_pltcalc_P8 & pid45=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P8 > work/kat/gul_S2_eltcalc_P8 & pid46=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P8 > work/kat/gul_S2_summarycalc_P8 & pid47=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P8 > work/kat/gul_S2_pltcalc_P8 & pid48=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P9 > work/kat/gul_S1_eltcalc_P9 & pid49=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P9 > work/kat/gul_S1_summarycalc_P9 & pid50=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P9 > work/kat/gul_S1_pltcalc_P9 & pid51=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P9 > work/kat/gul_S2_eltcalc_P9 & pid52=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P9 > work/kat/gul_S2_summarycalc_P9 & pid53=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P9 > work/kat/gul_S2_pltcalc_P9 & pid54=$!
+eltcalc -s < fifo/gul_S1_eltcalc_P10 > work/kat/gul_S1_eltcalc_P10 & pid55=$!
+summarycalctocsv -s < fifo/gul_S1_summarycalc_P10 > work/kat/gul_S1_summarycalc_P10 & pid56=$!
+pltcalc -s < fifo/gul_S1_pltcalc_P10 > work/kat/gul_S1_pltcalc_P10 & pid57=$!
+eltcalc -s < fifo/gul_S2_eltcalc_P10 > work/kat/gul_S2_eltcalc_P10 & pid58=$!
+summarycalctocsv -s < fifo/gul_S2_summarycalc_P10 > work/kat/gul_S2_summarycalc_P10 & pid59=$!
+pltcalc -s < fifo/gul_S2_pltcalc_P10 > work/kat/gul_S2_pltcalc_P10 & pid60=$!
+
+tee < fifo/gul_S1_summary_P1 fifo/gul_S1_eltcalc_P1 fifo/gul_S1_summarycalc_P1 fifo/gul_S1_pltcalc_P1 work/gul_S1_summaryaalcalc/P1.bin work/gul_S1_summaryleccalc/P1.bin > /dev/null & pid61=$!
+tee < fifo/gul_S2_summary_P1 fifo/gul_S2_eltcalc_P1 fifo/gul_S2_summarycalc_P1 fifo/gul_S2_pltcalc_P1 work/gul_S2_summaryaalcalc/P1.bin work/gul_S2_summaryleccalc/P1.bin > /dev/null & pid62=$!
+tee < fifo/gul_S1_summary_P2 fifo/gul_S1_eltcalc_P2 fifo/gul_S1_summarycalc_P2 fifo/gul_S1_pltcalc_P2 work/gul_S1_summaryaalcalc/P2.bin work/gul_S1_summaryleccalc/P2.bin > /dev/null & pid63=$!
+tee < fifo/gul_S2_summary_P2 fifo/gul_S2_eltcalc_P2 fifo/gul_S2_summarycalc_P2 fifo/gul_S2_pltcalc_P2 work/gul_S2_summaryaalcalc/P2.bin work/gul_S2_summaryleccalc/P2.bin > /dev/null & pid64=$!
+tee < fifo/gul_S1_summary_P3 fifo/gul_S1_eltcalc_P3 fifo/gul_S1_summarycalc_P3 fifo/gul_S1_pltcalc_P3 work/gul_S1_summaryaalcalc/P3.bin work/gul_S1_summaryleccalc/P3.bin > /dev/null & pid65=$!
+tee < fifo/gul_S2_summary_P3 fifo/gul_S2_eltcalc_P3 fifo/gul_S2_summarycalc_P3 fifo/gul_S2_pltcalc_P3 work/gul_S2_summaryaalcalc/P3.bin work/gul_S2_summaryleccalc/P3.bin > /dev/null & pid66=$!
+tee < fifo/gul_S1_summary_P4 fifo/gul_S1_eltcalc_P4 fifo/gul_S1_summarycalc_P4 fifo/gul_S1_pltcalc_P4 work/gul_S1_summaryaalcalc/P4.bin work/gul_S1_summaryleccalc/P4.bin > /dev/null & pid67=$!
+tee < fifo/gul_S2_summary_P4 fifo/gul_S2_eltcalc_P4 fifo/gul_S2_summarycalc_P4 fifo/gul_S2_pltcalc_P4 work/gul_S2_summaryaalcalc/P4.bin work/gul_S2_summaryleccalc/P4.bin > /dev/null & pid68=$!
+tee < fifo/gul_S1_summary_P5 fifo/gul_S1_eltcalc_P5 fifo/gul_S1_summarycalc_P5 fifo/gul_S1_pltcalc_P5 work/gul_S1_summaryaalcalc/P5.bin work/gul_S1_summaryleccalc/P5.bin > /dev/null & pid69=$!
+tee < fifo/gul_S2_summary_P5 fifo/gul_S2_eltcalc_P5 fifo/gul_S2_summarycalc_P5 fifo/gul_S2_pltcalc_P5 work/gul_S2_summaryaalcalc/P5.bin work/gul_S2_summaryleccalc/P5.bin > /dev/null & pid70=$!
+tee < fifo/gul_S1_summary_P6 fifo/gul_S1_eltcalc_P6 fifo/gul_S1_summarycalc_P6 fifo/gul_S1_pltcalc_P6 work/gul_S1_summaryaalcalc/P6.bin work/gul_S1_summaryleccalc/P6.bin > /dev/null & pid71=$!
+tee < fifo/gul_S2_summary_P6 fifo/gul_S2_eltcalc_P6 fifo/gul_S2_summarycalc_P6 fifo/gul_S2_pltcalc_P6 work/gul_S2_summaryaalcalc/P6.bin work/gul_S2_summaryleccalc/P6.bin > /dev/null & pid72=$!
+tee < fifo/gul_S1_summary_P7 fifo/gul_S1_eltcalc_P7 fifo/gul_S1_summarycalc_P7 fifo/gul_S1_pltcalc_P7 work/gul_S1_summaryaalcalc/P7.bin work/gul_S1_summaryleccalc/P7.bin > /dev/null & pid73=$!
+tee < fifo/gul_S2_summary_P7 fifo/gul_S2_eltcalc_P7 fifo/gul_S2_summarycalc_P7 fifo/gul_S2_pltcalc_P7 work/gul_S2_summaryaalcalc/P7.bin work/gul_S2_summaryleccalc/P7.bin > /dev/null & pid74=$!
+tee < fifo/gul_S1_summary_P8 fifo/gul_S1_eltcalc_P8 fifo/gul_S1_summarycalc_P8 fifo/gul_S1_pltcalc_P8 work/gul_S1_summaryaalcalc/P8.bin work/gul_S1_summaryleccalc/P8.bin > /dev/null & pid75=$!
+tee < fifo/gul_S2_summary_P8 fifo/gul_S2_eltcalc_P8 fifo/gul_S2_summarycalc_P8 fifo/gul_S2_pltcalc_P8 work/gul_S2_summaryaalcalc/P8.bin work/gul_S2_summaryleccalc/P8.bin > /dev/null & pid76=$!
+tee < fifo/gul_S1_summary_P9 fifo/gul_S1_eltcalc_P9 fifo/gul_S1_summarycalc_P9 fifo/gul_S1_pltcalc_P9 work/gul_S1_summaryaalcalc/P9.bin work/gul_S1_summaryleccalc/P9.bin > /dev/null & pid77=$!
+tee < fifo/gul_S2_summary_P9 fifo/gul_S2_eltcalc_P9 fifo/gul_S2_summarycalc_P9 fifo/gul_S2_pltcalc_P9 work/gul_S2_summaryaalcalc/P9.bin work/gul_S2_summaryleccalc/P9.bin > /dev/null & pid78=$!
+tee < fifo/gul_S1_summary_P10 fifo/gul_S1_eltcalc_P10 fifo/gul_S1_summarycalc_P10 fifo/gul_S1_pltcalc_P10 work/gul_S1_summaryaalcalc/P10.bin work/gul_S1_summaryleccalc/P10.bin > /dev/null & pid79=$!
+tee < fifo/gul_S2_summary_P10 fifo/gul_S2_eltcalc_P10 fifo/gul_S2_summarycalc_P10 fifo/gul_S2_pltcalc_P10 work/gul_S2_summaryaalcalc/P10.bin work/gul_S2_summaryleccalc/P10.bin > /dev/null & pid80=$!
+
+summarycalc -i  -1 fifo/gul_S1_summary_P1 -2 fifo/gul_S2_summary_P1 < fifo/gul_P1 &
+summarycalc -i  -1 fifo/gul_S1_summary_P2 -2 fifo/gul_S2_summary_P2 < fifo/gul_P2 &
+summarycalc -i  -1 fifo/gul_S1_summary_P3 -2 fifo/gul_S2_summary_P3 < fifo/gul_P3 &
+summarycalc -i  -1 fifo/gul_S1_summary_P4 -2 fifo/gul_S2_summary_P4 < fifo/gul_P4 &
+summarycalc -i  -1 fifo/gul_S1_summary_P5 -2 fifo/gul_S2_summary_P5 < fifo/gul_P5 &
+summarycalc -i  -1 fifo/gul_S1_summary_P6 -2 fifo/gul_S2_summary_P6 < fifo/gul_P6 &
+summarycalc -i  -1 fifo/gul_S1_summary_P7 -2 fifo/gul_S2_summary_P7 < fifo/gul_P7 &
+summarycalc -i  -1 fifo/gul_S1_summary_P8 -2 fifo/gul_S2_summary_P8 < fifo/gul_P8 &
+summarycalc -i  -1 fifo/gul_S1_summary_P9 -2 fifo/gul_S2_summary_P9 < fifo/gul_P9 &
+summarycalc -i  -1 fifo/gul_S1_summary_P10 -2 fifo/gul_S2_summary_P10 < fifo/gul_P10 &
+
+eve 1 10 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P1  &
+eve 2 10 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P2  &
+eve 3 10 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P3  &
+eve 4 10 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P4  &
+eve 5 10 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P5  &
+eve 6 10 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P6  &
+eve 7 10 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P7  &
+eve 8 10 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P8  &
+eve 9 10 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P9  &
+eve 10 10 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P10  &
+
+wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 $pid13 $pid14 $pid15 $pid16 $pid17 $pid18 $pid19 $pid20 $pid21 $pid22 $pid23 $pid24 $pid25 $pid26 $pid27 $pid28 $pid29 $pid30 $pid31 $pid32 $pid33 $pid34 $pid35 $pid36 $pid37 $pid38 $pid39 $pid40 $pid41 $pid42 $pid43 $pid44 $pid45 $pid46 $pid47 $pid48 $pid49 $pid50 $pid51 $pid52 $pid53 $pid54 $pid55 $pid56 $pid57 $pid58 $pid59 $pid60 $pid61 $pid62 $pid63 $pid64 $pid65 $pid66 $pid67 $pid68 $pid69 $pid70 $pid71 $pid72 $pid73 $pid74 $pid75 $pid76 $pid77 $pid78 $pid79 $pid80
+
+
+# --- Do ground up loss kats ---
+
+kat -s work/kat/gul_S1_eltcalc_P1 work/kat/gul_S1_eltcalc_P2 work/kat/gul_S1_eltcalc_P3 work/kat/gul_S1_eltcalc_P4 work/kat/gul_S1_eltcalc_P5 work/kat/gul_S1_eltcalc_P6 work/kat/gul_S1_eltcalc_P7 work/kat/gul_S1_eltcalc_P8 work/kat/gul_S1_eltcalc_P9 work/kat/gul_S1_eltcalc_P10 > output/gul_S1_eltcalc.csv & kpid1=$!
+kat work/kat/gul_S1_pltcalc_P1 work/kat/gul_S1_pltcalc_P2 work/kat/gul_S1_pltcalc_P3 work/kat/gul_S1_pltcalc_P4 work/kat/gul_S1_pltcalc_P5 work/kat/gul_S1_pltcalc_P6 work/kat/gul_S1_pltcalc_P7 work/kat/gul_S1_pltcalc_P8 work/kat/gul_S1_pltcalc_P9 work/kat/gul_S1_pltcalc_P10 > output/gul_S1_pltcalc.csv & kpid2=$!
+kat work/kat/gul_S1_summarycalc_P1 work/kat/gul_S1_summarycalc_P2 work/kat/gul_S1_summarycalc_P3 work/kat/gul_S1_summarycalc_P4 work/kat/gul_S1_summarycalc_P5 work/kat/gul_S1_summarycalc_P6 work/kat/gul_S1_summarycalc_P7 work/kat/gul_S1_summarycalc_P8 work/kat/gul_S1_summarycalc_P9 work/kat/gul_S1_summarycalc_P10 > output/gul_S1_summarycalc.csv & kpid3=$!
+kat -s work/kat/gul_S2_eltcalc_P1 work/kat/gul_S2_eltcalc_P2 work/kat/gul_S2_eltcalc_P3 work/kat/gul_S2_eltcalc_P4 work/kat/gul_S2_eltcalc_P5 work/kat/gul_S2_eltcalc_P6 work/kat/gul_S2_eltcalc_P7 work/kat/gul_S2_eltcalc_P8 work/kat/gul_S2_eltcalc_P9 work/kat/gul_S2_eltcalc_P10 > output/gul_S2_eltcalc.csv & kpid4=$!
+kat work/kat/gul_S2_pltcalc_P1 work/kat/gul_S2_pltcalc_P2 work/kat/gul_S2_pltcalc_P3 work/kat/gul_S2_pltcalc_P4 work/kat/gul_S2_pltcalc_P5 work/kat/gul_S2_pltcalc_P6 work/kat/gul_S2_pltcalc_P7 work/kat/gul_S2_pltcalc_P8 work/kat/gul_S2_pltcalc_P9 work/kat/gul_S2_pltcalc_P10 > output/gul_S2_pltcalc.csv & kpid5=$!
+kat work/kat/gul_S2_summarycalc_P1 work/kat/gul_S2_summarycalc_P2 work/kat/gul_S2_summarycalc_P3 work/kat/gul_S2_summarycalc_P4 work/kat/gul_S2_summarycalc_P5 work/kat/gul_S2_summarycalc_P6 work/kat/gul_S2_summarycalc_P7 work/kat/gul_S2_summarycalc_P8 work/kat/gul_S2_summarycalc_P9 work/kat/gul_S2_summarycalc_P10 > output/gul_S2_summarycalc.csv & kpid6=$!
+wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
+
+
+aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv & lpid1=$!
+ordleccalc -r -Kgul_S1_summaryleccalc -F -S -s -M -m -W -w -O output/gul_S1_ept.csv -o output/gul_S1_psept.csv & lpid2=$!
+leccalc -r -Kgul_S1_summaryleccalc -F output/gul_S1_leccalc_full_uncertainty_aep.csv -f output/gul_S1_leccalc_full_uncertainty_oep.csv -S output/gul_S1_leccalc_sample_mean_aep.csv -s output/gul_S1_leccalc_sample_mean_oep.csv -W output/gul_S1_leccalc_wheatsheaf_aep.csv -M output/gul_S1_leccalc_wheatsheaf_mean_aep.csv -m output/gul_S1_leccalc_wheatsheaf_mean_oep.csv -w output/gul_S1_leccalc_wheatsheaf_oep.csv & lpid3=$!
+aalcalc -Kgul_S2_summaryaalcalc > output/gul_S2_aalcalc.csv & lpid4=$!
+ordleccalc -r -Kgul_S2_summaryleccalc -F -S -s -M -m -W -w -O output/gul_S2_ept.csv -o output/gul_S2_psept.csv & lpid5=$!
+leccalc -r -Kgul_S2_summaryleccalc -F output/gul_S2_leccalc_full_uncertainty_aep.csv -f output/gul_S2_leccalc_full_uncertainty_oep.csv -S output/gul_S2_leccalc_sample_mean_aep.csv -s output/gul_S2_leccalc_sample_mean_oep.csv -W output/gul_S2_leccalc_wheatsheaf_aep.csv -M output/gul_S2_leccalc_wheatsheaf_mean_aep.csv -m output/gul_S2_leccalc_wheatsheaf_mean_oep.csv -w output/gul_S2_leccalc_wheatsheaf_oep.csv & lpid6=$!
+wait $lpid1 $lpid2 $lpid3 $lpid4 $lpid5 $lpid6
+
+rm -R -f work/*
+rm -R -f fifo/*

--- a/tests/model_execution/lb_kparse_reference/gul_ord_psept_2_output_10_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_ord_psept_2_output_10_partition.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+
+rm -R -f fifo/*
+rm -R -f work/*
+mkdir work/kat/
+
+mkdir work/gul_S1_summaryleccalc
+mkdir work/gul_S2_summaryleccalc
+
+mkfifo fifo/gul_P1
+mkfifo fifo/gul_P2
+mkfifo fifo/gul_P3
+mkfifo fifo/gul_P4
+mkfifo fifo/gul_P5
+mkfifo fifo/gul_P6
+mkfifo fifo/gul_P7
+mkfifo fifo/gul_P8
+mkfifo fifo/gul_P9
+mkfifo fifo/gul_P10
+
+mkfifo fifo/gul_S1_summary_P1
+mkfifo fifo/gul_S2_summary_P1
+
+mkfifo fifo/gul_S1_summary_P2
+mkfifo fifo/gul_S2_summary_P2
+
+mkfifo fifo/gul_S1_summary_P3
+mkfifo fifo/gul_S2_summary_P3
+
+mkfifo fifo/gul_S1_summary_P4
+mkfifo fifo/gul_S2_summary_P4
+
+mkfifo fifo/gul_S1_summary_P5
+mkfifo fifo/gul_S2_summary_P5
+
+mkfifo fifo/gul_S1_summary_P6
+mkfifo fifo/gul_S2_summary_P6
+
+mkfifo fifo/gul_S1_summary_P7
+mkfifo fifo/gul_S2_summary_P7
+
+mkfifo fifo/gul_S1_summary_P8
+mkfifo fifo/gul_S2_summary_P8
+
+mkfifo fifo/gul_S1_summary_P9
+mkfifo fifo/gul_S2_summary_P9
+
+mkfifo fifo/gul_S1_summary_P10
+mkfifo fifo/gul_S2_summary_P10
+
+
+
+# --- Do ground up loss computes ---
+
+
+tee < fifo/gul_S1_summary_P1 work/gul_S1_summaryleccalc/P1.bin > /dev/null & pid1=$!
+tee < fifo/gul_S2_summary_P1 work/gul_S2_summaryleccalc/P1.bin > /dev/null & pid2=$!
+tee < fifo/gul_S1_summary_P2 work/gul_S1_summaryleccalc/P2.bin > /dev/null & pid3=$!
+tee < fifo/gul_S2_summary_P2 work/gul_S2_summaryleccalc/P2.bin > /dev/null & pid4=$!
+tee < fifo/gul_S1_summary_P3 work/gul_S1_summaryleccalc/P3.bin > /dev/null & pid5=$!
+tee < fifo/gul_S2_summary_P3 work/gul_S2_summaryleccalc/P3.bin > /dev/null & pid6=$!
+tee < fifo/gul_S1_summary_P4 work/gul_S1_summaryleccalc/P4.bin > /dev/null & pid7=$!
+tee < fifo/gul_S2_summary_P4 work/gul_S2_summaryleccalc/P4.bin > /dev/null & pid8=$!
+tee < fifo/gul_S1_summary_P5 work/gul_S1_summaryleccalc/P5.bin > /dev/null & pid9=$!
+tee < fifo/gul_S2_summary_P5 work/gul_S2_summaryleccalc/P5.bin > /dev/null & pid10=$!
+tee < fifo/gul_S1_summary_P6 work/gul_S1_summaryleccalc/P6.bin > /dev/null & pid11=$!
+tee < fifo/gul_S2_summary_P6 work/gul_S2_summaryleccalc/P6.bin > /dev/null & pid12=$!
+tee < fifo/gul_S1_summary_P7 work/gul_S1_summaryleccalc/P7.bin > /dev/null & pid13=$!
+tee < fifo/gul_S2_summary_P7 work/gul_S2_summaryleccalc/P7.bin > /dev/null & pid14=$!
+tee < fifo/gul_S1_summary_P8 work/gul_S1_summaryleccalc/P8.bin > /dev/null & pid15=$!
+tee < fifo/gul_S2_summary_P8 work/gul_S2_summaryleccalc/P8.bin > /dev/null & pid16=$!
+tee < fifo/gul_S1_summary_P9 work/gul_S1_summaryleccalc/P9.bin > /dev/null & pid17=$!
+tee < fifo/gul_S2_summary_P9 work/gul_S2_summaryleccalc/P9.bin > /dev/null & pid18=$!
+tee < fifo/gul_S1_summary_P10 work/gul_S1_summaryleccalc/P10.bin > /dev/null & pid19=$!
+tee < fifo/gul_S2_summary_P10 work/gul_S2_summaryleccalc/P10.bin > /dev/null & pid20=$!
+
+summarycalc -i  -1 fifo/gul_S1_summary_P1 -2 fifo/gul_S2_summary_P1 < fifo/gul_P1 &
+summarycalc -i  -1 fifo/gul_S1_summary_P2 -2 fifo/gul_S2_summary_P2 < fifo/gul_P2 &
+summarycalc -i  -1 fifo/gul_S1_summary_P3 -2 fifo/gul_S2_summary_P3 < fifo/gul_P3 &
+summarycalc -i  -1 fifo/gul_S1_summary_P4 -2 fifo/gul_S2_summary_P4 < fifo/gul_P4 &
+summarycalc -i  -1 fifo/gul_S1_summary_P5 -2 fifo/gul_S2_summary_P5 < fifo/gul_P5 &
+summarycalc -i  -1 fifo/gul_S1_summary_P6 -2 fifo/gul_S2_summary_P6 < fifo/gul_P6 &
+summarycalc -i  -1 fifo/gul_S1_summary_P7 -2 fifo/gul_S2_summary_P7 < fifo/gul_P7 &
+summarycalc -i  -1 fifo/gul_S1_summary_P8 -2 fifo/gul_S2_summary_P8 < fifo/gul_P8 &
+summarycalc -i  -1 fifo/gul_S1_summary_P9 -2 fifo/gul_S2_summary_P9 < fifo/gul_P9 &
+summarycalc -i  -1 fifo/gul_S1_summary_P10 -2 fifo/gul_S2_summary_P10 < fifo/gul_P10 &
+
+eve 1 10 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P1  &
+eve 2 10 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P2  &
+eve 3 10 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P3  &
+eve 4 10 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P4  &
+eve 5 10 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P5  &
+eve 6 10 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P6  &
+eve 7 10 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P7  &
+eve 8 10 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P8  &
+eve 9 10 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P9  &
+eve 10 10 | getmodel | gulcalc -S0 -L0 -r -a0 -i - > fifo/gul_P10  &
+
+wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 $pid13 $pid14 $pid15 $pid16 $pid17 $pid18 $pid19 $pid20
+
+
+# --- Do ground up loss kats ---
+
+
+ordleccalc  -Kgul_S1_summaryleccalc -W -w -o output/gul_S1_psept.csv & lpid1=$!
+ordleccalc -r -Kgul_S2_summaryleccalc -W -w -o output/gul_S2_psept.csv & lpid2=$!
+wait $lpid1 $lpid2
+
+rm -R -f work/*
+rm -R -f fifo/*

--- a/tests/model_execution/test_bash.py
+++ b/tests/model_execution/test_bash.py
@@ -97,12 +97,13 @@ class Genbash(TestCase):
         )
 
     def check(self, name, reference_filename=None):
+        pass
         output_filename = os.path.join(self.KPARSE_OUTPUT_FOLDER, "{}.sh".format(name))
         if not reference_filename:
             reference_filename = os.path.join(self.KPARSE_REFERENCE_FOLDER, "{}.sh".format(name))
 
         if self.fifo_tmp_dir:
-            # Create temp Ref file   
+            # Create temp Ref file
             ref_template = reference_filename
             ref_tmp_file = NamedTemporaryFile("w+", delete=False)
             with io.open(output_filename, 'r') as f:
@@ -118,7 +119,7 @@ class Genbash(TestCase):
             ref_tmp_file.write(ktools_script)
             ref_tmp_file.close()
             reference_filename = ref_tmp_file.name
-        
+
         d = diff.unified_diff(reference_filename, output_filename, as_string=True)
         if d:
             self.fail(d)
@@ -427,6 +428,7 @@ class Genbash(TestCase):
         self.genbash("gul_il_lec_2_output", 10)
         self.check("gul_il_lec_2_output_10_partition")
 
+    # RI checks
     def test_analysis_settings_1(self):
         self.genbash("analysis_settings_1", 1)
         self.check("analysis_settings_1_1_partition")
@@ -442,6 +444,35 @@ class Genbash(TestCase):
     def test_analysis_settings_4_0_reins_iters(self):
         self.genbash("analysis_settings_4", 1, 1)
         self.check("analysis_settings_4_1_reins_layer_1_partition")
+
+    def test_analysis_settings_5_0_reins_iters(self):
+        self.genbash("analysis_settings_5", 1, 1)
+        self.check("analysis_settings_5_1_reins_layer_1_partition")
+
+    # ORD checks
+    def test_gul_ord_ept_1_output_1_partitions(self):
+        self.genbash("gul_ord_ept_1_output", 1)
+        self.check("gul_ord_ept_1_output_1_partition")
+
+    def test_gul_ord_ept_1_output_20_partitions(self):
+        self.genbash("gul_ord_ept_1_output", 20)
+        self.check("gul_ord_ept_1_output_20_partition")
+
+    def test_gul_ord_psept_2_output_10_partitions(self):
+        self.genbash("gul_ord_psept_2_output", 10)
+        self.check("gul_ord_psept_2_output_10_partition")
+
+    def test_gul_ord_ept_psept_lec_2_output_10_partitions(self):
+        self.genbash("gul_ord_ept_psept_lec_2_output", 10)
+        self.check("gul_ord_ept_psept_lec_2_output_10_partition")
+
+    def test_gul_il_ord_ept_psept_2_output_10_partitions(self):
+        self.genbash("gul_il_ord_ept_psept_2_output", 10)
+        self.check("gul_il_ord_ept_psept_2_output_10_partition")
+
+    def test_gul_il_ord_psept_lec_1_output_10_partitions(self):
+        self.genbash("gul_il_ord_psept_lec_1_output", 10)
+        self.check("gul_il_ord_psept_lec_1_output_10_partition")
 
 
 class Genbash_GulItemStream(Genbash):

--- a/tests/model_execution/tmp_fc_kparse_reference/analysis_settings_5_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/analysis_settings_5_1_reins_layer_1_partition.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+mkdir output/full_correlation/
+
+rm -R -f work/*
+mkdir work/kat/
+mkdir work/full_correlation/
+mkdir work/full_correlation/kat/
+
+rm -R -f /tmp/%FIFO_DIR%/
+mkdir -p /tmp/%FIFO_DIR%/fifo/
+mkdir /tmp/%FIFO_DIR%/fifo/full_correlation/
+mkdir work/gul_S1_summaryaalcalc
+mkdir work/full_correlation/gul_S1_summaryaalcalc
+mkdir work/il_S1_summaryleccalc
+mkdir work/full_correlation/il_S1_summaryleccalc
+mkdir work/ri_S1_summaryleccalc
+mkdir work/full_correlation/ri_S1_summaryleccalc
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P1
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P1
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P1
+
+mkfifo /tmp/%FIFO_DIR%/fifo/il_P1
+
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summary_P1
+
+mkfifo /tmp/%FIFO_DIR%/fifo/ri_P1
+
+mkfifo /tmp/%FIFO_DIR%/fifo/ri_S1_summary_P1
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P1
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P1
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_P1
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P1
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/ri_P1
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/ri_S1_summary_P1
+
+
+
+# --- Do reinsurance loss computes ---
+
+
+tee < /tmp/%FIFO_DIR%/fifo/ri_S1_summary_P1 work/ri_S1_summaryleccalc/P1.bin > /dev/null & pid1=$!
+
+summarycalc -f -p RI_1 -1 /tmp/%FIFO_DIR%/fifo/ri_S1_summary_P1 < /tmp/%FIFO_DIR%/fifo/ri_P1 &
+
+# --- Do insured loss computes ---
+
+
+tee < /tmp/%FIFO_DIR%/fifo/il_S1_summary_P1 work/il_S1_summaryleccalc/P1.bin > /dev/null & pid2=$!
+
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/il_S1_summary_P1 < /tmp/%FIFO_DIR%/fifo/il_P1 &
+
+# --- Do ground up loss computes ---
+
+eltcalc < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P1 > work/kat/gul_S1_eltcalc_P1 & pid3=$!
+summarycalctocsv < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P1 > work/kat/gul_S1_summarycalc_P1 & pid4=$!
+pltcalc < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P1 > work/kat/gul_S1_pltcalc_P1 & pid5=$!
+
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P1 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P1 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P1 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P1 work/gul_S1_summaryaalcalc/P1.bin > /dev/null & pid6=$!
+
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P1 < /tmp/%FIFO_DIR%/fifo/gul_P1 &
+
+# --- Do reinsurance loss computes ---
+
+
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/ri_S1_summary_P1 work/full_correlation/ri_S1_summaryleccalc/P1.bin > /dev/null & pid7=$!
+
+summarycalc -f -p RI_1 -1 /tmp/%FIFO_DIR%/fifo/full_correlation/ri_S1_summary_P1 < /tmp/%FIFO_DIR%/fifo/full_correlation/ri_P1 &
+
+# --- Do insured loss computes ---
+
+
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P1 work/full_correlation/il_S1_summaryleccalc/P1.bin > /dev/null & pid8=$!
+
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P1 < /tmp/%FIFO_DIR%/fifo/full_correlation/il_P1 &
+
+# --- Do ground up loss computes ---
+
+eltcalc < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P1 > work/full_correlation/kat/gul_S1_eltcalc_P1 & pid9=$!
+summarycalctocsv < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P1 > work/full_correlation/kat/gul_S1_summarycalc_P1 & pid10=$!
+pltcalc < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P1 > work/full_correlation/kat/gul_S1_pltcalc_P1 & pid11=$!
+
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P1 work/full_correlation/gul_S1_summaryaalcalc/P1.bin > /dev/null & pid12=$!
+
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P1 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P1 &
+
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P1  | fmcalc -a2 | tee /tmp/%FIFO_DIR%/fifo/full_correlation/il_P1 | fmcalc -a3 -n -p RI_1 > /tmp/%FIFO_DIR%/fifo/full_correlation/ri_P1 &
+eve 1 1 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P1 -a1 -i - | tee /tmp/%FIFO_DIR%/fifo/gul_P1 | fmcalc -a2 | tee /tmp/%FIFO_DIR%/fifo/il_P1 | fmcalc -a3 -n -p RI_1 > /tmp/%FIFO_DIR%/fifo/ri_P1 &
+
+wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12
+
+
+# --- Do reinsurance loss kats ---
+
+
+# --- Do reinsurance loss kats for fully correlated output ---
+
+
+# --- Do insured loss kats ---
+
+
+# --- Do insured loss kats for fully correlated output ---
+
+
+# --- Do ground up loss kats ---
+
+kat -s work/kat/gul_S1_eltcalc_P1 > output/gul_S1_eltcalc.csv & kpid1=$!
+kat work/kat/gul_S1_pltcalc_P1 > output/gul_S1_pltcalc.csv & kpid2=$!
+kat work/kat/gul_S1_summarycalc_P1 > output/gul_S1_summarycalc.csv & kpid3=$!
+
+# --- Do ground up loss kats for fully correlated output ---
+
+kat -s work/full_correlation/kat/gul_S1_eltcalc_P1 > output/full_correlation/gul_S1_eltcalc.csv & kpid4=$!
+kat work/full_correlation/kat/gul_S1_pltcalc_P1 > output/full_correlation/gul_S1_pltcalc.csv & kpid5=$!
+kat work/full_correlation/kat/gul_S1_summarycalc_P1 > output/full_correlation/gul_S1_summarycalc.csv & kpid6=$!
+wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
+
+
+ordleccalc -r -Kri_S1_summaryleccalc -F -f -S -s -M -m -W -w -O output/ri_S1_ept.csv -o output/ri_S1_psept.csv & lpid1=$!
+ordleccalc  -Kil_S1_summaryleccalc -F -S -s -M -m -O output/il_S1_ept.csv & lpid2=$!
+aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv & lpid3=$!
+ordleccalc -r -Kfull_correlation/ri_S1_summaryleccalc -F -f -S -s -M -m -W -w -O output/full_correlation/ri_S1_ept.csv -o output/full_correlation/ri_S1_psept.csv & lpid4=$!
+ordleccalc  -Kfull_correlation/il_S1_summaryleccalc -F -S -s -M -m -O output/full_correlation/il_S1_ept.csv & lpid5=$!
+aalcalc -Kfull_correlation/gul_S1_summaryaalcalc > output/full_correlation/gul_S1_aalcalc.csv & lpid6=$!
+wait $lpid1 $lpid2 $lpid3 $lpid4 $lpid5 $lpid6
+
+rm -R -f work/*
+rm -R -f /tmp/%FIFO_DIR%/

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_il_ord_ept_psept_2_output_10_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_il_ord_ept_psept_2_output_10_partition.sh
@@ -1,0 +1,919 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+mkdir output/full_correlation/
+
+rm -R -f work/*
+mkdir work/kat/
+mkdir work/full_correlation/
+mkdir work/full_correlation/kat/
+
+rm -R -f /tmp/%FIFO_DIR%/
+mkdir -p /tmp/%FIFO_DIR%/fifo/
+mkdir /tmp/%FIFO_DIR%/fifo/full_correlation/
+mkdir work/gul_S1_summaryleccalc
+mkdir work/gul_S1_summaryaalcalc
+mkdir work/gul_S2_summaryleccalc
+mkdir work/gul_S2_summaryaalcalc
+mkdir work/full_correlation/gul_S1_summaryleccalc
+mkdir work/full_correlation/gul_S1_summaryaalcalc
+mkdir work/full_correlation/gul_S2_summaryleccalc
+mkdir work/full_correlation/gul_S2_summaryaalcalc
+mkdir work/il_S1_summaryleccalc
+mkdir work/il_S1_summaryaalcalc
+mkdir work/il_S2_summaryleccalc
+mkdir work/il_S2_summaryaalcalc
+mkdir work/full_correlation/il_S1_summaryleccalc
+mkdir work/full_correlation/il_S1_summaryaalcalc
+mkdir work/full_correlation/il_S2_summaryleccalc
+mkdir work/full_correlation/il_S2_summaryaalcalc
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P10
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P10
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P1
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P2
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P3
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P4
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P5
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P6
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P7
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P8
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P9
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P10
+
+mkfifo /tmp/%FIFO_DIR%/fifo/il_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/il_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/il_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/il_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/il_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/il_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/il_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/il_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/il_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/il_P10
+
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summary_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_summary_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P1
+
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summary_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_summary_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P2
+
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summary_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_summary_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P3
+
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summary_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_summary_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P4
+
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summary_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_summary_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P5
+
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summary_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_summary_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P6
+
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summary_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_summary_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P7
+
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summary_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_summary_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P8
+
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summary_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_summary_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P9
+
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summary_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_summary_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P10
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P10
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P1
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P2
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P3
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P4
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P5
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P6
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P7
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P8
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P9
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P10
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_P10
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summary_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_eltcalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summarycalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_pltcalc_P1
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summary_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_eltcalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summarycalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_pltcalc_P2
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summary_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_eltcalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summarycalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_pltcalc_P3
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summary_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_eltcalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summarycalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_pltcalc_P4
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summary_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_eltcalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summarycalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_pltcalc_P5
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summary_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_eltcalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summarycalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_pltcalc_P6
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summary_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_eltcalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summarycalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_pltcalc_P7
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summary_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_eltcalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summarycalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_pltcalc_P8
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summary_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_eltcalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summarycalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_pltcalc_P9
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summary_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_eltcalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summarycalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_pltcalc_P10
+
+
+
+# --- Do insured loss computes ---
+
+eltcalc < /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P1 > work/kat/il_S1_eltcalc_P1 & pid1=$!
+summarycalctocsv < /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P1 > work/kat/il_S1_summarycalc_P1 & pid2=$!
+pltcalc < /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P1 > work/kat/il_S1_pltcalc_P1 & pid3=$!
+eltcalc < /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P1 > work/kat/il_S2_eltcalc_P1 & pid4=$!
+summarycalctocsv < /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P1 > work/kat/il_S2_summarycalc_P1 & pid5=$!
+pltcalc < /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P1 > work/kat/il_S2_pltcalc_P1 & pid6=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P2 > work/kat/il_S1_eltcalc_P2 & pid7=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P2 > work/kat/il_S1_summarycalc_P2 & pid8=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P2 > work/kat/il_S1_pltcalc_P2 & pid9=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P2 > work/kat/il_S2_eltcalc_P2 & pid10=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P2 > work/kat/il_S2_summarycalc_P2 & pid11=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P2 > work/kat/il_S2_pltcalc_P2 & pid12=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P3 > work/kat/il_S1_eltcalc_P3 & pid13=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P3 > work/kat/il_S1_summarycalc_P3 & pid14=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P3 > work/kat/il_S1_pltcalc_P3 & pid15=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P3 > work/kat/il_S2_eltcalc_P3 & pid16=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P3 > work/kat/il_S2_summarycalc_P3 & pid17=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P3 > work/kat/il_S2_pltcalc_P3 & pid18=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P4 > work/kat/il_S1_eltcalc_P4 & pid19=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P4 > work/kat/il_S1_summarycalc_P4 & pid20=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P4 > work/kat/il_S1_pltcalc_P4 & pid21=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P4 > work/kat/il_S2_eltcalc_P4 & pid22=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P4 > work/kat/il_S2_summarycalc_P4 & pid23=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P4 > work/kat/il_S2_pltcalc_P4 & pid24=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P5 > work/kat/il_S1_eltcalc_P5 & pid25=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P5 > work/kat/il_S1_summarycalc_P5 & pid26=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P5 > work/kat/il_S1_pltcalc_P5 & pid27=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P5 > work/kat/il_S2_eltcalc_P5 & pid28=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P5 > work/kat/il_S2_summarycalc_P5 & pid29=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P5 > work/kat/il_S2_pltcalc_P5 & pid30=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P6 > work/kat/il_S1_eltcalc_P6 & pid31=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P6 > work/kat/il_S1_summarycalc_P6 & pid32=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P6 > work/kat/il_S1_pltcalc_P6 & pid33=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P6 > work/kat/il_S2_eltcalc_P6 & pid34=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P6 > work/kat/il_S2_summarycalc_P6 & pid35=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P6 > work/kat/il_S2_pltcalc_P6 & pid36=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P7 > work/kat/il_S1_eltcalc_P7 & pid37=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P7 > work/kat/il_S1_summarycalc_P7 & pid38=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P7 > work/kat/il_S1_pltcalc_P7 & pid39=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P7 > work/kat/il_S2_eltcalc_P7 & pid40=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P7 > work/kat/il_S2_summarycalc_P7 & pid41=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P7 > work/kat/il_S2_pltcalc_P7 & pid42=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P8 > work/kat/il_S1_eltcalc_P8 & pid43=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P8 > work/kat/il_S1_summarycalc_P8 & pid44=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P8 > work/kat/il_S1_pltcalc_P8 & pid45=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P8 > work/kat/il_S2_eltcalc_P8 & pid46=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P8 > work/kat/il_S2_summarycalc_P8 & pid47=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P8 > work/kat/il_S2_pltcalc_P8 & pid48=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P9 > work/kat/il_S1_eltcalc_P9 & pid49=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P9 > work/kat/il_S1_summarycalc_P9 & pid50=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P9 > work/kat/il_S1_pltcalc_P9 & pid51=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P9 > work/kat/il_S2_eltcalc_P9 & pid52=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P9 > work/kat/il_S2_summarycalc_P9 & pid53=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P9 > work/kat/il_S2_pltcalc_P9 & pid54=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P10 > work/kat/il_S1_eltcalc_P10 & pid55=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P10 > work/kat/il_S1_summarycalc_P10 & pid56=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P10 > work/kat/il_S1_pltcalc_P10 & pid57=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P10 > work/kat/il_S2_eltcalc_P10 & pid58=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P10 > work/kat/il_S2_summarycalc_P10 & pid59=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P10 > work/kat/il_S2_pltcalc_P10 & pid60=$!
+
+tee < /tmp/%FIFO_DIR%/fifo/il_S1_summary_P1 /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P1 /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P1 /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P1 work/il_S1_summaryaalcalc/P1.bin work/il_S1_summaryleccalc/P1.bin > /dev/null & pid61=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S2_summary_P1 /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P1 /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P1 /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P1 work/il_S2_summaryaalcalc/P1.bin work/il_S2_summaryleccalc/P1.bin > /dev/null & pid62=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S1_summary_P2 /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P2 /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P2 /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P2 work/il_S1_summaryaalcalc/P2.bin work/il_S1_summaryleccalc/P2.bin > /dev/null & pid63=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S2_summary_P2 /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P2 /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P2 /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P2 work/il_S2_summaryaalcalc/P2.bin work/il_S2_summaryleccalc/P2.bin > /dev/null & pid64=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S1_summary_P3 /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P3 /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P3 /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P3 work/il_S1_summaryaalcalc/P3.bin work/il_S1_summaryleccalc/P3.bin > /dev/null & pid65=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S2_summary_P3 /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P3 /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P3 /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P3 work/il_S2_summaryaalcalc/P3.bin work/il_S2_summaryleccalc/P3.bin > /dev/null & pid66=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S1_summary_P4 /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P4 /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P4 /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P4 work/il_S1_summaryaalcalc/P4.bin work/il_S1_summaryleccalc/P4.bin > /dev/null & pid67=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S2_summary_P4 /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P4 /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P4 /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P4 work/il_S2_summaryaalcalc/P4.bin work/il_S2_summaryleccalc/P4.bin > /dev/null & pid68=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S1_summary_P5 /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P5 /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P5 /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P5 work/il_S1_summaryaalcalc/P5.bin work/il_S1_summaryleccalc/P5.bin > /dev/null & pid69=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S2_summary_P5 /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P5 /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P5 /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P5 work/il_S2_summaryaalcalc/P5.bin work/il_S2_summaryleccalc/P5.bin > /dev/null & pid70=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S1_summary_P6 /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P6 /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P6 /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P6 work/il_S1_summaryaalcalc/P6.bin work/il_S1_summaryleccalc/P6.bin > /dev/null & pid71=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S2_summary_P6 /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P6 /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P6 /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P6 work/il_S2_summaryaalcalc/P6.bin work/il_S2_summaryleccalc/P6.bin > /dev/null & pid72=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S1_summary_P7 /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P7 /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P7 /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P7 work/il_S1_summaryaalcalc/P7.bin work/il_S1_summaryleccalc/P7.bin > /dev/null & pid73=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S2_summary_P7 /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P7 /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P7 /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P7 work/il_S2_summaryaalcalc/P7.bin work/il_S2_summaryleccalc/P7.bin > /dev/null & pid74=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S1_summary_P8 /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P8 /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P8 /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P8 work/il_S1_summaryaalcalc/P8.bin work/il_S1_summaryleccalc/P8.bin > /dev/null & pid75=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S2_summary_P8 /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P8 /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P8 /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P8 work/il_S2_summaryaalcalc/P8.bin work/il_S2_summaryleccalc/P8.bin > /dev/null & pid76=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S1_summary_P9 /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P9 /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P9 /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P9 work/il_S1_summaryaalcalc/P9.bin work/il_S1_summaryleccalc/P9.bin > /dev/null & pid77=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S2_summary_P9 /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P9 /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P9 /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P9 work/il_S2_summaryaalcalc/P9.bin work/il_S2_summaryleccalc/P9.bin > /dev/null & pid78=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S1_summary_P10 /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P10 /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P10 /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P10 work/il_S1_summaryaalcalc/P10.bin work/il_S1_summaryleccalc/P10.bin > /dev/null & pid79=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S2_summary_P10 /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P10 /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P10 /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P10 work/il_S2_summaryaalcalc/P10.bin work/il_S2_summaryleccalc/P10.bin > /dev/null & pid80=$!
+
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/il_S1_summary_P1 -2 /tmp/%FIFO_DIR%/fifo/il_S2_summary_P1 < /tmp/%FIFO_DIR%/fifo/il_P1 &
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/il_S1_summary_P2 -2 /tmp/%FIFO_DIR%/fifo/il_S2_summary_P2 < /tmp/%FIFO_DIR%/fifo/il_P2 &
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/il_S1_summary_P3 -2 /tmp/%FIFO_DIR%/fifo/il_S2_summary_P3 < /tmp/%FIFO_DIR%/fifo/il_P3 &
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/il_S1_summary_P4 -2 /tmp/%FIFO_DIR%/fifo/il_S2_summary_P4 < /tmp/%FIFO_DIR%/fifo/il_P4 &
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/il_S1_summary_P5 -2 /tmp/%FIFO_DIR%/fifo/il_S2_summary_P5 < /tmp/%FIFO_DIR%/fifo/il_P5 &
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/il_S1_summary_P6 -2 /tmp/%FIFO_DIR%/fifo/il_S2_summary_P6 < /tmp/%FIFO_DIR%/fifo/il_P6 &
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/il_S1_summary_P7 -2 /tmp/%FIFO_DIR%/fifo/il_S2_summary_P7 < /tmp/%FIFO_DIR%/fifo/il_P7 &
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/il_S1_summary_P8 -2 /tmp/%FIFO_DIR%/fifo/il_S2_summary_P8 < /tmp/%FIFO_DIR%/fifo/il_P8 &
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/il_S1_summary_P9 -2 /tmp/%FIFO_DIR%/fifo/il_S2_summary_P9 < /tmp/%FIFO_DIR%/fifo/il_P9 &
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/il_S1_summary_P10 -2 /tmp/%FIFO_DIR%/fifo/il_S2_summary_P10 < /tmp/%FIFO_DIR%/fifo/il_P10 &
+
+# --- Do ground up loss computes ---
+
+eltcalc < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P1 > work/kat/gul_S1_eltcalc_P1 & pid81=$!
+summarycalctocsv < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P1 > work/kat/gul_S1_summarycalc_P1 & pid82=$!
+pltcalc < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P1 > work/kat/gul_S1_pltcalc_P1 & pid83=$!
+eltcalc < /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P1 > work/kat/gul_S2_eltcalc_P1 & pid84=$!
+summarycalctocsv < /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P1 > work/kat/gul_S2_summarycalc_P1 & pid85=$!
+pltcalc < /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P1 > work/kat/gul_S2_pltcalc_P1 & pid86=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P2 > work/kat/gul_S1_eltcalc_P2 & pid87=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P2 > work/kat/gul_S1_summarycalc_P2 & pid88=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P2 > work/kat/gul_S1_pltcalc_P2 & pid89=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P2 > work/kat/gul_S2_eltcalc_P2 & pid90=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P2 > work/kat/gul_S2_summarycalc_P2 & pid91=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P2 > work/kat/gul_S2_pltcalc_P2 & pid92=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P3 > work/kat/gul_S1_eltcalc_P3 & pid93=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P3 > work/kat/gul_S1_summarycalc_P3 & pid94=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P3 > work/kat/gul_S1_pltcalc_P3 & pid95=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P3 > work/kat/gul_S2_eltcalc_P3 & pid96=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P3 > work/kat/gul_S2_summarycalc_P3 & pid97=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P3 > work/kat/gul_S2_pltcalc_P3 & pid98=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P4 > work/kat/gul_S1_eltcalc_P4 & pid99=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P4 > work/kat/gul_S1_summarycalc_P4 & pid100=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P4 > work/kat/gul_S1_pltcalc_P4 & pid101=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P4 > work/kat/gul_S2_eltcalc_P4 & pid102=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P4 > work/kat/gul_S2_summarycalc_P4 & pid103=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P4 > work/kat/gul_S2_pltcalc_P4 & pid104=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P5 > work/kat/gul_S1_eltcalc_P5 & pid105=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P5 > work/kat/gul_S1_summarycalc_P5 & pid106=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P5 > work/kat/gul_S1_pltcalc_P5 & pid107=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P5 > work/kat/gul_S2_eltcalc_P5 & pid108=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P5 > work/kat/gul_S2_summarycalc_P5 & pid109=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P5 > work/kat/gul_S2_pltcalc_P5 & pid110=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P6 > work/kat/gul_S1_eltcalc_P6 & pid111=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P6 > work/kat/gul_S1_summarycalc_P6 & pid112=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P6 > work/kat/gul_S1_pltcalc_P6 & pid113=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P6 > work/kat/gul_S2_eltcalc_P6 & pid114=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P6 > work/kat/gul_S2_summarycalc_P6 & pid115=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P6 > work/kat/gul_S2_pltcalc_P6 & pid116=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P7 > work/kat/gul_S1_eltcalc_P7 & pid117=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P7 > work/kat/gul_S1_summarycalc_P7 & pid118=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P7 > work/kat/gul_S1_pltcalc_P7 & pid119=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P7 > work/kat/gul_S2_eltcalc_P7 & pid120=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P7 > work/kat/gul_S2_summarycalc_P7 & pid121=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P7 > work/kat/gul_S2_pltcalc_P7 & pid122=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P8 > work/kat/gul_S1_eltcalc_P8 & pid123=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P8 > work/kat/gul_S1_summarycalc_P8 & pid124=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P8 > work/kat/gul_S1_pltcalc_P8 & pid125=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P8 > work/kat/gul_S2_eltcalc_P8 & pid126=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P8 > work/kat/gul_S2_summarycalc_P8 & pid127=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P8 > work/kat/gul_S2_pltcalc_P8 & pid128=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P9 > work/kat/gul_S1_eltcalc_P9 & pid129=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P9 > work/kat/gul_S1_summarycalc_P9 & pid130=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P9 > work/kat/gul_S1_pltcalc_P9 & pid131=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P9 > work/kat/gul_S2_eltcalc_P9 & pid132=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P9 > work/kat/gul_S2_summarycalc_P9 & pid133=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P9 > work/kat/gul_S2_pltcalc_P9 & pid134=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P10 > work/kat/gul_S1_eltcalc_P10 & pid135=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P10 > work/kat/gul_S1_summarycalc_P10 & pid136=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P10 > work/kat/gul_S1_pltcalc_P10 & pid137=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P10 > work/kat/gul_S2_eltcalc_P10 & pid138=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P10 > work/kat/gul_S2_summarycalc_P10 & pid139=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P10 > work/kat/gul_S2_pltcalc_P10 & pid140=$!
+
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P1 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P1 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P1 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P1 work/gul_S1_summaryaalcalc/P1.bin work/gul_S1_summaryleccalc/P1.bin > /dev/null & pid141=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P1 /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P1 /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P1 /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P1 work/gul_S2_summaryaalcalc/P1.bin work/gul_S2_summaryleccalc/P1.bin > /dev/null & pid142=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P2 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P2 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P2 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P2 work/gul_S1_summaryaalcalc/P2.bin work/gul_S1_summaryleccalc/P2.bin > /dev/null & pid143=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P2 /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P2 /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P2 /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P2 work/gul_S2_summaryaalcalc/P2.bin work/gul_S2_summaryleccalc/P2.bin > /dev/null & pid144=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P3 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P3 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P3 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P3 work/gul_S1_summaryaalcalc/P3.bin work/gul_S1_summaryleccalc/P3.bin > /dev/null & pid145=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P3 /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P3 /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P3 /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P3 work/gul_S2_summaryaalcalc/P3.bin work/gul_S2_summaryleccalc/P3.bin > /dev/null & pid146=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P4 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P4 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P4 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P4 work/gul_S1_summaryaalcalc/P4.bin work/gul_S1_summaryleccalc/P4.bin > /dev/null & pid147=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P4 /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P4 /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P4 /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P4 work/gul_S2_summaryaalcalc/P4.bin work/gul_S2_summaryleccalc/P4.bin > /dev/null & pid148=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P5 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P5 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P5 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P5 work/gul_S1_summaryaalcalc/P5.bin work/gul_S1_summaryleccalc/P5.bin > /dev/null & pid149=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P5 /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P5 /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P5 /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P5 work/gul_S2_summaryaalcalc/P5.bin work/gul_S2_summaryleccalc/P5.bin > /dev/null & pid150=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P6 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P6 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P6 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P6 work/gul_S1_summaryaalcalc/P6.bin work/gul_S1_summaryleccalc/P6.bin > /dev/null & pid151=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P6 /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P6 /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P6 /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P6 work/gul_S2_summaryaalcalc/P6.bin work/gul_S2_summaryleccalc/P6.bin > /dev/null & pid152=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P7 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P7 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P7 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P7 work/gul_S1_summaryaalcalc/P7.bin work/gul_S1_summaryleccalc/P7.bin > /dev/null & pid153=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P7 /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P7 /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P7 /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P7 work/gul_S2_summaryaalcalc/P7.bin work/gul_S2_summaryleccalc/P7.bin > /dev/null & pid154=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P8 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P8 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P8 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P8 work/gul_S1_summaryaalcalc/P8.bin work/gul_S1_summaryleccalc/P8.bin > /dev/null & pid155=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P8 /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P8 /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P8 /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P8 work/gul_S2_summaryaalcalc/P8.bin work/gul_S2_summaryleccalc/P8.bin > /dev/null & pid156=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P9 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P9 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P9 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P9 work/gul_S1_summaryaalcalc/P9.bin work/gul_S1_summaryleccalc/P9.bin > /dev/null & pid157=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P9 /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P9 /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P9 /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P9 work/gul_S2_summaryaalcalc/P9.bin work/gul_S2_summaryleccalc/P9.bin > /dev/null & pid158=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P10 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P10 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P10 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P10 work/gul_S1_summaryaalcalc/P10.bin work/gul_S1_summaryleccalc/P10.bin > /dev/null & pid159=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P10 /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P10 /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P10 /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P10 work/gul_S2_summaryaalcalc/P10.bin work/gul_S2_summaryleccalc/P10.bin > /dev/null & pid160=$!
+
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P1 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P1 < /tmp/%FIFO_DIR%/fifo/gul_P1 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P2 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P2 < /tmp/%FIFO_DIR%/fifo/gul_P2 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P3 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P3 < /tmp/%FIFO_DIR%/fifo/gul_P3 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P4 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P4 < /tmp/%FIFO_DIR%/fifo/gul_P4 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P5 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P5 < /tmp/%FIFO_DIR%/fifo/gul_P5 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P6 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P6 < /tmp/%FIFO_DIR%/fifo/gul_P6 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P7 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P7 < /tmp/%FIFO_DIR%/fifo/gul_P7 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P8 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P8 < /tmp/%FIFO_DIR%/fifo/gul_P8 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P9 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P9 < /tmp/%FIFO_DIR%/fifo/gul_P9 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P10 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P10 < /tmp/%FIFO_DIR%/fifo/gul_P10 &
+
+# --- Do insured loss computes ---
+
+eltcalc < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P1 > work/full_correlation/kat/il_S1_eltcalc_P1 & pid161=$!
+summarycalctocsv < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P1 > work/full_correlation/kat/il_S1_summarycalc_P1 & pid162=$!
+pltcalc < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P1 > work/full_correlation/kat/il_S1_pltcalc_P1 & pid163=$!
+eltcalc < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_eltcalc_P1 > work/full_correlation/kat/il_S2_eltcalc_P1 & pid164=$!
+summarycalctocsv < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summarycalc_P1 > work/full_correlation/kat/il_S2_summarycalc_P1 & pid165=$!
+pltcalc < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_pltcalc_P1 > work/full_correlation/kat/il_S2_pltcalc_P1 & pid166=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P2 > work/full_correlation/kat/il_S1_eltcalc_P2 & pid167=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P2 > work/full_correlation/kat/il_S1_summarycalc_P2 & pid168=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P2 > work/full_correlation/kat/il_S1_pltcalc_P2 & pid169=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_eltcalc_P2 > work/full_correlation/kat/il_S2_eltcalc_P2 & pid170=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summarycalc_P2 > work/full_correlation/kat/il_S2_summarycalc_P2 & pid171=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_pltcalc_P2 > work/full_correlation/kat/il_S2_pltcalc_P2 & pid172=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P3 > work/full_correlation/kat/il_S1_eltcalc_P3 & pid173=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P3 > work/full_correlation/kat/il_S1_summarycalc_P3 & pid174=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P3 > work/full_correlation/kat/il_S1_pltcalc_P3 & pid175=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_eltcalc_P3 > work/full_correlation/kat/il_S2_eltcalc_P3 & pid176=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summarycalc_P3 > work/full_correlation/kat/il_S2_summarycalc_P3 & pid177=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_pltcalc_P3 > work/full_correlation/kat/il_S2_pltcalc_P3 & pid178=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P4 > work/full_correlation/kat/il_S1_eltcalc_P4 & pid179=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P4 > work/full_correlation/kat/il_S1_summarycalc_P4 & pid180=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P4 > work/full_correlation/kat/il_S1_pltcalc_P4 & pid181=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_eltcalc_P4 > work/full_correlation/kat/il_S2_eltcalc_P4 & pid182=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summarycalc_P4 > work/full_correlation/kat/il_S2_summarycalc_P4 & pid183=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_pltcalc_P4 > work/full_correlation/kat/il_S2_pltcalc_P4 & pid184=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P5 > work/full_correlation/kat/il_S1_eltcalc_P5 & pid185=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P5 > work/full_correlation/kat/il_S1_summarycalc_P5 & pid186=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P5 > work/full_correlation/kat/il_S1_pltcalc_P5 & pid187=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_eltcalc_P5 > work/full_correlation/kat/il_S2_eltcalc_P5 & pid188=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summarycalc_P5 > work/full_correlation/kat/il_S2_summarycalc_P5 & pid189=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_pltcalc_P5 > work/full_correlation/kat/il_S2_pltcalc_P5 & pid190=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P6 > work/full_correlation/kat/il_S1_eltcalc_P6 & pid191=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P6 > work/full_correlation/kat/il_S1_summarycalc_P6 & pid192=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P6 > work/full_correlation/kat/il_S1_pltcalc_P6 & pid193=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_eltcalc_P6 > work/full_correlation/kat/il_S2_eltcalc_P6 & pid194=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summarycalc_P6 > work/full_correlation/kat/il_S2_summarycalc_P6 & pid195=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_pltcalc_P6 > work/full_correlation/kat/il_S2_pltcalc_P6 & pid196=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P7 > work/full_correlation/kat/il_S1_eltcalc_P7 & pid197=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P7 > work/full_correlation/kat/il_S1_summarycalc_P7 & pid198=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P7 > work/full_correlation/kat/il_S1_pltcalc_P7 & pid199=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_eltcalc_P7 > work/full_correlation/kat/il_S2_eltcalc_P7 & pid200=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summarycalc_P7 > work/full_correlation/kat/il_S2_summarycalc_P7 & pid201=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_pltcalc_P7 > work/full_correlation/kat/il_S2_pltcalc_P7 & pid202=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P8 > work/full_correlation/kat/il_S1_eltcalc_P8 & pid203=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P8 > work/full_correlation/kat/il_S1_summarycalc_P8 & pid204=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P8 > work/full_correlation/kat/il_S1_pltcalc_P8 & pid205=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_eltcalc_P8 > work/full_correlation/kat/il_S2_eltcalc_P8 & pid206=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summarycalc_P8 > work/full_correlation/kat/il_S2_summarycalc_P8 & pid207=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_pltcalc_P8 > work/full_correlation/kat/il_S2_pltcalc_P8 & pid208=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P9 > work/full_correlation/kat/il_S1_eltcalc_P9 & pid209=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P9 > work/full_correlation/kat/il_S1_summarycalc_P9 & pid210=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P9 > work/full_correlation/kat/il_S1_pltcalc_P9 & pid211=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_eltcalc_P9 > work/full_correlation/kat/il_S2_eltcalc_P9 & pid212=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summarycalc_P9 > work/full_correlation/kat/il_S2_summarycalc_P9 & pid213=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_pltcalc_P9 > work/full_correlation/kat/il_S2_pltcalc_P9 & pid214=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P10 > work/full_correlation/kat/il_S1_eltcalc_P10 & pid215=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P10 > work/full_correlation/kat/il_S1_summarycalc_P10 & pid216=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P10 > work/full_correlation/kat/il_S1_pltcalc_P10 & pid217=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_eltcalc_P10 > work/full_correlation/kat/il_S2_eltcalc_P10 & pid218=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summarycalc_P10 > work/full_correlation/kat/il_S2_summarycalc_P10 & pid219=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_pltcalc_P10 > work/full_correlation/kat/il_S2_pltcalc_P10 & pid220=$!
+
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P1 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P1 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P1 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P1 work/full_correlation/il_S1_summaryaalcalc/P1.bin work/full_correlation/il_S1_summaryleccalc/P1.bin > /dev/null & pid221=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summary_P1 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_eltcalc_P1 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summarycalc_P1 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_pltcalc_P1 work/full_correlation/il_S2_summaryaalcalc/P1.bin work/full_correlation/il_S2_summaryleccalc/P1.bin > /dev/null & pid222=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P2 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P2 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P2 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P2 work/full_correlation/il_S1_summaryaalcalc/P2.bin work/full_correlation/il_S1_summaryleccalc/P2.bin > /dev/null & pid223=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summary_P2 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_eltcalc_P2 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summarycalc_P2 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_pltcalc_P2 work/full_correlation/il_S2_summaryaalcalc/P2.bin work/full_correlation/il_S2_summaryleccalc/P2.bin > /dev/null & pid224=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P3 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P3 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P3 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P3 work/full_correlation/il_S1_summaryaalcalc/P3.bin work/full_correlation/il_S1_summaryleccalc/P3.bin > /dev/null & pid225=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summary_P3 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_eltcalc_P3 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summarycalc_P3 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_pltcalc_P3 work/full_correlation/il_S2_summaryaalcalc/P3.bin work/full_correlation/il_S2_summaryleccalc/P3.bin > /dev/null & pid226=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P4 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P4 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P4 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P4 work/full_correlation/il_S1_summaryaalcalc/P4.bin work/full_correlation/il_S1_summaryleccalc/P4.bin > /dev/null & pid227=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summary_P4 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_eltcalc_P4 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summarycalc_P4 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_pltcalc_P4 work/full_correlation/il_S2_summaryaalcalc/P4.bin work/full_correlation/il_S2_summaryleccalc/P4.bin > /dev/null & pid228=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P5 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P5 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P5 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P5 work/full_correlation/il_S1_summaryaalcalc/P5.bin work/full_correlation/il_S1_summaryleccalc/P5.bin > /dev/null & pid229=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summary_P5 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_eltcalc_P5 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summarycalc_P5 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_pltcalc_P5 work/full_correlation/il_S2_summaryaalcalc/P5.bin work/full_correlation/il_S2_summaryleccalc/P5.bin > /dev/null & pid230=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P6 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P6 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P6 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P6 work/full_correlation/il_S1_summaryaalcalc/P6.bin work/full_correlation/il_S1_summaryleccalc/P6.bin > /dev/null & pid231=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summary_P6 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_eltcalc_P6 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summarycalc_P6 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_pltcalc_P6 work/full_correlation/il_S2_summaryaalcalc/P6.bin work/full_correlation/il_S2_summaryleccalc/P6.bin > /dev/null & pid232=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P7 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P7 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P7 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P7 work/full_correlation/il_S1_summaryaalcalc/P7.bin work/full_correlation/il_S1_summaryleccalc/P7.bin > /dev/null & pid233=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summary_P7 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_eltcalc_P7 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summarycalc_P7 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_pltcalc_P7 work/full_correlation/il_S2_summaryaalcalc/P7.bin work/full_correlation/il_S2_summaryleccalc/P7.bin > /dev/null & pid234=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P8 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P8 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P8 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P8 work/full_correlation/il_S1_summaryaalcalc/P8.bin work/full_correlation/il_S1_summaryleccalc/P8.bin > /dev/null & pid235=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summary_P8 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_eltcalc_P8 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summarycalc_P8 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_pltcalc_P8 work/full_correlation/il_S2_summaryaalcalc/P8.bin work/full_correlation/il_S2_summaryleccalc/P8.bin > /dev/null & pid236=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P9 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P9 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P9 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P9 work/full_correlation/il_S1_summaryaalcalc/P9.bin work/full_correlation/il_S1_summaryleccalc/P9.bin > /dev/null & pid237=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summary_P9 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_eltcalc_P9 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summarycalc_P9 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_pltcalc_P9 work/full_correlation/il_S2_summaryaalcalc/P9.bin work/full_correlation/il_S2_summaryleccalc/P9.bin > /dev/null & pid238=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P10 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P10 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P10 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P10 work/full_correlation/il_S1_summaryaalcalc/P10.bin work/full_correlation/il_S1_summaryleccalc/P10.bin > /dev/null & pid239=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summary_P10 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_eltcalc_P10 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summarycalc_P10 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_pltcalc_P10 work/full_correlation/il_S2_summaryaalcalc/P10.bin work/full_correlation/il_S2_summaryleccalc/P10.bin > /dev/null & pid240=$!
+
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P1 -2 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summary_P1 < /tmp/%FIFO_DIR%/fifo/full_correlation/il_P1 &
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P2 -2 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summary_P2 < /tmp/%FIFO_DIR%/fifo/full_correlation/il_P2 &
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P3 -2 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summary_P3 < /tmp/%FIFO_DIR%/fifo/full_correlation/il_P3 &
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P4 -2 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summary_P4 < /tmp/%FIFO_DIR%/fifo/full_correlation/il_P4 &
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P5 -2 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summary_P5 < /tmp/%FIFO_DIR%/fifo/full_correlation/il_P5 &
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P6 -2 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summary_P6 < /tmp/%FIFO_DIR%/fifo/full_correlation/il_P6 &
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P7 -2 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summary_P7 < /tmp/%FIFO_DIR%/fifo/full_correlation/il_P7 &
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P8 -2 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summary_P8 < /tmp/%FIFO_DIR%/fifo/full_correlation/il_P8 &
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P9 -2 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summary_P9 < /tmp/%FIFO_DIR%/fifo/full_correlation/il_P9 &
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P10 -2 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S2_summary_P10 < /tmp/%FIFO_DIR%/fifo/full_correlation/il_P10 &
+
+# --- Do ground up loss computes ---
+
+eltcalc < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P1 > work/full_correlation/kat/gul_S1_eltcalc_P1 & pid241=$!
+summarycalctocsv < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P1 > work/full_correlation/kat/gul_S1_summarycalc_P1 & pid242=$!
+pltcalc < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P1 > work/full_correlation/kat/gul_S1_pltcalc_P1 & pid243=$!
+eltcalc < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P1 > work/full_correlation/kat/gul_S2_eltcalc_P1 & pid244=$!
+summarycalctocsv < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P1 > work/full_correlation/kat/gul_S2_summarycalc_P1 & pid245=$!
+pltcalc < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P1 > work/full_correlation/kat/gul_S2_pltcalc_P1 & pid246=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P2 > work/full_correlation/kat/gul_S1_eltcalc_P2 & pid247=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P2 > work/full_correlation/kat/gul_S1_summarycalc_P2 & pid248=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P2 > work/full_correlation/kat/gul_S1_pltcalc_P2 & pid249=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P2 > work/full_correlation/kat/gul_S2_eltcalc_P2 & pid250=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P2 > work/full_correlation/kat/gul_S2_summarycalc_P2 & pid251=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P2 > work/full_correlation/kat/gul_S2_pltcalc_P2 & pid252=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P3 > work/full_correlation/kat/gul_S1_eltcalc_P3 & pid253=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P3 > work/full_correlation/kat/gul_S1_summarycalc_P3 & pid254=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P3 > work/full_correlation/kat/gul_S1_pltcalc_P3 & pid255=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P3 > work/full_correlation/kat/gul_S2_eltcalc_P3 & pid256=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P3 > work/full_correlation/kat/gul_S2_summarycalc_P3 & pid257=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P3 > work/full_correlation/kat/gul_S2_pltcalc_P3 & pid258=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P4 > work/full_correlation/kat/gul_S1_eltcalc_P4 & pid259=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P4 > work/full_correlation/kat/gul_S1_summarycalc_P4 & pid260=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P4 > work/full_correlation/kat/gul_S1_pltcalc_P4 & pid261=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P4 > work/full_correlation/kat/gul_S2_eltcalc_P4 & pid262=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P4 > work/full_correlation/kat/gul_S2_summarycalc_P4 & pid263=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P4 > work/full_correlation/kat/gul_S2_pltcalc_P4 & pid264=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P5 > work/full_correlation/kat/gul_S1_eltcalc_P5 & pid265=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P5 > work/full_correlation/kat/gul_S1_summarycalc_P5 & pid266=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P5 > work/full_correlation/kat/gul_S1_pltcalc_P5 & pid267=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P5 > work/full_correlation/kat/gul_S2_eltcalc_P5 & pid268=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P5 > work/full_correlation/kat/gul_S2_summarycalc_P5 & pid269=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P5 > work/full_correlation/kat/gul_S2_pltcalc_P5 & pid270=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P6 > work/full_correlation/kat/gul_S1_eltcalc_P6 & pid271=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P6 > work/full_correlation/kat/gul_S1_summarycalc_P6 & pid272=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P6 > work/full_correlation/kat/gul_S1_pltcalc_P6 & pid273=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P6 > work/full_correlation/kat/gul_S2_eltcalc_P6 & pid274=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P6 > work/full_correlation/kat/gul_S2_summarycalc_P6 & pid275=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P6 > work/full_correlation/kat/gul_S2_pltcalc_P6 & pid276=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P7 > work/full_correlation/kat/gul_S1_eltcalc_P7 & pid277=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P7 > work/full_correlation/kat/gul_S1_summarycalc_P7 & pid278=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P7 > work/full_correlation/kat/gul_S1_pltcalc_P7 & pid279=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P7 > work/full_correlation/kat/gul_S2_eltcalc_P7 & pid280=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P7 > work/full_correlation/kat/gul_S2_summarycalc_P7 & pid281=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P7 > work/full_correlation/kat/gul_S2_pltcalc_P7 & pid282=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P8 > work/full_correlation/kat/gul_S1_eltcalc_P8 & pid283=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P8 > work/full_correlation/kat/gul_S1_summarycalc_P8 & pid284=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P8 > work/full_correlation/kat/gul_S1_pltcalc_P8 & pid285=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P8 > work/full_correlation/kat/gul_S2_eltcalc_P8 & pid286=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P8 > work/full_correlation/kat/gul_S2_summarycalc_P8 & pid287=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P8 > work/full_correlation/kat/gul_S2_pltcalc_P8 & pid288=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P9 > work/full_correlation/kat/gul_S1_eltcalc_P9 & pid289=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P9 > work/full_correlation/kat/gul_S1_summarycalc_P9 & pid290=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P9 > work/full_correlation/kat/gul_S1_pltcalc_P9 & pid291=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P9 > work/full_correlation/kat/gul_S2_eltcalc_P9 & pid292=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P9 > work/full_correlation/kat/gul_S2_summarycalc_P9 & pid293=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P9 > work/full_correlation/kat/gul_S2_pltcalc_P9 & pid294=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P10 > work/full_correlation/kat/gul_S1_eltcalc_P10 & pid295=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P10 > work/full_correlation/kat/gul_S1_summarycalc_P10 & pid296=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P10 > work/full_correlation/kat/gul_S1_pltcalc_P10 & pid297=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P10 > work/full_correlation/kat/gul_S2_eltcalc_P10 & pid298=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P10 > work/full_correlation/kat/gul_S2_summarycalc_P10 & pid299=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P10 > work/full_correlation/kat/gul_S2_pltcalc_P10 & pid300=$!
+
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P1 work/full_correlation/gul_S1_summaryaalcalc/P1.bin work/full_correlation/gul_S1_summaryleccalc/P1.bin > /dev/null & pid301=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P1 work/full_correlation/gul_S2_summaryaalcalc/P1.bin work/full_correlation/gul_S2_summaryleccalc/P1.bin > /dev/null & pid302=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P2 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P2 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P2 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P2 work/full_correlation/gul_S1_summaryaalcalc/P2.bin work/full_correlation/gul_S1_summaryleccalc/P2.bin > /dev/null & pid303=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P2 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P2 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P2 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P2 work/full_correlation/gul_S2_summaryaalcalc/P2.bin work/full_correlation/gul_S2_summaryleccalc/P2.bin > /dev/null & pid304=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P3 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P3 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P3 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P3 work/full_correlation/gul_S1_summaryaalcalc/P3.bin work/full_correlation/gul_S1_summaryleccalc/P3.bin > /dev/null & pid305=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P3 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P3 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P3 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P3 work/full_correlation/gul_S2_summaryaalcalc/P3.bin work/full_correlation/gul_S2_summaryleccalc/P3.bin > /dev/null & pid306=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P4 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P4 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P4 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P4 work/full_correlation/gul_S1_summaryaalcalc/P4.bin work/full_correlation/gul_S1_summaryleccalc/P4.bin > /dev/null & pid307=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P4 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P4 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P4 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P4 work/full_correlation/gul_S2_summaryaalcalc/P4.bin work/full_correlation/gul_S2_summaryleccalc/P4.bin > /dev/null & pid308=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P5 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P5 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P5 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P5 work/full_correlation/gul_S1_summaryaalcalc/P5.bin work/full_correlation/gul_S1_summaryleccalc/P5.bin > /dev/null & pid309=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P5 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P5 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P5 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P5 work/full_correlation/gul_S2_summaryaalcalc/P5.bin work/full_correlation/gul_S2_summaryleccalc/P5.bin > /dev/null & pid310=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P6 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P6 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P6 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P6 work/full_correlation/gul_S1_summaryaalcalc/P6.bin work/full_correlation/gul_S1_summaryleccalc/P6.bin > /dev/null & pid311=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P6 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P6 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P6 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P6 work/full_correlation/gul_S2_summaryaalcalc/P6.bin work/full_correlation/gul_S2_summaryleccalc/P6.bin > /dev/null & pid312=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P7 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P7 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P7 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P7 work/full_correlation/gul_S1_summaryaalcalc/P7.bin work/full_correlation/gul_S1_summaryleccalc/P7.bin > /dev/null & pid313=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P7 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P7 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P7 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P7 work/full_correlation/gul_S2_summaryaalcalc/P7.bin work/full_correlation/gul_S2_summaryleccalc/P7.bin > /dev/null & pid314=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P8 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P8 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P8 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P8 work/full_correlation/gul_S1_summaryaalcalc/P8.bin work/full_correlation/gul_S1_summaryleccalc/P8.bin > /dev/null & pid315=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P8 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P8 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P8 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P8 work/full_correlation/gul_S2_summaryaalcalc/P8.bin work/full_correlation/gul_S2_summaryleccalc/P8.bin > /dev/null & pid316=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P9 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P9 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P9 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P9 work/full_correlation/gul_S1_summaryaalcalc/P9.bin work/full_correlation/gul_S1_summaryleccalc/P9.bin > /dev/null & pid317=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P9 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P9 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P9 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P9 work/full_correlation/gul_S2_summaryaalcalc/P9.bin work/full_correlation/gul_S2_summaryleccalc/P9.bin > /dev/null & pid318=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P10 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P10 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P10 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P10 work/full_correlation/gul_S1_summaryaalcalc/P10.bin work/full_correlation/gul_S1_summaryleccalc/P10.bin > /dev/null & pid319=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P10 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P10 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P10 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P10 work/full_correlation/gul_S2_summaryaalcalc/P10.bin work/full_correlation/gul_S2_summaryleccalc/P10.bin > /dev/null & pid320=$!
+
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P1 -2 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P1 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P1 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P2 -2 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P2 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P2 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P3 -2 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P3 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P3 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P4 -2 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P4 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P4 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P5 -2 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P5 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P5 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P6 -2 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P6 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P6 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P7 -2 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P7 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P7 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P8 -2 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P8 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P8 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P9 -2 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P9 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P9 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P10 -2 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P10 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P10 &
+
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P1  | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/full_correlation/il_P1  &
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P2 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P2  | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/full_correlation/il_P2  &
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P3 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P3  | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/full_correlation/il_P3  &
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P4 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P4  | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/full_correlation/il_P4  &
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P5 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P5  | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/full_correlation/il_P5  &
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P6 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P6  | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/full_correlation/il_P6  &
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P7 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P7  | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/full_correlation/il_P7  &
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P8 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P8  | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/full_correlation/il_P8  &
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P9 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P9  | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/full_correlation/il_P9  &
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P10 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P10  | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/full_correlation/il_P10  &
+eve 1 10 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P1 -a1 -i - | tee /tmp/%FIFO_DIR%/fifo/gul_P1 | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/il_P1  &
+eve 2 10 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P2 -a1 -i - | tee /tmp/%FIFO_DIR%/fifo/gul_P2 | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/il_P2  &
+eve 3 10 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P3 -a1 -i - | tee /tmp/%FIFO_DIR%/fifo/gul_P3 | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/il_P3  &
+eve 4 10 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P4 -a1 -i - | tee /tmp/%FIFO_DIR%/fifo/gul_P4 | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/il_P4  &
+eve 5 10 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P5 -a1 -i - | tee /tmp/%FIFO_DIR%/fifo/gul_P5 | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/il_P5  &
+eve 6 10 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P6 -a1 -i - | tee /tmp/%FIFO_DIR%/fifo/gul_P6 | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/il_P6  &
+eve 7 10 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P7 -a1 -i - | tee /tmp/%FIFO_DIR%/fifo/gul_P7 | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/il_P7  &
+eve 8 10 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P8 -a1 -i - | tee /tmp/%FIFO_DIR%/fifo/gul_P8 | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/il_P8  &
+eve 9 10 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P9 -a1 -i - | tee /tmp/%FIFO_DIR%/fifo/gul_P9 | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/il_P9  &
+eve 10 10 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P10 -a1 -i - | tee /tmp/%FIFO_DIR%/fifo/gul_P10 | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/il_P10  &
+
+wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 $pid13 $pid14 $pid15 $pid16 $pid17 $pid18 $pid19 $pid20 $pid21 $pid22 $pid23 $pid24 $pid25 $pid26 $pid27 $pid28 $pid29 $pid30 $pid31 $pid32 $pid33 $pid34 $pid35 $pid36 $pid37 $pid38 $pid39 $pid40 $pid41 $pid42 $pid43 $pid44 $pid45 $pid46 $pid47 $pid48 $pid49 $pid50 $pid51 $pid52 $pid53 $pid54 $pid55 $pid56 $pid57 $pid58 $pid59 $pid60 $pid61 $pid62 $pid63 $pid64 $pid65 $pid66 $pid67 $pid68 $pid69 $pid70 $pid71 $pid72 $pid73 $pid74 $pid75 $pid76 $pid77 $pid78 $pid79 $pid80 $pid81 $pid82 $pid83 $pid84 $pid85 $pid86 $pid87 $pid88 $pid89 $pid90 $pid91 $pid92 $pid93 $pid94 $pid95 $pid96 $pid97 $pid98 $pid99 $pid100 $pid101 $pid102 $pid103 $pid104 $pid105 $pid106 $pid107 $pid108 $pid109 $pid110 $pid111 $pid112 $pid113 $pid114 $pid115 $pid116 $pid117 $pid118 $pid119 $pid120 $pid121 $pid122 $pid123 $pid124 $pid125 $pid126 $pid127 $pid128 $pid129 $pid130 $pid131 $pid132 $pid133 $pid134 $pid135 $pid136 $pid137 $pid138 $pid139 $pid140 $pid141 $pid142 $pid143 $pid144 $pid145 $pid146 $pid147 $pid148 $pid149 $pid150 $pid151 $pid152 $pid153 $pid154 $pid155 $pid156 $pid157 $pid158 $pid159 $pid160 $pid161 $pid162 $pid163 $pid164 $pid165 $pid166 $pid167 $pid168 $pid169 $pid170 $pid171 $pid172 $pid173 $pid174 $pid175 $pid176 $pid177 $pid178 $pid179 $pid180 $pid181 $pid182 $pid183 $pid184 $pid185 $pid186 $pid187 $pid188 $pid189 $pid190 $pid191 $pid192 $pid193 $pid194 $pid195 $pid196 $pid197 $pid198 $pid199 $pid200 $pid201 $pid202 $pid203 $pid204 $pid205 $pid206 $pid207 $pid208 $pid209 $pid210 $pid211 $pid212 $pid213 $pid214 $pid215 $pid216 $pid217 $pid218 $pid219 $pid220 $pid221 $pid222 $pid223 $pid224 $pid225 $pid226 $pid227 $pid228 $pid229 $pid230 $pid231 $pid232 $pid233 $pid234 $pid235 $pid236 $pid237 $pid238 $pid239 $pid240 $pid241 $pid242 $pid243 $pid244 $pid245 $pid246 $pid247 $pid248 $pid249 $pid250 $pid251 $pid252 $pid253 $pid254 $pid255 $pid256 $pid257 $pid258 $pid259 $pid260 $pid261 $pid262 $pid263 $pid264 $pid265 $pid266 $pid267 $pid268 $pid269 $pid270 $pid271 $pid272 $pid273 $pid274 $pid275 $pid276 $pid277 $pid278 $pid279 $pid280 $pid281 $pid282 $pid283 $pid284 $pid285 $pid286 $pid287 $pid288 $pid289 $pid290 $pid291 $pid292 $pid293 $pid294 $pid295 $pid296 $pid297 $pid298 $pid299 $pid300 $pid301 $pid302 $pid303 $pid304 $pid305 $pid306 $pid307 $pid308 $pid309 $pid310 $pid311 $pid312 $pid313 $pid314 $pid315 $pid316 $pid317 $pid318 $pid319 $pid320
+
+
+# --- Do insured loss kats ---
+
+kat -s work/kat/il_S1_eltcalc_P1 work/kat/il_S1_eltcalc_P2 work/kat/il_S1_eltcalc_P3 work/kat/il_S1_eltcalc_P4 work/kat/il_S1_eltcalc_P5 work/kat/il_S1_eltcalc_P6 work/kat/il_S1_eltcalc_P7 work/kat/il_S1_eltcalc_P8 work/kat/il_S1_eltcalc_P9 work/kat/il_S1_eltcalc_P10 > output/il_S1_eltcalc.csv & kpid1=$!
+kat work/kat/il_S1_pltcalc_P1 work/kat/il_S1_pltcalc_P2 work/kat/il_S1_pltcalc_P3 work/kat/il_S1_pltcalc_P4 work/kat/il_S1_pltcalc_P5 work/kat/il_S1_pltcalc_P6 work/kat/il_S1_pltcalc_P7 work/kat/il_S1_pltcalc_P8 work/kat/il_S1_pltcalc_P9 work/kat/il_S1_pltcalc_P10 > output/il_S1_pltcalc.csv & kpid2=$!
+kat work/kat/il_S1_summarycalc_P1 work/kat/il_S1_summarycalc_P2 work/kat/il_S1_summarycalc_P3 work/kat/il_S1_summarycalc_P4 work/kat/il_S1_summarycalc_P5 work/kat/il_S1_summarycalc_P6 work/kat/il_S1_summarycalc_P7 work/kat/il_S1_summarycalc_P8 work/kat/il_S1_summarycalc_P9 work/kat/il_S1_summarycalc_P10 > output/il_S1_summarycalc.csv & kpid3=$!
+kat -s work/kat/il_S2_eltcalc_P1 work/kat/il_S2_eltcalc_P2 work/kat/il_S2_eltcalc_P3 work/kat/il_S2_eltcalc_P4 work/kat/il_S2_eltcalc_P5 work/kat/il_S2_eltcalc_P6 work/kat/il_S2_eltcalc_P7 work/kat/il_S2_eltcalc_P8 work/kat/il_S2_eltcalc_P9 work/kat/il_S2_eltcalc_P10 > output/il_S2_eltcalc.csv & kpid4=$!
+kat work/kat/il_S2_pltcalc_P1 work/kat/il_S2_pltcalc_P2 work/kat/il_S2_pltcalc_P3 work/kat/il_S2_pltcalc_P4 work/kat/il_S2_pltcalc_P5 work/kat/il_S2_pltcalc_P6 work/kat/il_S2_pltcalc_P7 work/kat/il_S2_pltcalc_P8 work/kat/il_S2_pltcalc_P9 work/kat/il_S2_pltcalc_P10 > output/il_S2_pltcalc.csv & kpid5=$!
+kat work/kat/il_S2_summarycalc_P1 work/kat/il_S2_summarycalc_P2 work/kat/il_S2_summarycalc_P3 work/kat/il_S2_summarycalc_P4 work/kat/il_S2_summarycalc_P5 work/kat/il_S2_summarycalc_P6 work/kat/il_S2_summarycalc_P7 work/kat/il_S2_summarycalc_P8 work/kat/il_S2_summarycalc_P9 work/kat/il_S2_summarycalc_P10 > output/il_S2_summarycalc.csv & kpid6=$!
+
+# --- Do insured loss kats for fully correlated output ---
+
+kat -s work/full_correlation/kat/il_S1_eltcalc_P1 work/full_correlation/kat/il_S1_eltcalc_P2 work/full_correlation/kat/il_S1_eltcalc_P3 work/full_correlation/kat/il_S1_eltcalc_P4 work/full_correlation/kat/il_S1_eltcalc_P5 work/full_correlation/kat/il_S1_eltcalc_P6 work/full_correlation/kat/il_S1_eltcalc_P7 work/full_correlation/kat/il_S1_eltcalc_P8 work/full_correlation/kat/il_S1_eltcalc_P9 work/full_correlation/kat/il_S1_eltcalc_P10 > output/full_correlation/il_S1_eltcalc.csv & kpid7=$!
+kat work/full_correlation/kat/il_S1_pltcalc_P1 work/full_correlation/kat/il_S1_pltcalc_P2 work/full_correlation/kat/il_S1_pltcalc_P3 work/full_correlation/kat/il_S1_pltcalc_P4 work/full_correlation/kat/il_S1_pltcalc_P5 work/full_correlation/kat/il_S1_pltcalc_P6 work/full_correlation/kat/il_S1_pltcalc_P7 work/full_correlation/kat/il_S1_pltcalc_P8 work/full_correlation/kat/il_S1_pltcalc_P9 work/full_correlation/kat/il_S1_pltcalc_P10 > output/full_correlation/il_S1_pltcalc.csv & kpid8=$!
+kat work/full_correlation/kat/il_S1_summarycalc_P1 work/full_correlation/kat/il_S1_summarycalc_P2 work/full_correlation/kat/il_S1_summarycalc_P3 work/full_correlation/kat/il_S1_summarycalc_P4 work/full_correlation/kat/il_S1_summarycalc_P5 work/full_correlation/kat/il_S1_summarycalc_P6 work/full_correlation/kat/il_S1_summarycalc_P7 work/full_correlation/kat/il_S1_summarycalc_P8 work/full_correlation/kat/il_S1_summarycalc_P9 work/full_correlation/kat/il_S1_summarycalc_P10 > output/full_correlation/il_S1_summarycalc.csv & kpid9=$!
+kat -s work/full_correlation/kat/il_S2_eltcalc_P1 work/full_correlation/kat/il_S2_eltcalc_P2 work/full_correlation/kat/il_S2_eltcalc_P3 work/full_correlation/kat/il_S2_eltcalc_P4 work/full_correlation/kat/il_S2_eltcalc_P5 work/full_correlation/kat/il_S2_eltcalc_P6 work/full_correlation/kat/il_S2_eltcalc_P7 work/full_correlation/kat/il_S2_eltcalc_P8 work/full_correlation/kat/il_S2_eltcalc_P9 work/full_correlation/kat/il_S2_eltcalc_P10 > output/full_correlation/il_S2_eltcalc.csv & kpid10=$!
+kat work/full_correlation/kat/il_S2_pltcalc_P1 work/full_correlation/kat/il_S2_pltcalc_P2 work/full_correlation/kat/il_S2_pltcalc_P3 work/full_correlation/kat/il_S2_pltcalc_P4 work/full_correlation/kat/il_S2_pltcalc_P5 work/full_correlation/kat/il_S2_pltcalc_P6 work/full_correlation/kat/il_S2_pltcalc_P7 work/full_correlation/kat/il_S2_pltcalc_P8 work/full_correlation/kat/il_S2_pltcalc_P9 work/full_correlation/kat/il_S2_pltcalc_P10 > output/full_correlation/il_S2_pltcalc.csv & kpid11=$!
+kat work/full_correlation/kat/il_S2_summarycalc_P1 work/full_correlation/kat/il_S2_summarycalc_P2 work/full_correlation/kat/il_S2_summarycalc_P3 work/full_correlation/kat/il_S2_summarycalc_P4 work/full_correlation/kat/il_S2_summarycalc_P5 work/full_correlation/kat/il_S2_summarycalc_P6 work/full_correlation/kat/il_S2_summarycalc_P7 work/full_correlation/kat/il_S2_summarycalc_P8 work/full_correlation/kat/il_S2_summarycalc_P9 work/full_correlation/kat/il_S2_summarycalc_P10 > output/full_correlation/il_S2_summarycalc.csv & kpid12=$!
+
+# --- Do ground up loss kats ---
+
+kat -s work/kat/gul_S1_eltcalc_P1 work/kat/gul_S1_eltcalc_P2 work/kat/gul_S1_eltcalc_P3 work/kat/gul_S1_eltcalc_P4 work/kat/gul_S1_eltcalc_P5 work/kat/gul_S1_eltcalc_P6 work/kat/gul_S1_eltcalc_P7 work/kat/gul_S1_eltcalc_P8 work/kat/gul_S1_eltcalc_P9 work/kat/gul_S1_eltcalc_P10 > output/gul_S1_eltcalc.csv & kpid13=$!
+kat work/kat/gul_S1_pltcalc_P1 work/kat/gul_S1_pltcalc_P2 work/kat/gul_S1_pltcalc_P3 work/kat/gul_S1_pltcalc_P4 work/kat/gul_S1_pltcalc_P5 work/kat/gul_S1_pltcalc_P6 work/kat/gul_S1_pltcalc_P7 work/kat/gul_S1_pltcalc_P8 work/kat/gul_S1_pltcalc_P9 work/kat/gul_S1_pltcalc_P10 > output/gul_S1_pltcalc.csv & kpid14=$!
+kat work/kat/gul_S1_summarycalc_P1 work/kat/gul_S1_summarycalc_P2 work/kat/gul_S1_summarycalc_P3 work/kat/gul_S1_summarycalc_P4 work/kat/gul_S1_summarycalc_P5 work/kat/gul_S1_summarycalc_P6 work/kat/gul_S1_summarycalc_P7 work/kat/gul_S1_summarycalc_P8 work/kat/gul_S1_summarycalc_P9 work/kat/gul_S1_summarycalc_P10 > output/gul_S1_summarycalc.csv & kpid15=$!
+kat -s work/kat/gul_S2_eltcalc_P1 work/kat/gul_S2_eltcalc_P2 work/kat/gul_S2_eltcalc_P3 work/kat/gul_S2_eltcalc_P4 work/kat/gul_S2_eltcalc_P5 work/kat/gul_S2_eltcalc_P6 work/kat/gul_S2_eltcalc_P7 work/kat/gul_S2_eltcalc_P8 work/kat/gul_S2_eltcalc_P9 work/kat/gul_S2_eltcalc_P10 > output/gul_S2_eltcalc.csv & kpid16=$!
+kat work/kat/gul_S2_pltcalc_P1 work/kat/gul_S2_pltcalc_P2 work/kat/gul_S2_pltcalc_P3 work/kat/gul_S2_pltcalc_P4 work/kat/gul_S2_pltcalc_P5 work/kat/gul_S2_pltcalc_P6 work/kat/gul_S2_pltcalc_P7 work/kat/gul_S2_pltcalc_P8 work/kat/gul_S2_pltcalc_P9 work/kat/gul_S2_pltcalc_P10 > output/gul_S2_pltcalc.csv & kpid17=$!
+kat work/kat/gul_S2_summarycalc_P1 work/kat/gul_S2_summarycalc_P2 work/kat/gul_S2_summarycalc_P3 work/kat/gul_S2_summarycalc_P4 work/kat/gul_S2_summarycalc_P5 work/kat/gul_S2_summarycalc_P6 work/kat/gul_S2_summarycalc_P7 work/kat/gul_S2_summarycalc_P8 work/kat/gul_S2_summarycalc_P9 work/kat/gul_S2_summarycalc_P10 > output/gul_S2_summarycalc.csv & kpid18=$!
+
+# --- Do ground up loss kats for fully correlated output ---
+
+kat -s work/full_correlation/kat/gul_S1_eltcalc_P1 work/full_correlation/kat/gul_S1_eltcalc_P2 work/full_correlation/kat/gul_S1_eltcalc_P3 work/full_correlation/kat/gul_S1_eltcalc_P4 work/full_correlation/kat/gul_S1_eltcalc_P5 work/full_correlation/kat/gul_S1_eltcalc_P6 work/full_correlation/kat/gul_S1_eltcalc_P7 work/full_correlation/kat/gul_S1_eltcalc_P8 work/full_correlation/kat/gul_S1_eltcalc_P9 work/full_correlation/kat/gul_S1_eltcalc_P10 > output/full_correlation/gul_S1_eltcalc.csv & kpid19=$!
+kat work/full_correlation/kat/gul_S1_pltcalc_P1 work/full_correlation/kat/gul_S1_pltcalc_P2 work/full_correlation/kat/gul_S1_pltcalc_P3 work/full_correlation/kat/gul_S1_pltcalc_P4 work/full_correlation/kat/gul_S1_pltcalc_P5 work/full_correlation/kat/gul_S1_pltcalc_P6 work/full_correlation/kat/gul_S1_pltcalc_P7 work/full_correlation/kat/gul_S1_pltcalc_P8 work/full_correlation/kat/gul_S1_pltcalc_P9 work/full_correlation/kat/gul_S1_pltcalc_P10 > output/full_correlation/gul_S1_pltcalc.csv & kpid20=$!
+kat work/full_correlation/kat/gul_S1_summarycalc_P1 work/full_correlation/kat/gul_S1_summarycalc_P2 work/full_correlation/kat/gul_S1_summarycalc_P3 work/full_correlation/kat/gul_S1_summarycalc_P4 work/full_correlation/kat/gul_S1_summarycalc_P5 work/full_correlation/kat/gul_S1_summarycalc_P6 work/full_correlation/kat/gul_S1_summarycalc_P7 work/full_correlation/kat/gul_S1_summarycalc_P8 work/full_correlation/kat/gul_S1_summarycalc_P9 work/full_correlation/kat/gul_S1_summarycalc_P10 > output/full_correlation/gul_S1_summarycalc.csv & kpid21=$!
+kat -s work/full_correlation/kat/gul_S2_eltcalc_P1 work/full_correlation/kat/gul_S2_eltcalc_P2 work/full_correlation/kat/gul_S2_eltcalc_P3 work/full_correlation/kat/gul_S2_eltcalc_P4 work/full_correlation/kat/gul_S2_eltcalc_P5 work/full_correlation/kat/gul_S2_eltcalc_P6 work/full_correlation/kat/gul_S2_eltcalc_P7 work/full_correlation/kat/gul_S2_eltcalc_P8 work/full_correlation/kat/gul_S2_eltcalc_P9 work/full_correlation/kat/gul_S2_eltcalc_P10 > output/full_correlation/gul_S2_eltcalc.csv & kpid22=$!
+kat work/full_correlation/kat/gul_S2_pltcalc_P1 work/full_correlation/kat/gul_S2_pltcalc_P2 work/full_correlation/kat/gul_S2_pltcalc_P3 work/full_correlation/kat/gul_S2_pltcalc_P4 work/full_correlation/kat/gul_S2_pltcalc_P5 work/full_correlation/kat/gul_S2_pltcalc_P6 work/full_correlation/kat/gul_S2_pltcalc_P7 work/full_correlation/kat/gul_S2_pltcalc_P8 work/full_correlation/kat/gul_S2_pltcalc_P9 work/full_correlation/kat/gul_S2_pltcalc_P10 > output/full_correlation/gul_S2_pltcalc.csv & kpid23=$!
+kat work/full_correlation/kat/gul_S2_summarycalc_P1 work/full_correlation/kat/gul_S2_summarycalc_P2 work/full_correlation/kat/gul_S2_summarycalc_P3 work/full_correlation/kat/gul_S2_summarycalc_P4 work/full_correlation/kat/gul_S2_summarycalc_P5 work/full_correlation/kat/gul_S2_summarycalc_P6 work/full_correlation/kat/gul_S2_summarycalc_P7 work/full_correlation/kat/gul_S2_summarycalc_P8 work/full_correlation/kat/gul_S2_summarycalc_P9 work/full_correlation/kat/gul_S2_summarycalc_P10 > output/full_correlation/gul_S2_summarycalc.csv & kpid24=$!
+wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpid11 $kpid12 $kpid13 $kpid14 $kpid15 $kpid16 $kpid17 $kpid18 $kpid19 $kpid20 $kpid21 $kpid22 $kpid23 $kpid24
+
+
+aalcalc -Kil_S1_summaryaalcalc > output/il_S1_aalcalc.csv & lpid1=$!
+ordleccalc -r -Kil_S1_summaryleccalc -F -S -s -M -m -W -w -O output/il_S1_ept.csv -o output/il_S1_psept.csv & lpid2=$!
+aalcalc -Kil_S2_summaryaalcalc > output/il_S2_aalcalc.csv & lpid3=$!
+ordleccalc -r -Kil_S2_summaryleccalc -F -S -s -M -m -W -w -O output/il_S2_ept.csv -o output/il_S2_psept.csv & lpid4=$!
+aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv & lpid5=$!
+ordleccalc -r -Kgul_S1_summaryleccalc -F -S -s -M -m -W -w -O output/gul_S1_ept.csv -o output/gul_S1_psept.csv & lpid6=$!
+aalcalc -Kgul_S2_summaryaalcalc > output/gul_S2_aalcalc.csv & lpid7=$!
+ordleccalc -r -Kgul_S2_summaryleccalc -F -S -s -M -m -W -w -O output/gul_S2_ept.csv -o output/gul_S2_psept.csv & lpid8=$!
+aalcalc -Kfull_correlation/il_S1_summaryaalcalc > output/full_correlation/il_S1_aalcalc.csv & lpid9=$!
+ordleccalc -r -Kfull_correlation/il_S1_summaryleccalc -F -S -s -M -m -W -w -O output/full_correlation/il_S1_ept.csv -o output/full_correlation/il_S1_psept.csv & lpid10=$!
+aalcalc -Kfull_correlation/il_S2_summaryaalcalc > output/full_correlation/il_S2_aalcalc.csv & lpid11=$!
+ordleccalc -r -Kfull_correlation/il_S2_summaryleccalc -F -S -s -M -m -W -w -O output/full_correlation/il_S2_ept.csv -o output/full_correlation/il_S2_psept.csv & lpid12=$!
+aalcalc -Kfull_correlation/gul_S1_summaryaalcalc > output/full_correlation/gul_S1_aalcalc.csv & lpid13=$!
+ordleccalc -r -Kfull_correlation/gul_S1_summaryleccalc -F -S -s -M -m -W -w -O output/full_correlation/gul_S1_ept.csv -o output/full_correlation/gul_S1_psept.csv & lpid14=$!
+aalcalc -Kfull_correlation/gul_S2_summaryaalcalc > output/full_correlation/gul_S2_aalcalc.csv & lpid15=$!
+ordleccalc -r -Kfull_correlation/gul_S2_summaryleccalc -F -S -s -M -m -W -w -O output/full_correlation/gul_S2_ept.csv -o output/full_correlation/gul_S2_psept.csv & lpid16=$!
+wait $lpid1 $lpid2 $lpid3 $lpid4 $lpid5 $lpid6 $lpid7 $lpid8 $lpid9 $lpid10 $lpid11 $lpid12 $lpid13 $lpid14 $lpid15 $lpid16
+
+rm -R -f work/*
+rm -R -f /tmp/%FIFO_DIR%/

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_il_ord_psept_lec_1_output_10_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_il_ord_psept_lec_1_output_10_partition.sh
@@ -1,0 +1,575 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+mkdir output/full_correlation/
+
+rm -R -f work/*
+mkdir work/kat/
+mkdir work/full_correlation/
+mkdir work/full_correlation/kat/
+
+rm -R -f /tmp/%FIFO_DIR%/
+mkdir -p /tmp/%FIFO_DIR%/fifo/
+mkdir /tmp/%FIFO_DIR%/fifo/full_correlation/
+mkdir work/gul_S1_summaryleccalc
+mkdir work/gul_S1_summaryaalcalc
+mkdir work/full_correlation/gul_S1_summaryleccalc
+mkdir work/full_correlation/gul_S1_summaryaalcalc
+mkdir work/il_S1_summaryleccalc
+mkdir work/il_S1_summaryaalcalc
+mkdir work/full_correlation/il_S1_summaryleccalc
+mkdir work/full_correlation/il_S1_summaryaalcalc
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P10
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P10
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P1
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P2
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P3
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P4
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P5
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P6
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P7
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P8
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P9
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P10
+
+mkfifo /tmp/%FIFO_DIR%/fifo/il_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/il_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/il_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/il_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/il_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/il_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/il_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/il_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/il_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/il_P10
+
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summary_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P1
+
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summary_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P2
+
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summary_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P3
+
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summary_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P4
+
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summary_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P5
+
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summary_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P6
+
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summary_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P7
+
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summary_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P8
+
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summary_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P9
+
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summary_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P10
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P10
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P1
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P2
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P3
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P4
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P5
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P6
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P7
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P8
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P9
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P10
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_P10
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P1
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P2
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P3
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P4
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P5
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P6
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P7
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P8
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P9
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P10
+
+
+
+# --- Do insured loss computes ---
+
+eltcalc < /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P1 > work/kat/il_S1_eltcalc_P1 & pid1=$!
+summarycalctocsv < /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P1 > work/kat/il_S1_summarycalc_P1 & pid2=$!
+pltcalc < /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P1 > work/kat/il_S1_pltcalc_P1 & pid3=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P2 > work/kat/il_S1_eltcalc_P2 & pid4=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P2 > work/kat/il_S1_summarycalc_P2 & pid5=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P2 > work/kat/il_S1_pltcalc_P2 & pid6=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P3 > work/kat/il_S1_eltcalc_P3 & pid7=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P3 > work/kat/il_S1_summarycalc_P3 & pid8=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P3 > work/kat/il_S1_pltcalc_P3 & pid9=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P4 > work/kat/il_S1_eltcalc_P4 & pid10=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P4 > work/kat/il_S1_summarycalc_P4 & pid11=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P4 > work/kat/il_S1_pltcalc_P4 & pid12=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P5 > work/kat/il_S1_eltcalc_P5 & pid13=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P5 > work/kat/il_S1_summarycalc_P5 & pid14=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P5 > work/kat/il_S1_pltcalc_P5 & pid15=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P6 > work/kat/il_S1_eltcalc_P6 & pid16=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P6 > work/kat/il_S1_summarycalc_P6 & pid17=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P6 > work/kat/il_S1_pltcalc_P6 & pid18=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P7 > work/kat/il_S1_eltcalc_P7 & pid19=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P7 > work/kat/il_S1_summarycalc_P7 & pid20=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P7 > work/kat/il_S1_pltcalc_P7 & pid21=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P8 > work/kat/il_S1_eltcalc_P8 & pid22=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P8 > work/kat/il_S1_summarycalc_P8 & pid23=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P8 > work/kat/il_S1_pltcalc_P8 & pid24=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P9 > work/kat/il_S1_eltcalc_P9 & pid25=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P9 > work/kat/il_S1_summarycalc_P9 & pid26=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P9 > work/kat/il_S1_pltcalc_P9 & pid27=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P10 > work/kat/il_S1_eltcalc_P10 & pid28=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P10 > work/kat/il_S1_summarycalc_P10 & pid29=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P10 > work/kat/il_S1_pltcalc_P10 & pid30=$!
+
+tee < /tmp/%FIFO_DIR%/fifo/il_S1_summary_P1 /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P1 /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P1 /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P1 work/il_S1_summaryaalcalc/P1.bin work/il_S1_summaryleccalc/P1.bin > /dev/null & pid31=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S1_summary_P2 /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P2 /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P2 /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P2 work/il_S1_summaryaalcalc/P2.bin work/il_S1_summaryleccalc/P2.bin > /dev/null & pid32=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S1_summary_P3 /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P3 /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P3 /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P3 work/il_S1_summaryaalcalc/P3.bin work/il_S1_summaryleccalc/P3.bin > /dev/null & pid33=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S1_summary_P4 /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P4 /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P4 /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P4 work/il_S1_summaryaalcalc/P4.bin work/il_S1_summaryleccalc/P4.bin > /dev/null & pid34=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S1_summary_P5 /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P5 /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P5 /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P5 work/il_S1_summaryaalcalc/P5.bin work/il_S1_summaryleccalc/P5.bin > /dev/null & pid35=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S1_summary_P6 /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P6 /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P6 /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P6 work/il_S1_summaryaalcalc/P6.bin work/il_S1_summaryleccalc/P6.bin > /dev/null & pid36=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S1_summary_P7 /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P7 /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P7 /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P7 work/il_S1_summaryaalcalc/P7.bin work/il_S1_summaryleccalc/P7.bin > /dev/null & pid37=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S1_summary_P8 /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P8 /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P8 /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P8 work/il_S1_summaryaalcalc/P8.bin work/il_S1_summaryleccalc/P8.bin > /dev/null & pid38=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S1_summary_P9 /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P9 /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P9 /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P9 work/il_S1_summaryaalcalc/P9.bin work/il_S1_summaryleccalc/P9.bin > /dev/null & pid39=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S1_summary_P10 /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P10 /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P10 /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P10 work/il_S1_summaryaalcalc/P10.bin work/il_S1_summaryleccalc/P10.bin > /dev/null & pid40=$!
+
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/il_S1_summary_P1 < /tmp/%FIFO_DIR%/fifo/il_P1 &
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/il_S1_summary_P2 < /tmp/%FIFO_DIR%/fifo/il_P2 &
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/il_S1_summary_P3 < /tmp/%FIFO_DIR%/fifo/il_P3 &
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/il_S1_summary_P4 < /tmp/%FIFO_DIR%/fifo/il_P4 &
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/il_S1_summary_P5 < /tmp/%FIFO_DIR%/fifo/il_P5 &
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/il_S1_summary_P6 < /tmp/%FIFO_DIR%/fifo/il_P6 &
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/il_S1_summary_P7 < /tmp/%FIFO_DIR%/fifo/il_P7 &
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/il_S1_summary_P8 < /tmp/%FIFO_DIR%/fifo/il_P8 &
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/il_S1_summary_P9 < /tmp/%FIFO_DIR%/fifo/il_P9 &
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/il_S1_summary_P10 < /tmp/%FIFO_DIR%/fifo/il_P10 &
+
+# --- Do ground up loss computes ---
+
+eltcalc < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P1 > work/kat/gul_S1_eltcalc_P1 & pid41=$!
+summarycalctocsv < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P1 > work/kat/gul_S1_summarycalc_P1 & pid42=$!
+pltcalc < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P1 > work/kat/gul_S1_pltcalc_P1 & pid43=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P2 > work/kat/gul_S1_eltcalc_P2 & pid44=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P2 > work/kat/gul_S1_summarycalc_P2 & pid45=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P2 > work/kat/gul_S1_pltcalc_P2 & pid46=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P3 > work/kat/gul_S1_eltcalc_P3 & pid47=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P3 > work/kat/gul_S1_summarycalc_P3 & pid48=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P3 > work/kat/gul_S1_pltcalc_P3 & pid49=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P4 > work/kat/gul_S1_eltcalc_P4 & pid50=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P4 > work/kat/gul_S1_summarycalc_P4 & pid51=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P4 > work/kat/gul_S1_pltcalc_P4 & pid52=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P5 > work/kat/gul_S1_eltcalc_P5 & pid53=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P5 > work/kat/gul_S1_summarycalc_P5 & pid54=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P5 > work/kat/gul_S1_pltcalc_P5 & pid55=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P6 > work/kat/gul_S1_eltcalc_P6 & pid56=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P6 > work/kat/gul_S1_summarycalc_P6 & pid57=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P6 > work/kat/gul_S1_pltcalc_P6 & pid58=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P7 > work/kat/gul_S1_eltcalc_P7 & pid59=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P7 > work/kat/gul_S1_summarycalc_P7 & pid60=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P7 > work/kat/gul_S1_pltcalc_P7 & pid61=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P8 > work/kat/gul_S1_eltcalc_P8 & pid62=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P8 > work/kat/gul_S1_summarycalc_P8 & pid63=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P8 > work/kat/gul_S1_pltcalc_P8 & pid64=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P9 > work/kat/gul_S1_eltcalc_P9 & pid65=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P9 > work/kat/gul_S1_summarycalc_P9 & pid66=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P9 > work/kat/gul_S1_pltcalc_P9 & pid67=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P10 > work/kat/gul_S1_eltcalc_P10 & pid68=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P10 > work/kat/gul_S1_summarycalc_P10 & pid69=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P10 > work/kat/gul_S1_pltcalc_P10 & pid70=$!
+
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P1 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P1 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P1 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P1 work/gul_S1_summaryaalcalc/P1.bin work/gul_S1_summaryleccalc/P1.bin > /dev/null & pid71=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P2 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P2 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P2 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P2 work/gul_S1_summaryaalcalc/P2.bin work/gul_S1_summaryleccalc/P2.bin > /dev/null & pid72=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P3 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P3 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P3 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P3 work/gul_S1_summaryaalcalc/P3.bin work/gul_S1_summaryleccalc/P3.bin > /dev/null & pid73=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P4 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P4 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P4 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P4 work/gul_S1_summaryaalcalc/P4.bin work/gul_S1_summaryleccalc/P4.bin > /dev/null & pid74=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P5 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P5 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P5 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P5 work/gul_S1_summaryaalcalc/P5.bin work/gul_S1_summaryleccalc/P5.bin > /dev/null & pid75=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P6 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P6 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P6 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P6 work/gul_S1_summaryaalcalc/P6.bin work/gul_S1_summaryleccalc/P6.bin > /dev/null & pid76=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P7 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P7 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P7 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P7 work/gul_S1_summaryaalcalc/P7.bin work/gul_S1_summaryleccalc/P7.bin > /dev/null & pid77=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P8 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P8 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P8 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P8 work/gul_S1_summaryaalcalc/P8.bin work/gul_S1_summaryleccalc/P8.bin > /dev/null & pid78=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P9 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P9 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P9 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P9 work/gul_S1_summaryaalcalc/P9.bin work/gul_S1_summaryleccalc/P9.bin > /dev/null & pid79=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P10 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P10 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P10 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P10 work/gul_S1_summaryaalcalc/P10.bin work/gul_S1_summaryleccalc/P10.bin > /dev/null & pid80=$!
+
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P1 < /tmp/%FIFO_DIR%/fifo/gul_P1 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P2 < /tmp/%FIFO_DIR%/fifo/gul_P2 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P3 < /tmp/%FIFO_DIR%/fifo/gul_P3 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P4 < /tmp/%FIFO_DIR%/fifo/gul_P4 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P5 < /tmp/%FIFO_DIR%/fifo/gul_P5 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P6 < /tmp/%FIFO_DIR%/fifo/gul_P6 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P7 < /tmp/%FIFO_DIR%/fifo/gul_P7 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P8 < /tmp/%FIFO_DIR%/fifo/gul_P8 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P9 < /tmp/%FIFO_DIR%/fifo/gul_P9 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P10 < /tmp/%FIFO_DIR%/fifo/gul_P10 &
+
+# --- Do insured loss computes ---
+
+eltcalc < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P1 > work/full_correlation/kat/il_S1_eltcalc_P1 & pid81=$!
+summarycalctocsv < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P1 > work/full_correlation/kat/il_S1_summarycalc_P1 & pid82=$!
+pltcalc < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P1 > work/full_correlation/kat/il_S1_pltcalc_P1 & pid83=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P2 > work/full_correlation/kat/il_S1_eltcalc_P2 & pid84=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P2 > work/full_correlation/kat/il_S1_summarycalc_P2 & pid85=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P2 > work/full_correlation/kat/il_S1_pltcalc_P2 & pid86=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P3 > work/full_correlation/kat/il_S1_eltcalc_P3 & pid87=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P3 > work/full_correlation/kat/il_S1_summarycalc_P3 & pid88=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P3 > work/full_correlation/kat/il_S1_pltcalc_P3 & pid89=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P4 > work/full_correlation/kat/il_S1_eltcalc_P4 & pid90=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P4 > work/full_correlation/kat/il_S1_summarycalc_P4 & pid91=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P4 > work/full_correlation/kat/il_S1_pltcalc_P4 & pid92=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P5 > work/full_correlation/kat/il_S1_eltcalc_P5 & pid93=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P5 > work/full_correlation/kat/il_S1_summarycalc_P5 & pid94=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P5 > work/full_correlation/kat/il_S1_pltcalc_P5 & pid95=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P6 > work/full_correlation/kat/il_S1_eltcalc_P6 & pid96=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P6 > work/full_correlation/kat/il_S1_summarycalc_P6 & pid97=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P6 > work/full_correlation/kat/il_S1_pltcalc_P6 & pid98=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P7 > work/full_correlation/kat/il_S1_eltcalc_P7 & pid99=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P7 > work/full_correlation/kat/il_S1_summarycalc_P7 & pid100=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P7 > work/full_correlation/kat/il_S1_pltcalc_P7 & pid101=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P8 > work/full_correlation/kat/il_S1_eltcalc_P8 & pid102=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P8 > work/full_correlation/kat/il_S1_summarycalc_P8 & pid103=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P8 > work/full_correlation/kat/il_S1_pltcalc_P8 & pid104=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P9 > work/full_correlation/kat/il_S1_eltcalc_P9 & pid105=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P9 > work/full_correlation/kat/il_S1_summarycalc_P9 & pid106=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P9 > work/full_correlation/kat/il_S1_pltcalc_P9 & pid107=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P10 > work/full_correlation/kat/il_S1_eltcalc_P10 & pid108=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P10 > work/full_correlation/kat/il_S1_summarycalc_P10 & pid109=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P10 > work/full_correlation/kat/il_S1_pltcalc_P10 & pid110=$!
+
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P1 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P1 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P1 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P1 work/full_correlation/il_S1_summaryaalcalc/P1.bin work/full_correlation/il_S1_summaryleccalc/P1.bin > /dev/null & pid111=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P2 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P2 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P2 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P2 work/full_correlation/il_S1_summaryaalcalc/P2.bin work/full_correlation/il_S1_summaryleccalc/P2.bin > /dev/null & pid112=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P3 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P3 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P3 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P3 work/full_correlation/il_S1_summaryaalcalc/P3.bin work/full_correlation/il_S1_summaryleccalc/P3.bin > /dev/null & pid113=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P4 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P4 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P4 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P4 work/full_correlation/il_S1_summaryaalcalc/P4.bin work/full_correlation/il_S1_summaryleccalc/P4.bin > /dev/null & pid114=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P5 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P5 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P5 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P5 work/full_correlation/il_S1_summaryaalcalc/P5.bin work/full_correlation/il_S1_summaryleccalc/P5.bin > /dev/null & pid115=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P6 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P6 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P6 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P6 work/full_correlation/il_S1_summaryaalcalc/P6.bin work/full_correlation/il_S1_summaryleccalc/P6.bin > /dev/null & pid116=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P7 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P7 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P7 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P7 work/full_correlation/il_S1_summaryaalcalc/P7.bin work/full_correlation/il_S1_summaryleccalc/P7.bin > /dev/null & pid117=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P8 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P8 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P8 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P8 work/full_correlation/il_S1_summaryaalcalc/P8.bin work/full_correlation/il_S1_summaryleccalc/P8.bin > /dev/null & pid118=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P9 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P9 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P9 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P9 work/full_correlation/il_S1_summaryaalcalc/P9.bin work/full_correlation/il_S1_summaryleccalc/P9.bin > /dev/null & pid119=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P10 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_eltcalc_P10 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summarycalc_P10 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_pltcalc_P10 work/full_correlation/il_S1_summaryaalcalc/P10.bin work/full_correlation/il_S1_summaryleccalc/P10.bin > /dev/null & pid120=$!
+
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P1 < /tmp/%FIFO_DIR%/fifo/full_correlation/il_P1 &
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P2 < /tmp/%FIFO_DIR%/fifo/full_correlation/il_P2 &
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P3 < /tmp/%FIFO_DIR%/fifo/full_correlation/il_P3 &
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P4 < /tmp/%FIFO_DIR%/fifo/full_correlation/il_P4 &
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P5 < /tmp/%FIFO_DIR%/fifo/full_correlation/il_P5 &
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P6 < /tmp/%FIFO_DIR%/fifo/full_correlation/il_P6 &
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P7 < /tmp/%FIFO_DIR%/fifo/full_correlation/il_P7 &
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P8 < /tmp/%FIFO_DIR%/fifo/full_correlation/il_P8 &
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P9 < /tmp/%FIFO_DIR%/fifo/full_correlation/il_P9 &
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/il_S1_summary_P10 < /tmp/%FIFO_DIR%/fifo/full_correlation/il_P10 &
+
+# --- Do ground up loss computes ---
+
+eltcalc < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P1 > work/full_correlation/kat/gul_S1_eltcalc_P1 & pid121=$!
+summarycalctocsv < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P1 > work/full_correlation/kat/gul_S1_summarycalc_P1 & pid122=$!
+pltcalc < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P1 > work/full_correlation/kat/gul_S1_pltcalc_P1 & pid123=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P2 > work/full_correlation/kat/gul_S1_eltcalc_P2 & pid124=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P2 > work/full_correlation/kat/gul_S1_summarycalc_P2 & pid125=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P2 > work/full_correlation/kat/gul_S1_pltcalc_P2 & pid126=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P3 > work/full_correlation/kat/gul_S1_eltcalc_P3 & pid127=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P3 > work/full_correlation/kat/gul_S1_summarycalc_P3 & pid128=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P3 > work/full_correlation/kat/gul_S1_pltcalc_P3 & pid129=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P4 > work/full_correlation/kat/gul_S1_eltcalc_P4 & pid130=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P4 > work/full_correlation/kat/gul_S1_summarycalc_P4 & pid131=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P4 > work/full_correlation/kat/gul_S1_pltcalc_P4 & pid132=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P5 > work/full_correlation/kat/gul_S1_eltcalc_P5 & pid133=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P5 > work/full_correlation/kat/gul_S1_summarycalc_P5 & pid134=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P5 > work/full_correlation/kat/gul_S1_pltcalc_P5 & pid135=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P6 > work/full_correlation/kat/gul_S1_eltcalc_P6 & pid136=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P6 > work/full_correlation/kat/gul_S1_summarycalc_P6 & pid137=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P6 > work/full_correlation/kat/gul_S1_pltcalc_P6 & pid138=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P7 > work/full_correlation/kat/gul_S1_eltcalc_P7 & pid139=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P7 > work/full_correlation/kat/gul_S1_summarycalc_P7 & pid140=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P7 > work/full_correlation/kat/gul_S1_pltcalc_P7 & pid141=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P8 > work/full_correlation/kat/gul_S1_eltcalc_P8 & pid142=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P8 > work/full_correlation/kat/gul_S1_summarycalc_P8 & pid143=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P8 > work/full_correlation/kat/gul_S1_pltcalc_P8 & pid144=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P9 > work/full_correlation/kat/gul_S1_eltcalc_P9 & pid145=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P9 > work/full_correlation/kat/gul_S1_summarycalc_P9 & pid146=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P9 > work/full_correlation/kat/gul_S1_pltcalc_P9 & pid147=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P10 > work/full_correlation/kat/gul_S1_eltcalc_P10 & pid148=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P10 > work/full_correlation/kat/gul_S1_summarycalc_P10 & pid149=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P10 > work/full_correlation/kat/gul_S1_pltcalc_P10 & pid150=$!
+
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P1 work/full_correlation/gul_S1_summaryaalcalc/P1.bin work/full_correlation/gul_S1_summaryleccalc/P1.bin > /dev/null & pid151=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P2 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P2 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P2 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P2 work/full_correlation/gul_S1_summaryaalcalc/P2.bin work/full_correlation/gul_S1_summaryleccalc/P2.bin > /dev/null & pid152=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P3 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P3 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P3 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P3 work/full_correlation/gul_S1_summaryaalcalc/P3.bin work/full_correlation/gul_S1_summaryleccalc/P3.bin > /dev/null & pid153=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P4 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P4 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P4 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P4 work/full_correlation/gul_S1_summaryaalcalc/P4.bin work/full_correlation/gul_S1_summaryleccalc/P4.bin > /dev/null & pid154=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P5 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P5 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P5 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P5 work/full_correlation/gul_S1_summaryaalcalc/P5.bin work/full_correlation/gul_S1_summaryleccalc/P5.bin > /dev/null & pid155=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P6 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P6 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P6 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P6 work/full_correlation/gul_S1_summaryaalcalc/P6.bin work/full_correlation/gul_S1_summaryleccalc/P6.bin > /dev/null & pid156=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P7 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P7 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P7 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P7 work/full_correlation/gul_S1_summaryaalcalc/P7.bin work/full_correlation/gul_S1_summaryleccalc/P7.bin > /dev/null & pid157=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P8 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P8 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P8 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P8 work/full_correlation/gul_S1_summaryaalcalc/P8.bin work/full_correlation/gul_S1_summaryleccalc/P8.bin > /dev/null & pid158=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P9 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P9 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P9 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P9 work/full_correlation/gul_S1_summaryaalcalc/P9.bin work/full_correlation/gul_S1_summaryleccalc/P9.bin > /dev/null & pid159=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P10 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P10 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P10 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P10 work/full_correlation/gul_S1_summaryaalcalc/P10.bin work/full_correlation/gul_S1_summaryleccalc/P10.bin > /dev/null & pid160=$!
+
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P1 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P1 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P2 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P2 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P3 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P3 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P4 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P4 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P5 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P5 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P6 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P6 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P7 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P7 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P8 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P8 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P9 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P9 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P10 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P10 &
+
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P1  | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/full_correlation/il_P1  &
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P2 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P2  | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/full_correlation/il_P2  &
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P3 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P3  | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/full_correlation/il_P3  &
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P4 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P4  | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/full_correlation/il_P4  &
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P5 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P5  | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/full_correlation/il_P5  &
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P6 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P6  | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/full_correlation/il_P6  &
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P7 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P7  | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/full_correlation/il_P7  &
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P8 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P8  | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/full_correlation/il_P8  &
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P9 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P9  | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/full_correlation/il_P9  &
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P10 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P10  | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/full_correlation/il_P10  &
+eve 1 10 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P1 -a1 -i - | tee /tmp/%FIFO_DIR%/fifo/gul_P1 | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/il_P1  &
+eve 2 10 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P2 -a1 -i - | tee /tmp/%FIFO_DIR%/fifo/gul_P2 | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/il_P2  &
+eve 3 10 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P3 -a1 -i - | tee /tmp/%FIFO_DIR%/fifo/gul_P3 | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/il_P3  &
+eve 4 10 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P4 -a1 -i - | tee /tmp/%FIFO_DIR%/fifo/gul_P4 | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/il_P4  &
+eve 5 10 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P5 -a1 -i - | tee /tmp/%FIFO_DIR%/fifo/gul_P5 | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/il_P5  &
+eve 6 10 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P6 -a1 -i - | tee /tmp/%FIFO_DIR%/fifo/gul_P6 | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/il_P6  &
+eve 7 10 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P7 -a1 -i - | tee /tmp/%FIFO_DIR%/fifo/gul_P7 | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/il_P7  &
+eve 8 10 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P8 -a1 -i - | tee /tmp/%FIFO_DIR%/fifo/gul_P8 | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/il_P8  &
+eve 9 10 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P9 -a1 -i - | tee /tmp/%FIFO_DIR%/fifo/gul_P9 | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/il_P9  &
+eve 10 10 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_fc_P10 -a1 -i - | tee /tmp/%FIFO_DIR%/fifo/gul_P10 | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/il_P10  &
+
+wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 $pid13 $pid14 $pid15 $pid16 $pid17 $pid18 $pid19 $pid20 $pid21 $pid22 $pid23 $pid24 $pid25 $pid26 $pid27 $pid28 $pid29 $pid30 $pid31 $pid32 $pid33 $pid34 $pid35 $pid36 $pid37 $pid38 $pid39 $pid40 $pid41 $pid42 $pid43 $pid44 $pid45 $pid46 $pid47 $pid48 $pid49 $pid50 $pid51 $pid52 $pid53 $pid54 $pid55 $pid56 $pid57 $pid58 $pid59 $pid60 $pid61 $pid62 $pid63 $pid64 $pid65 $pid66 $pid67 $pid68 $pid69 $pid70 $pid71 $pid72 $pid73 $pid74 $pid75 $pid76 $pid77 $pid78 $pid79 $pid80 $pid81 $pid82 $pid83 $pid84 $pid85 $pid86 $pid87 $pid88 $pid89 $pid90 $pid91 $pid92 $pid93 $pid94 $pid95 $pid96 $pid97 $pid98 $pid99 $pid100 $pid101 $pid102 $pid103 $pid104 $pid105 $pid106 $pid107 $pid108 $pid109 $pid110 $pid111 $pid112 $pid113 $pid114 $pid115 $pid116 $pid117 $pid118 $pid119 $pid120 $pid121 $pid122 $pid123 $pid124 $pid125 $pid126 $pid127 $pid128 $pid129 $pid130 $pid131 $pid132 $pid133 $pid134 $pid135 $pid136 $pid137 $pid138 $pid139 $pid140 $pid141 $pid142 $pid143 $pid144 $pid145 $pid146 $pid147 $pid148 $pid149 $pid150 $pid151 $pid152 $pid153 $pid154 $pid155 $pid156 $pid157 $pid158 $pid159 $pid160
+
+
+# --- Do insured loss kats ---
+
+kat -s work/kat/il_S1_eltcalc_P1 work/kat/il_S1_eltcalc_P2 work/kat/il_S1_eltcalc_P3 work/kat/il_S1_eltcalc_P4 work/kat/il_S1_eltcalc_P5 work/kat/il_S1_eltcalc_P6 work/kat/il_S1_eltcalc_P7 work/kat/il_S1_eltcalc_P8 work/kat/il_S1_eltcalc_P9 work/kat/il_S1_eltcalc_P10 > output/il_S1_eltcalc.csv & kpid1=$!
+kat work/kat/il_S1_pltcalc_P1 work/kat/il_S1_pltcalc_P2 work/kat/il_S1_pltcalc_P3 work/kat/il_S1_pltcalc_P4 work/kat/il_S1_pltcalc_P5 work/kat/il_S1_pltcalc_P6 work/kat/il_S1_pltcalc_P7 work/kat/il_S1_pltcalc_P8 work/kat/il_S1_pltcalc_P9 work/kat/il_S1_pltcalc_P10 > output/il_S1_pltcalc.csv & kpid2=$!
+kat work/kat/il_S1_summarycalc_P1 work/kat/il_S1_summarycalc_P2 work/kat/il_S1_summarycalc_P3 work/kat/il_S1_summarycalc_P4 work/kat/il_S1_summarycalc_P5 work/kat/il_S1_summarycalc_P6 work/kat/il_S1_summarycalc_P7 work/kat/il_S1_summarycalc_P8 work/kat/il_S1_summarycalc_P9 work/kat/il_S1_summarycalc_P10 > output/il_S1_summarycalc.csv & kpid3=$!
+
+# --- Do insured loss kats for fully correlated output ---
+
+kat -s work/full_correlation/kat/il_S1_eltcalc_P1 work/full_correlation/kat/il_S1_eltcalc_P2 work/full_correlation/kat/il_S1_eltcalc_P3 work/full_correlation/kat/il_S1_eltcalc_P4 work/full_correlation/kat/il_S1_eltcalc_P5 work/full_correlation/kat/il_S1_eltcalc_P6 work/full_correlation/kat/il_S1_eltcalc_P7 work/full_correlation/kat/il_S1_eltcalc_P8 work/full_correlation/kat/il_S1_eltcalc_P9 work/full_correlation/kat/il_S1_eltcalc_P10 > output/full_correlation/il_S1_eltcalc.csv & kpid4=$!
+kat work/full_correlation/kat/il_S1_pltcalc_P1 work/full_correlation/kat/il_S1_pltcalc_P2 work/full_correlation/kat/il_S1_pltcalc_P3 work/full_correlation/kat/il_S1_pltcalc_P4 work/full_correlation/kat/il_S1_pltcalc_P5 work/full_correlation/kat/il_S1_pltcalc_P6 work/full_correlation/kat/il_S1_pltcalc_P7 work/full_correlation/kat/il_S1_pltcalc_P8 work/full_correlation/kat/il_S1_pltcalc_P9 work/full_correlation/kat/il_S1_pltcalc_P10 > output/full_correlation/il_S1_pltcalc.csv & kpid5=$!
+kat work/full_correlation/kat/il_S1_summarycalc_P1 work/full_correlation/kat/il_S1_summarycalc_P2 work/full_correlation/kat/il_S1_summarycalc_P3 work/full_correlation/kat/il_S1_summarycalc_P4 work/full_correlation/kat/il_S1_summarycalc_P5 work/full_correlation/kat/il_S1_summarycalc_P6 work/full_correlation/kat/il_S1_summarycalc_P7 work/full_correlation/kat/il_S1_summarycalc_P8 work/full_correlation/kat/il_S1_summarycalc_P9 work/full_correlation/kat/il_S1_summarycalc_P10 > output/full_correlation/il_S1_summarycalc.csv & kpid6=$!
+
+# --- Do ground up loss kats ---
+
+kat -s work/kat/gul_S1_eltcalc_P1 work/kat/gul_S1_eltcalc_P2 work/kat/gul_S1_eltcalc_P3 work/kat/gul_S1_eltcalc_P4 work/kat/gul_S1_eltcalc_P5 work/kat/gul_S1_eltcalc_P6 work/kat/gul_S1_eltcalc_P7 work/kat/gul_S1_eltcalc_P8 work/kat/gul_S1_eltcalc_P9 work/kat/gul_S1_eltcalc_P10 > output/gul_S1_eltcalc.csv & kpid7=$!
+kat work/kat/gul_S1_pltcalc_P1 work/kat/gul_S1_pltcalc_P2 work/kat/gul_S1_pltcalc_P3 work/kat/gul_S1_pltcalc_P4 work/kat/gul_S1_pltcalc_P5 work/kat/gul_S1_pltcalc_P6 work/kat/gul_S1_pltcalc_P7 work/kat/gul_S1_pltcalc_P8 work/kat/gul_S1_pltcalc_P9 work/kat/gul_S1_pltcalc_P10 > output/gul_S1_pltcalc.csv & kpid8=$!
+kat work/kat/gul_S1_summarycalc_P1 work/kat/gul_S1_summarycalc_P2 work/kat/gul_S1_summarycalc_P3 work/kat/gul_S1_summarycalc_P4 work/kat/gul_S1_summarycalc_P5 work/kat/gul_S1_summarycalc_P6 work/kat/gul_S1_summarycalc_P7 work/kat/gul_S1_summarycalc_P8 work/kat/gul_S1_summarycalc_P9 work/kat/gul_S1_summarycalc_P10 > output/gul_S1_summarycalc.csv & kpid9=$!
+
+# --- Do ground up loss kats for fully correlated output ---
+
+kat -s work/full_correlation/kat/gul_S1_eltcalc_P1 work/full_correlation/kat/gul_S1_eltcalc_P2 work/full_correlation/kat/gul_S1_eltcalc_P3 work/full_correlation/kat/gul_S1_eltcalc_P4 work/full_correlation/kat/gul_S1_eltcalc_P5 work/full_correlation/kat/gul_S1_eltcalc_P6 work/full_correlation/kat/gul_S1_eltcalc_P7 work/full_correlation/kat/gul_S1_eltcalc_P8 work/full_correlation/kat/gul_S1_eltcalc_P9 work/full_correlation/kat/gul_S1_eltcalc_P10 > output/full_correlation/gul_S1_eltcalc.csv & kpid10=$!
+kat work/full_correlation/kat/gul_S1_pltcalc_P1 work/full_correlation/kat/gul_S1_pltcalc_P2 work/full_correlation/kat/gul_S1_pltcalc_P3 work/full_correlation/kat/gul_S1_pltcalc_P4 work/full_correlation/kat/gul_S1_pltcalc_P5 work/full_correlation/kat/gul_S1_pltcalc_P6 work/full_correlation/kat/gul_S1_pltcalc_P7 work/full_correlation/kat/gul_S1_pltcalc_P8 work/full_correlation/kat/gul_S1_pltcalc_P9 work/full_correlation/kat/gul_S1_pltcalc_P10 > output/full_correlation/gul_S1_pltcalc.csv & kpid11=$!
+kat work/full_correlation/kat/gul_S1_summarycalc_P1 work/full_correlation/kat/gul_S1_summarycalc_P2 work/full_correlation/kat/gul_S1_summarycalc_P3 work/full_correlation/kat/gul_S1_summarycalc_P4 work/full_correlation/kat/gul_S1_summarycalc_P5 work/full_correlation/kat/gul_S1_summarycalc_P6 work/full_correlation/kat/gul_S1_summarycalc_P7 work/full_correlation/kat/gul_S1_summarycalc_P8 work/full_correlation/kat/gul_S1_summarycalc_P9 work/full_correlation/kat/gul_S1_summarycalc_P10 > output/full_correlation/gul_S1_summarycalc.csv & kpid12=$!
+wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpid11 $kpid12
+
+
+aalcalc -Kil_S1_summaryaalcalc > output/il_S1_aalcalc.csv & lpid1=$!
+ordleccalc -r -Kil_S1_summaryleccalc -W -w -o output/il_S1_psept.csv & lpid2=$!
+leccalc -r -Kil_S1_summaryleccalc -F output/il_S1_leccalc_full_uncertainty_aep.csv -f output/il_S1_leccalc_full_uncertainty_oep.csv -S output/il_S1_leccalc_sample_mean_aep.csv -s output/il_S1_leccalc_sample_mean_oep.csv -W output/il_S1_leccalc_wheatsheaf_aep.csv -M output/il_S1_leccalc_wheatsheaf_mean_aep.csv -m output/il_S1_leccalc_wheatsheaf_mean_oep.csv -w output/il_S1_leccalc_wheatsheaf_oep.csv & lpid3=$!
+aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv & lpid4=$!
+ordleccalc  -Kgul_S1_summaryleccalc -W -w -o output/gul_S1_psept.csv & lpid5=$!
+leccalc -r -Kgul_S1_summaryleccalc -F output/gul_S1_leccalc_full_uncertainty_aep.csv -f output/gul_S1_leccalc_full_uncertainty_oep.csv -S output/gul_S1_leccalc_sample_mean_aep.csv -s output/gul_S1_leccalc_sample_mean_oep.csv -W output/gul_S1_leccalc_wheatsheaf_aep.csv -M output/gul_S1_leccalc_wheatsheaf_mean_aep.csv -m output/gul_S1_leccalc_wheatsheaf_mean_oep.csv -w output/gul_S1_leccalc_wheatsheaf_oep.csv & lpid6=$!
+aalcalc -Kfull_correlation/il_S1_summaryaalcalc > output/full_correlation/il_S1_aalcalc.csv & lpid7=$!
+ordleccalc -r -Kfull_correlation/il_S1_summaryleccalc -W -w -o output/full_correlation/il_S1_psept.csv & lpid8=$!
+leccalc -r -Kfull_correlation/il_S1_summaryleccalc -F output/full_correlation/il_S1_leccalc_full_uncertainty_aep.csv -f output/full_correlation/il_S1_leccalc_full_uncertainty_oep.csv -S output/full_correlation/il_S1_leccalc_sample_mean_aep.csv -s output/full_correlation/il_S1_leccalc_sample_mean_oep.csv -W output/full_correlation/il_S1_leccalc_wheatsheaf_aep.csv -M output/full_correlation/il_S1_leccalc_wheatsheaf_mean_aep.csv -m output/full_correlation/il_S1_leccalc_wheatsheaf_mean_oep.csv -w output/full_correlation/il_S1_leccalc_wheatsheaf_oep.csv & lpid9=$!
+aalcalc -Kfull_correlation/gul_S1_summaryaalcalc > output/full_correlation/gul_S1_aalcalc.csv & lpid10=$!
+ordleccalc  -Kfull_correlation/gul_S1_summaryleccalc -W -w -o output/full_correlation/gul_S1_psept.csv & lpid11=$!
+leccalc -r -Kfull_correlation/gul_S1_summaryleccalc -F output/full_correlation/gul_S1_leccalc_full_uncertainty_aep.csv -f output/full_correlation/gul_S1_leccalc_full_uncertainty_oep.csv -S output/full_correlation/gul_S1_leccalc_sample_mean_aep.csv -s output/full_correlation/gul_S1_leccalc_sample_mean_oep.csv -W output/full_correlation/gul_S1_leccalc_wheatsheaf_aep.csv -M output/full_correlation/gul_S1_leccalc_wheatsheaf_mean_aep.csv -m output/full_correlation/gul_S1_leccalc_wheatsheaf_mean_oep.csv -w output/full_correlation/gul_S1_leccalc_wheatsheaf_oep.csv & lpid12=$!
+wait $lpid1 $lpid2 $lpid3 $lpid4 $lpid5 $lpid6 $lpid7 $lpid8 $lpid9 $lpid10 $lpid11 $lpid12
+
+rm -R -f work/*
+rm -R -f /tmp/%FIFO_DIR%/

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_ord_ept_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_ord_ept_1_output_1_partition.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+mkdir output/full_correlation/
+
+rm -R -f work/*
+mkdir work/kat/
+mkdir work/full_correlation/
+mkdir work/full_correlation/kat/
+
+rm -R -f /tmp/%FIFO_DIR%/
+mkdir -p /tmp/%FIFO_DIR%/fifo/
+mkdir /tmp/%FIFO_DIR%/fifo/full_correlation/
+mkdir work/gul_S1_summaryleccalc
+mkdir work/full_correlation/gul_S1_summaryleccalc
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P1
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P1
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P1
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P1
+
+
+
+# --- Do ground up loss computes ---
+
+
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P1 work/gul_S1_summaryleccalc/P1.bin > /dev/null & pid1=$!
+
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P1 < /tmp/%FIFO_DIR%/fifo/gul_P1 &
+
+# --- Do ground up loss computes ---
+
+
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P1 work/full_correlation/gul_S1_summaryleccalc/P1.bin > /dev/null & pid2=$!
+
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P1 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P1 &
+
+eve 1 1 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P1 -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P1  &
+
+wait $pid1 $pid2
+
+
+# --- Do ground up loss kats ---
+
+
+# --- Do ground up loss kats for fully correlated output ---
+
+
+ordleccalc -r -Kgul_S1_summaryleccalc -F -f -S -s -M -m -O output/gul_S1_ept.csv & lpid1=$!
+ordleccalc -r -Kfull_correlation/gul_S1_summaryleccalc -F -f -S -s -M -m -O output/full_correlation/gul_S1_ept.csv & lpid2=$!
+wait $lpid1 $lpid2
+
+rm -R -f work/*
+rm -R -f /tmp/%FIFO_DIR%/

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_ord_ept_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_ord_ept_1_output_20_partition.sh
@@ -1,0 +1,276 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+mkdir output/full_correlation/
+
+rm -R -f work/*
+mkdir work/kat/
+mkdir work/full_correlation/
+mkdir work/full_correlation/kat/
+
+rm -R -f /tmp/%FIFO_DIR%/
+mkdir -p /tmp/%FIFO_DIR%/fifo/
+mkdir /tmp/%FIFO_DIR%/fifo/full_correlation/
+mkdir work/gul_S1_summaryleccalc
+mkdir work/full_correlation/gul_S1_summaryleccalc
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P11
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P12
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P13
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P14
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P15
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P16
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P17
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P18
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P19
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P20
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P1
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P2
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P3
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P4
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P5
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P6
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P7
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P8
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P9
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P10
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P11
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P12
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P13
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P14
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P15
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P16
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P17
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P18
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P19
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P20
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P11
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P12
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P13
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P14
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P15
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P16
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P17
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P18
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P19
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P20
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P1
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P2
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P3
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P4
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P5
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P6
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P7
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P8
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P9
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P10
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P11
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P12
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P13
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P14
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P15
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P16
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P17
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P18
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P19
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P20
+
+
+
+# --- Do ground up loss computes ---
+
+
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P1 work/gul_S1_summaryleccalc/P1.bin > /dev/null & pid1=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P2 work/gul_S1_summaryleccalc/P2.bin > /dev/null & pid2=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P3 work/gul_S1_summaryleccalc/P3.bin > /dev/null & pid3=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P4 work/gul_S1_summaryleccalc/P4.bin > /dev/null & pid4=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P5 work/gul_S1_summaryleccalc/P5.bin > /dev/null & pid5=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P6 work/gul_S1_summaryleccalc/P6.bin > /dev/null & pid6=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P7 work/gul_S1_summaryleccalc/P7.bin > /dev/null & pid7=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P8 work/gul_S1_summaryleccalc/P8.bin > /dev/null & pid8=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P9 work/gul_S1_summaryleccalc/P9.bin > /dev/null & pid9=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P10 work/gul_S1_summaryleccalc/P10.bin > /dev/null & pid10=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P11 work/gul_S1_summaryleccalc/P11.bin > /dev/null & pid11=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P12 work/gul_S1_summaryleccalc/P12.bin > /dev/null & pid12=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P13 work/gul_S1_summaryleccalc/P13.bin > /dev/null & pid13=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P14 work/gul_S1_summaryleccalc/P14.bin > /dev/null & pid14=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P15 work/gul_S1_summaryleccalc/P15.bin > /dev/null & pid15=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P16 work/gul_S1_summaryleccalc/P16.bin > /dev/null & pid16=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P17 work/gul_S1_summaryleccalc/P17.bin > /dev/null & pid17=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P18 work/gul_S1_summaryleccalc/P18.bin > /dev/null & pid18=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P19 work/gul_S1_summaryleccalc/P19.bin > /dev/null & pid19=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P20 work/gul_S1_summaryleccalc/P20.bin > /dev/null & pid20=$!
+
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P1 < /tmp/%FIFO_DIR%/fifo/gul_P1 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P2 < /tmp/%FIFO_DIR%/fifo/gul_P2 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P3 < /tmp/%FIFO_DIR%/fifo/gul_P3 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P4 < /tmp/%FIFO_DIR%/fifo/gul_P4 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P5 < /tmp/%FIFO_DIR%/fifo/gul_P5 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P6 < /tmp/%FIFO_DIR%/fifo/gul_P6 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P7 < /tmp/%FIFO_DIR%/fifo/gul_P7 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P8 < /tmp/%FIFO_DIR%/fifo/gul_P8 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P9 < /tmp/%FIFO_DIR%/fifo/gul_P9 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P10 < /tmp/%FIFO_DIR%/fifo/gul_P10 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P11 < /tmp/%FIFO_DIR%/fifo/gul_P11 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P12 < /tmp/%FIFO_DIR%/fifo/gul_P12 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P13 < /tmp/%FIFO_DIR%/fifo/gul_P13 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P14 < /tmp/%FIFO_DIR%/fifo/gul_P14 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P15 < /tmp/%FIFO_DIR%/fifo/gul_P15 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P16 < /tmp/%FIFO_DIR%/fifo/gul_P16 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P17 < /tmp/%FIFO_DIR%/fifo/gul_P17 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P18 < /tmp/%FIFO_DIR%/fifo/gul_P18 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P19 < /tmp/%FIFO_DIR%/fifo/gul_P19 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P20 < /tmp/%FIFO_DIR%/fifo/gul_P20 &
+
+# --- Do ground up loss computes ---
+
+
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P1 work/full_correlation/gul_S1_summaryleccalc/P1.bin > /dev/null & pid21=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P2 work/full_correlation/gul_S1_summaryleccalc/P2.bin > /dev/null & pid22=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P3 work/full_correlation/gul_S1_summaryleccalc/P3.bin > /dev/null & pid23=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P4 work/full_correlation/gul_S1_summaryleccalc/P4.bin > /dev/null & pid24=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P5 work/full_correlation/gul_S1_summaryleccalc/P5.bin > /dev/null & pid25=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P6 work/full_correlation/gul_S1_summaryleccalc/P6.bin > /dev/null & pid26=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P7 work/full_correlation/gul_S1_summaryleccalc/P7.bin > /dev/null & pid27=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P8 work/full_correlation/gul_S1_summaryleccalc/P8.bin > /dev/null & pid28=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P9 work/full_correlation/gul_S1_summaryleccalc/P9.bin > /dev/null & pid29=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P10 work/full_correlation/gul_S1_summaryleccalc/P10.bin > /dev/null & pid30=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P11 work/full_correlation/gul_S1_summaryleccalc/P11.bin > /dev/null & pid31=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P12 work/full_correlation/gul_S1_summaryleccalc/P12.bin > /dev/null & pid32=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P13 work/full_correlation/gul_S1_summaryleccalc/P13.bin > /dev/null & pid33=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P14 work/full_correlation/gul_S1_summaryleccalc/P14.bin > /dev/null & pid34=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P15 work/full_correlation/gul_S1_summaryleccalc/P15.bin > /dev/null & pid35=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P16 work/full_correlation/gul_S1_summaryleccalc/P16.bin > /dev/null & pid36=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P17 work/full_correlation/gul_S1_summaryleccalc/P17.bin > /dev/null & pid37=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P18 work/full_correlation/gul_S1_summaryleccalc/P18.bin > /dev/null & pid38=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P19 work/full_correlation/gul_S1_summaryleccalc/P19.bin > /dev/null & pid39=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P20 work/full_correlation/gul_S1_summaryleccalc/P20.bin > /dev/null & pid40=$!
+
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P1 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P1 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P2 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P2 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P3 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P3 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P4 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P4 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P5 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P5 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P6 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P6 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P7 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P7 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P8 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P8 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P9 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P9 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P10 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P10 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P11 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P11 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P12 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P12 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P13 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P13 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P14 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P14 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P15 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P15 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P16 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P16 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P17 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P17 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P18 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P18 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P19 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P19 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P20 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P20 &
+
+eve 1 20 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P1 -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P1  &
+eve 2 20 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P2 -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P2  &
+eve 3 20 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P3 -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P3  &
+eve 4 20 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P4 -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P4  &
+eve 5 20 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P5 -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P5  &
+eve 6 20 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P6 -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P6  &
+eve 7 20 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P7 -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P7  &
+eve 8 20 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P8 -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P8  &
+eve 9 20 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P9 -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P9  &
+eve 10 20 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P10 -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P10  &
+eve 11 20 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P11 -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P11  &
+eve 12 20 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P12 -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P12  &
+eve 13 20 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P13 -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P13  &
+eve 14 20 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P14 -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P14  &
+eve 15 20 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P15 -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P15  &
+eve 16 20 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P16 -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P16  &
+eve 17 20 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P17 -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P17  &
+eve 18 20 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P18 -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P18  &
+eve 19 20 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P19 -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P19  &
+eve 20 20 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P20 -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P20  &
+
+wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 $pid13 $pid14 $pid15 $pid16 $pid17 $pid18 $pid19 $pid20 $pid21 $pid22 $pid23 $pid24 $pid25 $pid26 $pid27 $pid28 $pid29 $pid30 $pid31 $pid32 $pid33 $pid34 $pid35 $pid36 $pid37 $pid38 $pid39 $pid40
+
+
+# --- Do ground up loss kats ---
+
+
+# --- Do ground up loss kats for fully correlated output ---
+
+
+ordleccalc -r -Kgul_S1_summaryleccalc -F -f -S -s -M -m -O output/gul_S1_ept.csv & lpid1=$!
+ordleccalc -r -Kfull_correlation/gul_S1_summaryleccalc -F -f -S -s -M -m -O output/full_correlation/gul_S1_ept.csv & lpid2=$!
+wait $lpid1 $lpid2
+
+rm -R -f work/*
+rm -R -f /tmp/%FIFO_DIR%/

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_ord_ept_psept_lec_2_output_10_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_ord_ept_psept_lec_2_output_10_partition.sh
@@ -1,0 +1,476 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+mkdir output/full_correlation/
+
+rm -R -f work/*
+mkdir work/kat/
+mkdir work/full_correlation/
+mkdir work/full_correlation/kat/
+
+rm -R -f /tmp/%FIFO_DIR%/
+mkdir -p /tmp/%FIFO_DIR%/fifo/
+mkdir /tmp/%FIFO_DIR%/fifo/full_correlation/
+mkdir work/gul_S1_summaryleccalc
+mkdir work/gul_S1_summaryaalcalc
+mkdir work/gul_S2_summaryleccalc
+mkdir work/gul_S2_summaryaalcalc
+mkdir work/full_correlation/gul_S1_summaryleccalc
+mkdir work/full_correlation/gul_S1_summaryaalcalc
+mkdir work/full_correlation/gul_S2_summaryleccalc
+mkdir work/full_correlation/gul_S2_summaryaalcalc
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P10
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P1
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P2
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P3
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P4
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P5
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P6
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P7
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P8
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P9
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P10
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P10
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P1
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P2
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P3
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P4
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P5
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P6
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P7
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P8
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P9
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P10
+
+
+
+# --- Do ground up loss computes ---
+
+eltcalc < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P1 > work/kat/gul_S1_eltcalc_P1 & pid1=$!
+summarycalctocsv < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P1 > work/kat/gul_S1_summarycalc_P1 & pid2=$!
+pltcalc < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P1 > work/kat/gul_S1_pltcalc_P1 & pid3=$!
+eltcalc < /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P1 > work/kat/gul_S2_eltcalc_P1 & pid4=$!
+summarycalctocsv < /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P1 > work/kat/gul_S2_summarycalc_P1 & pid5=$!
+pltcalc < /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P1 > work/kat/gul_S2_pltcalc_P1 & pid6=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P2 > work/kat/gul_S1_eltcalc_P2 & pid7=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P2 > work/kat/gul_S1_summarycalc_P2 & pid8=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P2 > work/kat/gul_S1_pltcalc_P2 & pid9=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P2 > work/kat/gul_S2_eltcalc_P2 & pid10=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P2 > work/kat/gul_S2_summarycalc_P2 & pid11=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P2 > work/kat/gul_S2_pltcalc_P2 & pid12=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P3 > work/kat/gul_S1_eltcalc_P3 & pid13=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P3 > work/kat/gul_S1_summarycalc_P3 & pid14=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P3 > work/kat/gul_S1_pltcalc_P3 & pid15=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P3 > work/kat/gul_S2_eltcalc_P3 & pid16=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P3 > work/kat/gul_S2_summarycalc_P3 & pid17=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P3 > work/kat/gul_S2_pltcalc_P3 & pid18=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P4 > work/kat/gul_S1_eltcalc_P4 & pid19=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P4 > work/kat/gul_S1_summarycalc_P4 & pid20=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P4 > work/kat/gul_S1_pltcalc_P4 & pid21=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P4 > work/kat/gul_S2_eltcalc_P4 & pid22=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P4 > work/kat/gul_S2_summarycalc_P4 & pid23=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P4 > work/kat/gul_S2_pltcalc_P4 & pid24=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P5 > work/kat/gul_S1_eltcalc_P5 & pid25=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P5 > work/kat/gul_S1_summarycalc_P5 & pid26=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P5 > work/kat/gul_S1_pltcalc_P5 & pid27=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P5 > work/kat/gul_S2_eltcalc_P5 & pid28=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P5 > work/kat/gul_S2_summarycalc_P5 & pid29=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P5 > work/kat/gul_S2_pltcalc_P5 & pid30=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P6 > work/kat/gul_S1_eltcalc_P6 & pid31=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P6 > work/kat/gul_S1_summarycalc_P6 & pid32=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P6 > work/kat/gul_S1_pltcalc_P6 & pid33=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P6 > work/kat/gul_S2_eltcalc_P6 & pid34=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P6 > work/kat/gul_S2_summarycalc_P6 & pid35=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P6 > work/kat/gul_S2_pltcalc_P6 & pid36=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P7 > work/kat/gul_S1_eltcalc_P7 & pid37=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P7 > work/kat/gul_S1_summarycalc_P7 & pid38=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P7 > work/kat/gul_S1_pltcalc_P7 & pid39=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P7 > work/kat/gul_S2_eltcalc_P7 & pid40=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P7 > work/kat/gul_S2_summarycalc_P7 & pid41=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P7 > work/kat/gul_S2_pltcalc_P7 & pid42=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P8 > work/kat/gul_S1_eltcalc_P8 & pid43=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P8 > work/kat/gul_S1_summarycalc_P8 & pid44=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P8 > work/kat/gul_S1_pltcalc_P8 & pid45=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P8 > work/kat/gul_S2_eltcalc_P8 & pid46=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P8 > work/kat/gul_S2_summarycalc_P8 & pid47=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P8 > work/kat/gul_S2_pltcalc_P8 & pid48=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P9 > work/kat/gul_S1_eltcalc_P9 & pid49=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P9 > work/kat/gul_S1_summarycalc_P9 & pid50=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P9 > work/kat/gul_S1_pltcalc_P9 & pid51=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P9 > work/kat/gul_S2_eltcalc_P9 & pid52=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P9 > work/kat/gul_S2_summarycalc_P9 & pid53=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P9 > work/kat/gul_S2_pltcalc_P9 & pid54=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P10 > work/kat/gul_S1_eltcalc_P10 & pid55=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P10 > work/kat/gul_S1_summarycalc_P10 & pid56=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P10 > work/kat/gul_S1_pltcalc_P10 & pid57=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P10 > work/kat/gul_S2_eltcalc_P10 & pid58=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P10 > work/kat/gul_S2_summarycalc_P10 & pid59=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P10 > work/kat/gul_S2_pltcalc_P10 & pid60=$!
+
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P1 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P1 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P1 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P1 work/gul_S1_summaryaalcalc/P1.bin work/gul_S1_summaryleccalc/P1.bin > /dev/null & pid61=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P1 /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P1 /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P1 /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P1 work/gul_S2_summaryaalcalc/P1.bin work/gul_S2_summaryleccalc/P1.bin > /dev/null & pid62=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P2 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P2 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P2 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P2 work/gul_S1_summaryaalcalc/P2.bin work/gul_S1_summaryleccalc/P2.bin > /dev/null & pid63=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P2 /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P2 /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P2 /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P2 work/gul_S2_summaryaalcalc/P2.bin work/gul_S2_summaryleccalc/P2.bin > /dev/null & pid64=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P3 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P3 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P3 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P3 work/gul_S1_summaryaalcalc/P3.bin work/gul_S1_summaryleccalc/P3.bin > /dev/null & pid65=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P3 /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P3 /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P3 /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P3 work/gul_S2_summaryaalcalc/P3.bin work/gul_S2_summaryleccalc/P3.bin > /dev/null & pid66=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P4 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P4 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P4 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P4 work/gul_S1_summaryaalcalc/P4.bin work/gul_S1_summaryleccalc/P4.bin > /dev/null & pid67=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P4 /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P4 /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P4 /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P4 work/gul_S2_summaryaalcalc/P4.bin work/gul_S2_summaryleccalc/P4.bin > /dev/null & pid68=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P5 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P5 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P5 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P5 work/gul_S1_summaryaalcalc/P5.bin work/gul_S1_summaryleccalc/P5.bin > /dev/null & pid69=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P5 /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P5 /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P5 /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P5 work/gul_S2_summaryaalcalc/P5.bin work/gul_S2_summaryleccalc/P5.bin > /dev/null & pid70=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P6 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P6 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P6 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P6 work/gul_S1_summaryaalcalc/P6.bin work/gul_S1_summaryleccalc/P6.bin > /dev/null & pid71=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P6 /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P6 /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P6 /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P6 work/gul_S2_summaryaalcalc/P6.bin work/gul_S2_summaryleccalc/P6.bin > /dev/null & pid72=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P7 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P7 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P7 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P7 work/gul_S1_summaryaalcalc/P7.bin work/gul_S1_summaryleccalc/P7.bin > /dev/null & pid73=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P7 /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P7 /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P7 /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P7 work/gul_S2_summaryaalcalc/P7.bin work/gul_S2_summaryleccalc/P7.bin > /dev/null & pid74=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P8 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P8 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P8 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P8 work/gul_S1_summaryaalcalc/P8.bin work/gul_S1_summaryleccalc/P8.bin > /dev/null & pid75=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P8 /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P8 /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P8 /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P8 work/gul_S2_summaryaalcalc/P8.bin work/gul_S2_summaryleccalc/P8.bin > /dev/null & pid76=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P9 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P9 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P9 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P9 work/gul_S1_summaryaalcalc/P9.bin work/gul_S1_summaryleccalc/P9.bin > /dev/null & pid77=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P9 /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P9 /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P9 /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P9 work/gul_S2_summaryaalcalc/P9.bin work/gul_S2_summaryleccalc/P9.bin > /dev/null & pid78=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P10 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P10 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P10 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P10 work/gul_S1_summaryaalcalc/P10.bin work/gul_S1_summaryleccalc/P10.bin > /dev/null & pid79=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P10 /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P10 /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P10 /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P10 work/gul_S2_summaryaalcalc/P10.bin work/gul_S2_summaryleccalc/P10.bin > /dev/null & pid80=$!
+
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P1 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P1 < /tmp/%FIFO_DIR%/fifo/gul_P1 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P2 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P2 < /tmp/%FIFO_DIR%/fifo/gul_P2 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P3 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P3 < /tmp/%FIFO_DIR%/fifo/gul_P3 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P4 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P4 < /tmp/%FIFO_DIR%/fifo/gul_P4 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P5 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P5 < /tmp/%FIFO_DIR%/fifo/gul_P5 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P6 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P6 < /tmp/%FIFO_DIR%/fifo/gul_P6 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P7 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P7 < /tmp/%FIFO_DIR%/fifo/gul_P7 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P8 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P8 < /tmp/%FIFO_DIR%/fifo/gul_P8 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P9 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P9 < /tmp/%FIFO_DIR%/fifo/gul_P9 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P10 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P10 < /tmp/%FIFO_DIR%/fifo/gul_P10 &
+
+# --- Do ground up loss computes ---
+
+eltcalc < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P1 > work/full_correlation/kat/gul_S1_eltcalc_P1 & pid81=$!
+summarycalctocsv < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P1 > work/full_correlation/kat/gul_S1_summarycalc_P1 & pid82=$!
+pltcalc < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P1 > work/full_correlation/kat/gul_S1_pltcalc_P1 & pid83=$!
+eltcalc < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P1 > work/full_correlation/kat/gul_S2_eltcalc_P1 & pid84=$!
+summarycalctocsv < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P1 > work/full_correlation/kat/gul_S2_summarycalc_P1 & pid85=$!
+pltcalc < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P1 > work/full_correlation/kat/gul_S2_pltcalc_P1 & pid86=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P2 > work/full_correlation/kat/gul_S1_eltcalc_P2 & pid87=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P2 > work/full_correlation/kat/gul_S1_summarycalc_P2 & pid88=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P2 > work/full_correlation/kat/gul_S1_pltcalc_P2 & pid89=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P2 > work/full_correlation/kat/gul_S2_eltcalc_P2 & pid90=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P2 > work/full_correlation/kat/gul_S2_summarycalc_P2 & pid91=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P2 > work/full_correlation/kat/gul_S2_pltcalc_P2 & pid92=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P3 > work/full_correlation/kat/gul_S1_eltcalc_P3 & pid93=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P3 > work/full_correlation/kat/gul_S1_summarycalc_P3 & pid94=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P3 > work/full_correlation/kat/gul_S1_pltcalc_P3 & pid95=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P3 > work/full_correlation/kat/gul_S2_eltcalc_P3 & pid96=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P3 > work/full_correlation/kat/gul_S2_summarycalc_P3 & pid97=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P3 > work/full_correlation/kat/gul_S2_pltcalc_P3 & pid98=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P4 > work/full_correlation/kat/gul_S1_eltcalc_P4 & pid99=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P4 > work/full_correlation/kat/gul_S1_summarycalc_P4 & pid100=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P4 > work/full_correlation/kat/gul_S1_pltcalc_P4 & pid101=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P4 > work/full_correlation/kat/gul_S2_eltcalc_P4 & pid102=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P4 > work/full_correlation/kat/gul_S2_summarycalc_P4 & pid103=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P4 > work/full_correlation/kat/gul_S2_pltcalc_P4 & pid104=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P5 > work/full_correlation/kat/gul_S1_eltcalc_P5 & pid105=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P5 > work/full_correlation/kat/gul_S1_summarycalc_P5 & pid106=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P5 > work/full_correlation/kat/gul_S1_pltcalc_P5 & pid107=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P5 > work/full_correlation/kat/gul_S2_eltcalc_P5 & pid108=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P5 > work/full_correlation/kat/gul_S2_summarycalc_P5 & pid109=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P5 > work/full_correlation/kat/gul_S2_pltcalc_P5 & pid110=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P6 > work/full_correlation/kat/gul_S1_eltcalc_P6 & pid111=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P6 > work/full_correlation/kat/gul_S1_summarycalc_P6 & pid112=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P6 > work/full_correlation/kat/gul_S1_pltcalc_P6 & pid113=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P6 > work/full_correlation/kat/gul_S2_eltcalc_P6 & pid114=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P6 > work/full_correlation/kat/gul_S2_summarycalc_P6 & pid115=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P6 > work/full_correlation/kat/gul_S2_pltcalc_P6 & pid116=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P7 > work/full_correlation/kat/gul_S1_eltcalc_P7 & pid117=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P7 > work/full_correlation/kat/gul_S1_summarycalc_P7 & pid118=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P7 > work/full_correlation/kat/gul_S1_pltcalc_P7 & pid119=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P7 > work/full_correlation/kat/gul_S2_eltcalc_P7 & pid120=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P7 > work/full_correlation/kat/gul_S2_summarycalc_P7 & pid121=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P7 > work/full_correlation/kat/gul_S2_pltcalc_P7 & pid122=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P8 > work/full_correlation/kat/gul_S1_eltcalc_P8 & pid123=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P8 > work/full_correlation/kat/gul_S1_summarycalc_P8 & pid124=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P8 > work/full_correlation/kat/gul_S1_pltcalc_P8 & pid125=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P8 > work/full_correlation/kat/gul_S2_eltcalc_P8 & pid126=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P8 > work/full_correlation/kat/gul_S2_summarycalc_P8 & pid127=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P8 > work/full_correlation/kat/gul_S2_pltcalc_P8 & pid128=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P9 > work/full_correlation/kat/gul_S1_eltcalc_P9 & pid129=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P9 > work/full_correlation/kat/gul_S1_summarycalc_P9 & pid130=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P9 > work/full_correlation/kat/gul_S1_pltcalc_P9 & pid131=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P9 > work/full_correlation/kat/gul_S2_eltcalc_P9 & pid132=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P9 > work/full_correlation/kat/gul_S2_summarycalc_P9 & pid133=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P9 > work/full_correlation/kat/gul_S2_pltcalc_P9 & pid134=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P10 > work/full_correlation/kat/gul_S1_eltcalc_P10 & pid135=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P10 > work/full_correlation/kat/gul_S1_summarycalc_P10 & pid136=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P10 > work/full_correlation/kat/gul_S1_pltcalc_P10 & pid137=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P10 > work/full_correlation/kat/gul_S2_eltcalc_P10 & pid138=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P10 > work/full_correlation/kat/gul_S2_summarycalc_P10 & pid139=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P10 > work/full_correlation/kat/gul_S2_pltcalc_P10 & pid140=$!
+
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P1 work/full_correlation/gul_S1_summaryaalcalc/P1.bin work/full_correlation/gul_S1_summaryleccalc/P1.bin > /dev/null & pid141=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P1 work/full_correlation/gul_S2_summaryaalcalc/P1.bin work/full_correlation/gul_S2_summaryleccalc/P1.bin > /dev/null & pid142=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P2 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P2 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P2 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P2 work/full_correlation/gul_S1_summaryaalcalc/P2.bin work/full_correlation/gul_S1_summaryleccalc/P2.bin > /dev/null & pid143=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P2 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P2 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P2 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P2 work/full_correlation/gul_S2_summaryaalcalc/P2.bin work/full_correlation/gul_S2_summaryleccalc/P2.bin > /dev/null & pid144=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P3 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P3 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P3 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P3 work/full_correlation/gul_S1_summaryaalcalc/P3.bin work/full_correlation/gul_S1_summaryleccalc/P3.bin > /dev/null & pid145=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P3 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P3 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P3 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P3 work/full_correlation/gul_S2_summaryaalcalc/P3.bin work/full_correlation/gul_S2_summaryleccalc/P3.bin > /dev/null & pid146=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P4 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P4 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P4 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P4 work/full_correlation/gul_S1_summaryaalcalc/P4.bin work/full_correlation/gul_S1_summaryleccalc/P4.bin > /dev/null & pid147=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P4 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P4 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P4 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P4 work/full_correlation/gul_S2_summaryaalcalc/P4.bin work/full_correlation/gul_S2_summaryleccalc/P4.bin > /dev/null & pid148=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P5 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P5 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P5 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P5 work/full_correlation/gul_S1_summaryaalcalc/P5.bin work/full_correlation/gul_S1_summaryleccalc/P5.bin > /dev/null & pid149=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P5 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P5 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P5 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P5 work/full_correlation/gul_S2_summaryaalcalc/P5.bin work/full_correlation/gul_S2_summaryleccalc/P5.bin > /dev/null & pid150=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P6 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P6 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P6 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P6 work/full_correlation/gul_S1_summaryaalcalc/P6.bin work/full_correlation/gul_S1_summaryleccalc/P6.bin > /dev/null & pid151=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P6 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P6 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P6 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P6 work/full_correlation/gul_S2_summaryaalcalc/P6.bin work/full_correlation/gul_S2_summaryleccalc/P6.bin > /dev/null & pid152=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P7 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P7 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P7 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P7 work/full_correlation/gul_S1_summaryaalcalc/P7.bin work/full_correlation/gul_S1_summaryleccalc/P7.bin > /dev/null & pid153=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P7 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P7 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P7 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P7 work/full_correlation/gul_S2_summaryaalcalc/P7.bin work/full_correlation/gul_S2_summaryleccalc/P7.bin > /dev/null & pid154=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P8 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P8 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P8 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P8 work/full_correlation/gul_S1_summaryaalcalc/P8.bin work/full_correlation/gul_S1_summaryleccalc/P8.bin > /dev/null & pid155=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P8 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P8 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P8 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P8 work/full_correlation/gul_S2_summaryaalcalc/P8.bin work/full_correlation/gul_S2_summaryleccalc/P8.bin > /dev/null & pid156=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P9 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P9 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P9 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P9 work/full_correlation/gul_S1_summaryaalcalc/P9.bin work/full_correlation/gul_S1_summaryleccalc/P9.bin > /dev/null & pid157=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P9 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P9 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P9 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P9 work/full_correlation/gul_S2_summaryaalcalc/P9.bin work/full_correlation/gul_S2_summaryleccalc/P9.bin > /dev/null & pid158=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P10 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_eltcalc_P10 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summarycalc_P10 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_pltcalc_P10 work/full_correlation/gul_S1_summaryaalcalc/P10.bin work/full_correlation/gul_S1_summaryleccalc/P10.bin > /dev/null & pid159=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P10 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_eltcalc_P10 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summarycalc_P10 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_pltcalc_P10 work/full_correlation/gul_S2_summaryaalcalc/P10.bin work/full_correlation/gul_S2_summaryleccalc/P10.bin > /dev/null & pid160=$!
+
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P1 -2 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P1 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P1 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P2 -2 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P2 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P2 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P3 -2 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P3 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P3 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P4 -2 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P4 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P4 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P5 -2 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P5 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P5 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P6 -2 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P6 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P6 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P7 -2 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P7 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P7 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P8 -2 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P8 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P8 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P9 -2 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P9 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P9 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P10 -2 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P10 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P10 &
+
+eve 1 10 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P1 -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P1  &
+eve 2 10 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P2 -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P2  &
+eve 3 10 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P3 -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P3  &
+eve 4 10 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P4 -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P4  &
+eve 5 10 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P5 -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P5  &
+eve 6 10 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P6 -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P6  &
+eve 7 10 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P7 -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P7  &
+eve 8 10 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P8 -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P8  &
+eve 9 10 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P9 -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P9  &
+eve 10 10 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P10 -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P10  &
+
+wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 $pid13 $pid14 $pid15 $pid16 $pid17 $pid18 $pid19 $pid20 $pid21 $pid22 $pid23 $pid24 $pid25 $pid26 $pid27 $pid28 $pid29 $pid30 $pid31 $pid32 $pid33 $pid34 $pid35 $pid36 $pid37 $pid38 $pid39 $pid40 $pid41 $pid42 $pid43 $pid44 $pid45 $pid46 $pid47 $pid48 $pid49 $pid50 $pid51 $pid52 $pid53 $pid54 $pid55 $pid56 $pid57 $pid58 $pid59 $pid60 $pid61 $pid62 $pid63 $pid64 $pid65 $pid66 $pid67 $pid68 $pid69 $pid70 $pid71 $pid72 $pid73 $pid74 $pid75 $pid76 $pid77 $pid78 $pid79 $pid80 $pid81 $pid82 $pid83 $pid84 $pid85 $pid86 $pid87 $pid88 $pid89 $pid90 $pid91 $pid92 $pid93 $pid94 $pid95 $pid96 $pid97 $pid98 $pid99 $pid100 $pid101 $pid102 $pid103 $pid104 $pid105 $pid106 $pid107 $pid108 $pid109 $pid110 $pid111 $pid112 $pid113 $pid114 $pid115 $pid116 $pid117 $pid118 $pid119 $pid120 $pid121 $pid122 $pid123 $pid124 $pid125 $pid126 $pid127 $pid128 $pid129 $pid130 $pid131 $pid132 $pid133 $pid134 $pid135 $pid136 $pid137 $pid138 $pid139 $pid140 $pid141 $pid142 $pid143 $pid144 $pid145 $pid146 $pid147 $pid148 $pid149 $pid150 $pid151 $pid152 $pid153 $pid154 $pid155 $pid156 $pid157 $pid158 $pid159 $pid160
+
+
+# --- Do ground up loss kats ---
+
+kat -s work/kat/gul_S1_eltcalc_P1 work/kat/gul_S1_eltcalc_P2 work/kat/gul_S1_eltcalc_P3 work/kat/gul_S1_eltcalc_P4 work/kat/gul_S1_eltcalc_P5 work/kat/gul_S1_eltcalc_P6 work/kat/gul_S1_eltcalc_P7 work/kat/gul_S1_eltcalc_P8 work/kat/gul_S1_eltcalc_P9 work/kat/gul_S1_eltcalc_P10 > output/gul_S1_eltcalc.csv & kpid1=$!
+kat work/kat/gul_S1_pltcalc_P1 work/kat/gul_S1_pltcalc_P2 work/kat/gul_S1_pltcalc_P3 work/kat/gul_S1_pltcalc_P4 work/kat/gul_S1_pltcalc_P5 work/kat/gul_S1_pltcalc_P6 work/kat/gul_S1_pltcalc_P7 work/kat/gul_S1_pltcalc_P8 work/kat/gul_S1_pltcalc_P9 work/kat/gul_S1_pltcalc_P10 > output/gul_S1_pltcalc.csv & kpid2=$!
+kat work/kat/gul_S1_summarycalc_P1 work/kat/gul_S1_summarycalc_P2 work/kat/gul_S1_summarycalc_P3 work/kat/gul_S1_summarycalc_P4 work/kat/gul_S1_summarycalc_P5 work/kat/gul_S1_summarycalc_P6 work/kat/gul_S1_summarycalc_P7 work/kat/gul_S1_summarycalc_P8 work/kat/gul_S1_summarycalc_P9 work/kat/gul_S1_summarycalc_P10 > output/gul_S1_summarycalc.csv & kpid3=$!
+kat -s work/kat/gul_S2_eltcalc_P1 work/kat/gul_S2_eltcalc_P2 work/kat/gul_S2_eltcalc_P3 work/kat/gul_S2_eltcalc_P4 work/kat/gul_S2_eltcalc_P5 work/kat/gul_S2_eltcalc_P6 work/kat/gul_S2_eltcalc_P7 work/kat/gul_S2_eltcalc_P8 work/kat/gul_S2_eltcalc_P9 work/kat/gul_S2_eltcalc_P10 > output/gul_S2_eltcalc.csv & kpid4=$!
+kat work/kat/gul_S2_pltcalc_P1 work/kat/gul_S2_pltcalc_P2 work/kat/gul_S2_pltcalc_P3 work/kat/gul_S2_pltcalc_P4 work/kat/gul_S2_pltcalc_P5 work/kat/gul_S2_pltcalc_P6 work/kat/gul_S2_pltcalc_P7 work/kat/gul_S2_pltcalc_P8 work/kat/gul_S2_pltcalc_P9 work/kat/gul_S2_pltcalc_P10 > output/gul_S2_pltcalc.csv & kpid5=$!
+kat work/kat/gul_S2_summarycalc_P1 work/kat/gul_S2_summarycalc_P2 work/kat/gul_S2_summarycalc_P3 work/kat/gul_S2_summarycalc_P4 work/kat/gul_S2_summarycalc_P5 work/kat/gul_S2_summarycalc_P6 work/kat/gul_S2_summarycalc_P7 work/kat/gul_S2_summarycalc_P8 work/kat/gul_S2_summarycalc_P9 work/kat/gul_S2_summarycalc_P10 > output/gul_S2_summarycalc.csv & kpid6=$!
+
+# --- Do ground up loss kats for fully correlated output ---
+
+kat -s work/full_correlation/kat/gul_S1_eltcalc_P1 work/full_correlation/kat/gul_S1_eltcalc_P2 work/full_correlation/kat/gul_S1_eltcalc_P3 work/full_correlation/kat/gul_S1_eltcalc_P4 work/full_correlation/kat/gul_S1_eltcalc_P5 work/full_correlation/kat/gul_S1_eltcalc_P6 work/full_correlation/kat/gul_S1_eltcalc_P7 work/full_correlation/kat/gul_S1_eltcalc_P8 work/full_correlation/kat/gul_S1_eltcalc_P9 work/full_correlation/kat/gul_S1_eltcalc_P10 > output/full_correlation/gul_S1_eltcalc.csv & kpid7=$!
+kat work/full_correlation/kat/gul_S1_pltcalc_P1 work/full_correlation/kat/gul_S1_pltcalc_P2 work/full_correlation/kat/gul_S1_pltcalc_P3 work/full_correlation/kat/gul_S1_pltcalc_P4 work/full_correlation/kat/gul_S1_pltcalc_P5 work/full_correlation/kat/gul_S1_pltcalc_P6 work/full_correlation/kat/gul_S1_pltcalc_P7 work/full_correlation/kat/gul_S1_pltcalc_P8 work/full_correlation/kat/gul_S1_pltcalc_P9 work/full_correlation/kat/gul_S1_pltcalc_P10 > output/full_correlation/gul_S1_pltcalc.csv & kpid8=$!
+kat work/full_correlation/kat/gul_S1_summarycalc_P1 work/full_correlation/kat/gul_S1_summarycalc_P2 work/full_correlation/kat/gul_S1_summarycalc_P3 work/full_correlation/kat/gul_S1_summarycalc_P4 work/full_correlation/kat/gul_S1_summarycalc_P5 work/full_correlation/kat/gul_S1_summarycalc_P6 work/full_correlation/kat/gul_S1_summarycalc_P7 work/full_correlation/kat/gul_S1_summarycalc_P8 work/full_correlation/kat/gul_S1_summarycalc_P9 work/full_correlation/kat/gul_S1_summarycalc_P10 > output/full_correlation/gul_S1_summarycalc.csv & kpid9=$!
+kat -s work/full_correlation/kat/gul_S2_eltcalc_P1 work/full_correlation/kat/gul_S2_eltcalc_P2 work/full_correlation/kat/gul_S2_eltcalc_P3 work/full_correlation/kat/gul_S2_eltcalc_P4 work/full_correlation/kat/gul_S2_eltcalc_P5 work/full_correlation/kat/gul_S2_eltcalc_P6 work/full_correlation/kat/gul_S2_eltcalc_P7 work/full_correlation/kat/gul_S2_eltcalc_P8 work/full_correlation/kat/gul_S2_eltcalc_P9 work/full_correlation/kat/gul_S2_eltcalc_P10 > output/full_correlation/gul_S2_eltcalc.csv & kpid10=$!
+kat work/full_correlation/kat/gul_S2_pltcalc_P1 work/full_correlation/kat/gul_S2_pltcalc_P2 work/full_correlation/kat/gul_S2_pltcalc_P3 work/full_correlation/kat/gul_S2_pltcalc_P4 work/full_correlation/kat/gul_S2_pltcalc_P5 work/full_correlation/kat/gul_S2_pltcalc_P6 work/full_correlation/kat/gul_S2_pltcalc_P7 work/full_correlation/kat/gul_S2_pltcalc_P8 work/full_correlation/kat/gul_S2_pltcalc_P9 work/full_correlation/kat/gul_S2_pltcalc_P10 > output/full_correlation/gul_S2_pltcalc.csv & kpid11=$!
+kat work/full_correlation/kat/gul_S2_summarycalc_P1 work/full_correlation/kat/gul_S2_summarycalc_P2 work/full_correlation/kat/gul_S2_summarycalc_P3 work/full_correlation/kat/gul_S2_summarycalc_P4 work/full_correlation/kat/gul_S2_summarycalc_P5 work/full_correlation/kat/gul_S2_summarycalc_P6 work/full_correlation/kat/gul_S2_summarycalc_P7 work/full_correlation/kat/gul_S2_summarycalc_P8 work/full_correlation/kat/gul_S2_summarycalc_P9 work/full_correlation/kat/gul_S2_summarycalc_P10 > output/full_correlation/gul_S2_summarycalc.csv & kpid12=$!
+wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpid11 $kpid12
+
+
+aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv & lpid1=$!
+ordleccalc -r -Kgul_S1_summaryleccalc -F -S -s -M -m -W -w -O output/gul_S1_ept.csv -o output/gul_S1_psept.csv & lpid2=$!
+leccalc -r -Kgul_S1_summaryleccalc -F output/gul_S1_leccalc_full_uncertainty_aep.csv -f output/gul_S1_leccalc_full_uncertainty_oep.csv -S output/gul_S1_leccalc_sample_mean_aep.csv -s output/gul_S1_leccalc_sample_mean_oep.csv -W output/gul_S1_leccalc_wheatsheaf_aep.csv -M output/gul_S1_leccalc_wheatsheaf_mean_aep.csv -m output/gul_S1_leccalc_wheatsheaf_mean_oep.csv -w output/gul_S1_leccalc_wheatsheaf_oep.csv & lpid3=$!
+aalcalc -Kgul_S2_summaryaalcalc > output/gul_S2_aalcalc.csv & lpid4=$!
+ordleccalc -r -Kgul_S2_summaryleccalc -F -S -s -M -m -W -w -O output/gul_S2_ept.csv -o output/gul_S2_psept.csv & lpid5=$!
+leccalc -r -Kgul_S2_summaryleccalc -F output/gul_S2_leccalc_full_uncertainty_aep.csv -f output/gul_S2_leccalc_full_uncertainty_oep.csv -S output/gul_S2_leccalc_sample_mean_aep.csv -s output/gul_S2_leccalc_sample_mean_oep.csv -W output/gul_S2_leccalc_wheatsheaf_aep.csv -M output/gul_S2_leccalc_wheatsheaf_mean_aep.csv -m output/gul_S2_leccalc_wheatsheaf_mean_oep.csv -w output/gul_S2_leccalc_wheatsheaf_oep.csv & lpid6=$!
+aalcalc -Kfull_correlation/gul_S1_summaryaalcalc > output/full_correlation/gul_S1_aalcalc.csv & lpid7=$!
+ordleccalc -r -Kfull_correlation/gul_S1_summaryleccalc -F -S -s -M -m -W -w -O output/full_correlation/gul_S1_ept.csv -o output/full_correlation/gul_S1_psept.csv & lpid8=$!
+leccalc -r -Kfull_correlation/gul_S1_summaryleccalc -F output/full_correlation/gul_S1_leccalc_full_uncertainty_aep.csv -f output/full_correlation/gul_S1_leccalc_full_uncertainty_oep.csv -S output/full_correlation/gul_S1_leccalc_sample_mean_aep.csv -s output/full_correlation/gul_S1_leccalc_sample_mean_oep.csv -W output/full_correlation/gul_S1_leccalc_wheatsheaf_aep.csv -M output/full_correlation/gul_S1_leccalc_wheatsheaf_mean_aep.csv -m output/full_correlation/gul_S1_leccalc_wheatsheaf_mean_oep.csv -w output/full_correlation/gul_S1_leccalc_wheatsheaf_oep.csv & lpid9=$!
+aalcalc -Kfull_correlation/gul_S2_summaryaalcalc > output/full_correlation/gul_S2_aalcalc.csv & lpid10=$!
+ordleccalc -r -Kfull_correlation/gul_S2_summaryleccalc -F -S -s -M -m -W -w -O output/full_correlation/gul_S2_ept.csv -o output/full_correlation/gul_S2_psept.csv & lpid11=$!
+leccalc -r -Kfull_correlation/gul_S2_summaryleccalc -F output/full_correlation/gul_S2_leccalc_full_uncertainty_aep.csv -f output/full_correlation/gul_S2_leccalc_full_uncertainty_oep.csv -S output/full_correlation/gul_S2_leccalc_sample_mean_aep.csv -s output/full_correlation/gul_S2_leccalc_sample_mean_oep.csv -W output/full_correlation/gul_S2_leccalc_wheatsheaf_aep.csv -M output/full_correlation/gul_S2_leccalc_wheatsheaf_mean_aep.csv -m output/full_correlation/gul_S2_leccalc_wheatsheaf_mean_oep.csv -w output/full_correlation/gul_S2_leccalc_wheatsheaf_oep.csv & lpid12=$!
+wait $lpid1 $lpid2 $lpid3 $lpid4 $lpid5 $lpid6 $lpid7 $lpid8 $lpid9 $lpid10 $lpid11 $lpid12
+
+rm -R -f work/*
+rm -R -f /tmp/%FIFO_DIR%/

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_ord_psept_2_output_10_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_ord_psept_2_output_10_partition.sh
@@ -1,0 +1,210 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+mkdir output/full_correlation/
+
+rm -R -f work/*
+mkdir work/kat/
+mkdir work/full_correlation/
+mkdir work/full_correlation/kat/
+
+rm -R -f /tmp/%FIFO_DIR%/
+mkdir -p /tmp/%FIFO_DIR%/fifo/
+mkdir /tmp/%FIFO_DIR%/fifo/full_correlation/
+mkdir work/gul_S1_summaryleccalc
+mkdir work/gul_S2_summaryleccalc
+mkdir work/full_correlation/gul_S1_summaryleccalc
+mkdir work/full_correlation/gul_S2_summaryleccalc
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P10
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P1
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P2
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P3
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P4
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P5
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P6
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P7
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P8
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P9
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P10
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P10
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P1
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P2
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P3
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P4
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P5
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P6
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P7
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P8
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P9
+
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P10
+
+
+
+# --- Do ground up loss computes ---
+
+
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P1 work/gul_S1_summaryleccalc/P1.bin > /dev/null & pid1=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P1 work/gul_S2_summaryleccalc/P1.bin > /dev/null & pid2=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P2 work/gul_S1_summaryleccalc/P2.bin > /dev/null & pid3=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P2 work/gul_S2_summaryleccalc/P2.bin > /dev/null & pid4=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P3 work/gul_S1_summaryleccalc/P3.bin > /dev/null & pid5=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P3 work/gul_S2_summaryleccalc/P3.bin > /dev/null & pid6=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P4 work/gul_S1_summaryleccalc/P4.bin > /dev/null & pid7=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P4 work/gul_S2_summaryleccalc/P4.bin > /dev/null & pid8=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P5 work/gul_S1_summaryleccalc/P5.bin > /dev/null & pid9=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P5 work/gul_S2_summaryleccalc/P5.bin > /dev/null & pid10=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P6 work/gul_S1_summaryleccalc/P6.bin > /dev/null & pid11=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P6 work/gul_S2_summaryleccalc/P6.bin > /dev/null & pid12=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P7 work/gul_S1_summaryleccalc/P7.bin > /dev/null & pid13=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P7 work/gul_S2_summaryleccalc/P7.bin > /dev/null & pid14=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P8 work/gul_S1_summaryleccalc/P8.bin > /dev/null & pid15=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P8 work/gul_S2_summaryleccalc/P8.bin > /dev/null & pid16=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P9 work/gul_S1_summaryleccalc/P9.bin > /dev/null & pid17=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P9 work/gul_S2_summaryleccalc/P9.bin > /dev/null & pid18=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P10 work/gul_S1_summaryleccalc/P10.bin > /dev/null & pid19=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P10 work/gul_S2_summaryleccalc/P10.bin > /dev/null & pid20=$!
+
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P1 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P1 < /tmp/%FIFO_DIR%/fifo/gul_P1 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P2 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P2 < /tmp/%FIFO_DIR%/fifo/gul_P2 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P3 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P3 < /tmp/%FIFO_DIR%/fifo/gul_P3 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P4 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P4 < /tmp/%FIFO_DIR%/fifo/gul_P4 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P5 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P5 < /tmp/%FIFO_DIR%/fifo/gul_P5 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P6 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P6 < /tmp/%FIFO_DIR%/fifo/gul_P6 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P7 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P7 < /tmp/%FIFO_DIR%/fifo/gul_P7 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P8 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P8 < /tmp/%FIFO_DIR%/fifo/gul_P8 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P9 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P9 < /tmp/%FIFO_DIR%/fifo/gul_P9 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P10 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P10 < /tmp/%FIFO_DIR%/fifo/gul_P10 &
+
+# --- Do ground up loss computes ---
+
+
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P1 work/full_correlation/gul_S1_summaryleccalc/P1.bin > /dev/null & pid21=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P1 work/full_correlation/gul_S2_summaryleccalc/P1.bin > /dev/null & pid22=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P2 work/full_correlation/gul_S1_summaryleccalc/P2.bin > /dev/null & pid23=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P2 work/full_correlation/gul_S2_summaryleccalc/P2.bin > /dev/null & pid24=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P3 work/full_correlation/gul_S1_summaryleccalc/P3.bin > /dev/null & pid25=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P3 work/full_correlation/gul_S2_summaryleccalc/P3.bin > /dev/null & pid26=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P4 work/full_correlation/gul_S1_summaryleccalc/P4.bin > /dev/null & pid27=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P4 work/full_correlation/gul_S2_summaryleccalc/P4.bin > /dev/null & pid28=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P5 work/full_correlation/gul_S1_summaryleccalc/P5.bin > /dev/null & pid29=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P5 work/full_correlation/gul_S2_summaryleccalc/P5.bin > /dev/null & pid30=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P6 work/full_correlation/gul_S1_summaryleccalc/P6.bin > /dev/null & pid31=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P6 work/full_correlation/gul_S2_summaryleccalc/P6.bin > /dev/null & pid32=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P7 work/full_correlation/gul_S1_summaryleccalc/P7.bin > /dev/null & pid33=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P7 work/full_correlation/gul_S2_summaryleccalc/P7.bin > /dev/null & pid34=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P8 work/full_correlation/gul_S1_summaryleccalc/P8.bin > /dev/null & pid35=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P8 work/full_correlation/gul_S2_summaryleccalc/P8.bin > /dev/null & pid36=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P9 work/full_correlation/gul_S1_summaryleccalc/P9.bin > /dev/null & pid37=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P9 work/full_correlation/gul_S2_summaryleccalc/P9.bin > /dev/null & pid38=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P10 work/full_correlation/gul_S1_summaryleccalc/P10.bin > /dev/null & pid39=$!
+tee < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P10 work/full_correlation/gul_S2_summaryleccalc/P10.bin > /dev/null & pid40=$!
+
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P1 -2 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P1 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P1 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P2 -2 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P2 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P2 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P3 -2 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P3 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P3 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P4 -2 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P4 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P4 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P5 -2 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P5 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P5 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P6 -2 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P6 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P6 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P7 -2 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P7 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P7 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P8 -2 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P8 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P8 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P9 -2 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P9 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P9 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S1_summary_P10 -2 /tmp/%FIFO_DIR%/fifo/full_correlation/gul_S2_summary_P10 < /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P10 &
+
+eve 1 10 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P1 -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P1  &
+eve 2 10 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P2 -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P2  &
+eve 3 10 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P3 -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P3  &
+eve 4 10 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P4 -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P4  &
+eve 5 10 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P5 -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P5  &
+eve 6 10 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P6 -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P6  &
+eve 7 10 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P7 -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P7  &
+eve 8 10 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P8 -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P8  &
+eve 9 10 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P9 -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P9  &
+eve 10 10 | getmodel | gulcalc -S0 -L0 -r -j /tmp/%FIFO_DIR%/fifo/full_correlation/gul_P10 -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P10  &
+
+wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 $pid13 $pid14 $pid15 $pid16 $pid17 $pid18 $pid19 $pid20 $pid21 $pid22 $pid23 $pid24 $pid25 $pid26 $pid27 $pid28 $pid29 $pid30 $pid31 $pid32 $pid33 $pid34 $pid35 $pid36 $pid37 $pid38 $pid39 $pid40
+
+
+# --- Do ground up loss kats ---
+
+
+# --- Do ground up loss kats for fully correlated output ---
+
+
+ordleccalc  -Kgul_S1_summaryleccalc -W -w -o output/gul_S1_psept.csv & lpid1=$!
+ordleccalc -r -Kgul_S2_summaryleccalc -W -w -o output/gul_S2_psept.csv & lpid2=$!
+ordleccalc  -Kfull_correlation/gul_S1_summaryleccalc -W -w -o output/full_correlation/gul_S1_psept.csv & lpid3=$!
+ordleccalc -r -Kfull_correlation/gul_S2_summaryleccalc -W -w -o output/full_correlation/gul_S2_psept.csv & lpid4=$!
+wait $lpid1 $lpid2 $lpid3 $lpid4
+
+rm -R -f work/*
+rm -R -f /tmp/%FIFO_DIR%/

--- a/tests/model_execution/tmp_fc_kparse_reference/update-tmp-fc-tests.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/update-tmp-fc-tests.sh
@@ -84,6 +84,13 @@ all_files=(
     il_pltcalc_1_output_20_partition.sh
     il_summarycalc_1_output_1_partition.sh
     il_summarycalc_1_output_20_partition.sh
+    analysis_settings_5_1_reins_layer_1_partition.sh
+	gul_il_ord_ept_psept_2_output_10_partition.sh
+	gul_il_ord_psept_lec_1_output_10_partition.sh
+	gul_ord_ept_1_output_1_partition.sh
+	gul_ord_ept_1_output_20_partition.sh
+	gul_ord_ept_psept_lec_2_output_10_partition.sh
+	gul_ord_psept_2_output_10_partition.sh
 )
 
 for f in "${all_files[@]}"; do 

--- a/tests/model_execution/tmp_kparse_reference/analysis_settings_5_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/analysis_settings_5_1_reins_layer_1_partition.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+
+rm -R -f work/*
+mkdir work/kat/
+
+rm -R -f /tmp/%FIFO_DIR%/
+mkdir -p /tmp/%FIFO_DIR%/fifo/
+mkdir work/gul_S1_summaryaalcalc
+mkdir work/il_S1_summaryleccalc
+mkdir work/ri_S1_summaryleccalc
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P1
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P1
+
+mkfifo /tmp/%FIFO_DIR%/fifo/il_P1
+
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summary_P1
+
+mkfifo /tmp/%FIFO_DIR%/fifo/ri_P1
+
+mkfifo /tmp/%FIFO_DIR%/fifo/ri_S1_summary_P1
+
+
+
+# --- Do reinsurance loss computes ---
+
+
+tee < /tmp/%FIFO_DIR%/fifo/ri_S1_summary_P1 work/ri_S1_summaryleccalc/P1.bin > /dev/null & pid1=$!
+
+summarycalc -f -p RI_1 -1 /tmp/%FIFO_DIR%/fifo/ri_S1_summary_P1 < /tmp/%FIFO_DIR%/fifo/ri_P1 &
+
+# --- Do insured loss computes ---
+
+
+tee < /tmp/%FIFO_DIR%/fifo/il_S1_summary_P1 work/il_S1_summaryleccalc/P1.bin > /dev/null & pid2=$!
+
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/il_S1_summary_P1 < /tmp/%FIFO_DIR%/fifo/il_P1 &
+
+# --- Do ground up loss computes ---
+
+eltcalc < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P1 > work/kat/gul_S1_eltcalc_P1 & pid3=$!
+summarycalctocsv < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P1 > work/kat/gul_S1_summarycalc_P1 & pid4=$!
+pltcalc < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P1 > work/kat/gul_S1_pltcalc_P1 & pid5=$!
+
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P1 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P1 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P1 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P1 work/gul_S1_summaryaalcalc/P1.bin > /dev/null & pid6=$!
+
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P1 < /tmp/%FIFO_DIR%/fifo/gul_P1 &
+
+eve 1 1 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee /tmp/%FIFO_DIR%/fifo/gul_P1 | fmcalc -a2 | tee /tmp/%FIFO_DIR%/fifo/il_P1 | fmcalc -a3 -n -p RI_1 > /tmp/%FIFO_DIR%/fifo/ri_P1 &
+
+wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6
+
+
+# --- Do reinsurance loss kats ---
+
+
+# --- Do insured loss kats ---
+
+
+# --- Do ground up loss kats ---
+
+kat -s work/kat/gul_S1_eltcalc_P1 > output/gul_S1_eltcalc.csv & kpid1=$!
+kat work/kat/gul_S1_pltcalc_P1 > output/gul_S1_pltcalc.csv & kpid2=$!
+kat work/kat/gul_S1_summarycalc_P1 > output/gul_S1_summarycalc.csv & kpid3=$!
+wait $kpid1 $kpid2 $kpid3
+
+
+ordleccalc -r -Kri_S1_summaryleccalc -F -f -S -s -M -m -W -w -O output/ri_S1_ept.csv -o output/ri_S1_psept.csv & lpid1=$!
+ordleccalc  -Kil_S1_summaryleccalc -F -S -s -M -m -O output/il_S1_ept.csv & lpid2=$!
+aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv & lpid3=$!
+wait $lpid1 $lpid2 $lpid3
+
+rm -R -f work/*
+rm -R -f /tmp/%FIFO_DIR%/

--- a/tests/model_execution/tmp_kparse_reference/gul_il_ord_ept_psept_2_output_10_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_il_ord_ept_psept_2_output_10_partition.sh
@@ -1,0 +1,468 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+
+rm -R -f work/*
+mkdir work/kat/
+
+rm -R -f /tmp/%FIFO_DIR%/
+mkdir -p /tmp/%FIFO_DIR%/fifo/
+mkdir work/gul_S1_summaryleccalc
+mkdir work/gul_S1_summaryaalcalc
+mkdir work/gul_S2_summaryleccalc
+mkdir work/gul_S2_summaryaalcalc
+mkdir work/il_S1_summaryleccalc
+mkdir work/il_S1_summaryaalcalc
+mkdir work/il_S2_summaryleccalc
+mkdir work/il_S2_summaryaalcalc
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P10
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P1
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P2
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P3
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P4
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P5
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P6
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P7
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P8
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P9
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P10
+
+mkfifo /tmp/%FIFO_DIR%/fifo/il_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/il_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/il_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/il_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/il_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/il_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/il_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/il_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/il_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/il_P10
+
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summary_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_summary_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P1
+
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summary_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_summary_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P2
+
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summary_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_summary_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P3
+
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summary_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_summary_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P4
+
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summary_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_summary_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P5
+
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summary_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_summary_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P6
+
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summary_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_summary_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P7
+
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summary_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_summary_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P8
+
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summary_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_summary_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P9
+
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summary_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_summary_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P10
+
+
+
+# --- Do insured loss computes ---
+
+eltcalc < /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P1 > work/kat/il_S1_eltcalc_P1 & pid1=$!
+summarycalctocsv < /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P1 > work/kat/il_S1_summarycalc_P1 & pid2=$!
+pltcalc < /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P1 > work/kat/il_S1_pltcalc_P1 & pid3=$!
+eltcalc < /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P1 > work/kat/il_S2_eltcalc_P1 & pid4=$!
+summarycalctocsv < /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P1 > work/kat/il_S2_summarycalc_P1 & pid5=$!
+pltcalc < /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P1 > work/kat/il_S2_pltcalc_P1 & pid6=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P2 > work/kat/il_S1_eltcalc_P2 & pid7=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P2 > work/kat/il_S1_summarycalc_P2 & pid8=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P2 > work/kat/il_S1_pltcalc_P2 & pid9=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P2 > work/kat/il_S2_eltcalc_P2 & pid10=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P2 > work/kat/il_S2_summarycalc_P2 & pid11=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P2 > work/kat/il_S2_pltcalc_P2 & pid12=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P3 > work/kat/il_S1_eltcalc_P3 & pid13=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P3 > work/kat/il_S1_summarycalc_P3 & pid14=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P3 > work/kat/il_S1_pltcalc_P3 & pid15=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P3 > work/kat/il_S2_eltcalc_P3 & pid16=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P3 > work/kat/il_S2_summarycalc_P3 & pid17=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P3 > work/kat/il_S2_pltcalc_P3 & pid18=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P4 > work/kat/il_S1_eltcalc_P4 & pid19=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P4 > work/kat/il_S1_summarycalc_P4 & pid20=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P4 > work/kat/il_S1_pltcalc_P4 & pid21=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P4 > work/kat/il_S2_eltcalc_P4 & pid22=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P4 > work/kat/il_S2_summarycalc_P4 & pid23=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P4 > work/kat/il_S2_pltcalc_P4 & pid24=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P5 > work/kat/il_S1_eltcalc_P5 & pid25=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P5 > work/kat/il_S1_summarycalc_P5 & pid26=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P5 > work/kat/il_S1_pltcalc_P5 & pid27=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P5 > work/kat/il_S2_eltcalc_P5 & pid28=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P5 > work/kat/il_S2_summarycalc_P5 & pid29=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P5 > work/kat/il_S2_pltcalc_P5 & pid30=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P6 > work/kat/il_S1_eltcalc_P6 & pid31=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P6 > work/kat/il_S1_summarycalc_P6 & pid32=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P6 > work/kat/il_S1_pltcalc_P6 & pid33=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P6 > work/kat/il_S2_eltcalc_P6 & pid34=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P6 > work/kat/il_S2_summarycalc_P6 & pid35=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P6 > work/kat/il_S2_pltcalc_P6 & pid36=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P7 > work/kat/il_S1_eltcalc_P7 & pid37=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P7 > work/kat/il_S1_summarycalc_P7 & pid38=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P7 > work/kat/il_S1_pltcalc_P7 & pid39=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P7 > work/kat/il_S2_eltcalc_P7 & pid40=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P7 > work/kat/il_S2_summarycalc_P7 & pid41=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P7 > work/kat/il_S2_pltcalc_P7 & pid42=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P8 > work/kat/il_S1_eltcalc_P8 & pid43=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P8 > work/kat/il_S1_summarycalc_P8 & pid44=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P8 > work/kat/il_S1_pltcalc_P8 & pid45=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P8 > work/kat/il_S2_eltcalc_P8 & pid46=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P8 > work/kat/il_S2_summarycalc_P8 & pid47=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P8 > work/kat/il_S2_pltcalc_P8 & pid48=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P9 > work/kat/il_S1_eltcalc_P9 & pid49=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P9 > work/kat/il_S1_summarycalc_P9 & pid50=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P9 > work/kat/il_S1_pltcalc_P9 & pid51=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P9 > work/kat/il_S2_eltcalc_P9 & pid52=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P9 > work/kat/il_S2_summarycalc_P9 & pid53=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P9 > work/kat/il_S2_pltcalc_P9 & pid54=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P10 > work/kat/il_S1_eltcalc_P10 & pid55=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P10 > work/kat/il_S1_summarycalc_P10 & pid56=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P10 > work/kat/il_S1_pltcalc_P10 & pid57=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P10 > work/kat/il_S2_eltcalc_P10 & pid58=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P10 > work/kat/il_S2_summarycalc_P10 & pid59=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P10 > work/kat/il_S2_pltcalc_P10 & pid60=$!
+
+tee < /tmp/%FIFO_DIR%/fifo/il_S1_summary_P1 /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P1 /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P1 /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P1 work/il_S1_summaryaalcalc/P1.bin work/il_S1_summaryleccalc/P1.bin > /dev/null & pid61=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S2_summary_P1 /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P1 /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P1 /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P1 work/il_S2_summaryaalcalc/P1.bin work/il_S2_summaryleccalc/P1.bin > /dev/null & pid62=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S1_summary_P2 /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P2 /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P2 /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P2 work/il_S1_summaryaalcalc/P2.bin work/il_S1_summaryleccalc/P2.bin > /dev/null & pid63=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S2_summary_P2 /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P2 /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P2 /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P2 work/il_S2_summaryaalcalc/P2.bin work/il_S2_summaryleccalc/P2.bin > /dev/null & pid64=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S1_summary_P3 /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P3 /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P3 /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P3 work/il_S1_summaryaalcalc/P3.bin work/il_S1_summaryleccalc/P3.bin > /dev/null & pid65=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S2_summary_P3 /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P3 /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P3 /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P3 work/il_S2_summaryaalcalc/P3.bin work/il_S2_summaryleccalc/P3.bin > /dev/null & pid66=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S1_summary_P4 /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P4 /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P4 /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P4 work/il_S1_summaryaalcalc/P4.bin work/il_S1_summaryleccalc/P4.bin > /dev/null & pid67=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S2_summary_P4 /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P4 /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P4 /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P4 work/il_S2_summaryaalcalc/P4.bin work/il_S2_summaryleccalc/P4.bin > /dev/null & pid68=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S1_summary_P5 /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P5 /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P5 /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P5 work/il_S1_summaryaalcalc/P5.bin work/il_S1_summaryleccalc/P5.bin > /dev/null & pid69=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S2_summary_P5 /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P5 /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P5 /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P5 work/il_S2_summaryaalcalc/P5.bin work/il_S2_summaryleccalc/P5.bin > /dev/null & pid70=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S1_summary_P6 /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P6 /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P6 /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P6 work/il_S1_summaryaalcalc/P6.bin work/il_S1_summaryleccalc/P6.bin > /dev/null & pid71=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S2_summary_P6 /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P6 /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P6 /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P6 work/il_S2_summaryaalcalc/P6.bin work/il_S2_summaryleccalc/P6.bin > /dev/null & pid72=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S1_summary_P7 /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P7 /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P7 /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P7 work/il_S1_summaryaalcalc/P7.bin work/il_S1_summaryleccalc/P7.bin > /dev/null & pid73=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S2_summary_P7 /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P7 /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P7 /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P7 work/il_S2_summaryaalcalc/P7.bin work/il_S2_summaryleccalc/P7.bin > /dev/null & pid74=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S1_summary_P8 /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P8 /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P8 /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P8 work/il_S1_summaryaalcalc/P8.bin work/il_S1_summaryleccalc/P8.bin > /dev/null & pid75=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S2_summary_P8 /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P8 /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P8 /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P8 work/il_S2_summaryaalcalc/P8.bin work/il_S2_summaryleccalc/P8.bin > /dev/null & pid76=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S1_summary_P9 /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P9 /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P9 /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P9 work/il_S1_summaryaalcalc/P9.bin work/il_S1_summaryleccalc/P9.bin > /dev/null & pid77=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S2_summary_P9 /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P9 /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P9 /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P9 work/il_S2_summaryaalcalc/P9.bin work/il_S2_summaryleccalc/P9.bin > /dev/null & pid78=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S1_summary_P10 /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P10 /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P10 /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P10 work/il_S1_summaryaalcalc/P10.bin work/il_S1_summaryleccalc/P10.bin > /dev/null & pid79=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S2_summary_P10 /tmp/%FIFO_DIR%/fifo/il_S2_eltcalc_P10 /tmp/%FIFO_DIR%/fifo/il_S2_summarycalc_P10 /tmp/%FIFO_DIR%/fifo/il_S2_pltcalc_P10 work/il_S2_summaryaalcalc/P10.bin work/il_S2_summaryleccalc/P10.bin > /dev/null & pid80=$!
+
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/il_S1_summary_P1 -2 /tmp/%FIFO_DIR%/fifo/il_S2_summary_P1 < /tmp/%FIFO_DIR%/fifo/il_P1 &
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/il_S1_summary_P2 -2 /tmp/%FIFO_DIR%/fifo/il_S2_summary_P2 < /tmp/%FIFO_DIR%/fifo/il_P2 &
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/il_S1_summary_P3 -2 /tmp/%FIFO_DIR%/fifo/il_S2_summary_P3 < /tmp/%FIFO_DIR%/fifo/il_P3 &
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/il_S1_summary_P4 -2 /tmp/%FIFO_DIR%/fifo/il_S2_summary_P4 < /tmp/%FIFO_DIR%/fifo/il_P4 &
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/il_S1_summary_P5 -2 /tmp/%FIFO_DIR%/fifo/il_S2_summary_P5 < /tmp/%FIFO_DIR%/fifo/il_P5 &
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/il_S1_summary_P6 -2 /tmp/%FIFO_DIR%/fifo/il_S2_summary_P6 < /tmp/%FIFO_DIR%/fifo/il_P6 &
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/il_S1_summary_P7 -2 /tmp/%FIFO_DIR%/fifo/il_S2_summary_P7 < /tmp/%FIFO_DIR%/fifo/il_P7 &
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/il_S1_summary_P8 -2 /tmp/%FIFO_DIR%/fifo/il_S2_summary_P8 < /tmp/%FIFO_DIR%/fifo/il_P8 &
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/il_S1_summary_P9 -2 /tmp/%FIFO_DIR%/fifo/il_S2_summary_P9 < /tmp/%FIFO_DIR%/fifo/il_P9 &
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/il_S1_summary_P10 -2 /tmp/%FIFO_DIR%/fifo/il_S2_summary_P10 < /tmp/%FIFO_DIR%/fifo/il_P10 &
+
+# --- Do ground up loss computes ---
+
+eltcalc < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P1 > work/kat/gul_S1_eltcalc_P1 & pid81=$!
+summarycalctocsv < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P1 > work/kat/gul_S1_summarycalc_P1 & pid82=$!
+pltcalc < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P1 > work/kat/gul_S1_pltcalc_P1 & pid83=$!
+eltcalc < /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P1 > work/kat/gul_S2_eltcalc_P1 & pid84=$!
+summarycalctocsv < /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P1 > work/kat/gul_S2_summarycalc_P1 & pid85=$!
+pltcalc < /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P1 > work/kat/gul_S2_pltcalc_P1 & pid86=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P2 > work/kat/gul_S1_eltcalc_P2 & pid87=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P2 > work/kat/gul_S1_summarycalc_P2 & pid88=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P2 > work/kat/gul_S1_pltcalc_P2 & pid89=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P2 > work/kat/gul_S2_eltcalc_P2 & pid90=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P2 > work/kat/gul_S2_summarycalc_P2 & pid91=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P2 > work/kat/gul_S2_pltcalc_P2 & pid92=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P3 > work/kat/gul_S1_eltcalc_P3 & pid93=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P3 > work/kat/gul_S1_summarycalc_P3 & pid94=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P3 > work/kat/gul_S1_pltcalc_P3 & pid95=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P3 > work/kat/gul_S2_eltcalc_P3 & pid96=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P3 > work/kat/gul_S2_summarycalc_P3 & pid97=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P3 > work/kat/gul_S2_pltcalc_P3 & pid98=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P4 > work/kat/gul_S1_eltcalc_P4 & pid99=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P4 > work/kat/gul_S1_summarycalc_P4 & pid100=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P4 > work/kat/gul_S1_pltcalc_P4 & pid101=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P4 > work/kat/gul_S2_eltcalc_P4 & pid102=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P4 > work/kat/gul_S2_summarycalc_P4 & pid103=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P4 > work/kat/gul_S2_pltcalc_P4 & pid104=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P5 > work/kat/gul_S1_eltcalc_P5 & pid105=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P5 > work/kat/gul_S1_summarycalc_P5 & pid106=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P5 > work/kat/gul_S1_pltcalc_P5 & pid107=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P5 > work/kat/gul_S2_eltcalc_P5 & pid108=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P5 > work/kat/gul_S2_summarycalc_P5 & pid109=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P5 > work/kat/gul_S2_pltcalc_P5 & pid110=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P6 > work/kat/gul_S1_eltcalc_P6 & pid111=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P6 > work/kat/gul_S1_summarycalc_P6 & pid112=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P6 > work/kat/gul_S1_pltcalc_P6 & pid113=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P6 > work/kat/gul_S2_eltcalc_P6 & pid114=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P6 > work/kat/gul_S2_summarycalc_P6 & pid115=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P6 > work/kat/gul_S2_pltcalc_P6 & pid116=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P7 > work/kat/gul_S1_eltcalc_P7 & pid117=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P7 > work/kat/gul_S1_summarycalc_P7 & pid118=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P7 > work/kat/gul_S1_pltcalc_P7 & pid119=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P7 > work/kat/gul_S2_eltcalc_P7 & pid120=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P7 > work/kat/gul_S2_summarycalc_P7 & pid121=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P7 > work/kat/gul_S2_pltcalc_P7 & pid122=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P8 > work/kat/gul_S1_eltcalc_P8 & pid123=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P8 > work/kat/gul_S1_summarycalc_P8 & pid124=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P8 > work/kat/gul_S1_pltcalc_P8 & pid125=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P8 > work/kat/gul_S2_eltcalc_P8 & pid126=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P8 > work/kat/gul_S2_summarycalc_P8 & pid127=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P8 > work/kat/gul_S2_pltcalc_P8 & pid128=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P9 > work/kat/gul_S1_eltcalc_P9 & pid129=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P9 > work/kat/gul_S1_summarycalc_P9 & pid130=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P9 > work/kat/gul_S1_pltcalc_P9 & pid131=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P9 > work/kat/gul_S2_eltcalc_P9 & pid132=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P9 > work/kat/gul_S2_summarycalc_P9 & pid133=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P9 > work/kat/gul_S2_pltcalc_P9 & pid134=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P10 > work/kat/gul_S1_eltcalc_P10 & pid135=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P10 > work/kat/gul_S1_summarycalc_P10 & pid136=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P10 > work/kat/gul_S1_pltcalc_P10 & pid137=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P10 > work/kat/gul_S2_eltcalc_P10 & pid138=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P10 > work/kat/gul_S2_summarycalc_P10 & pid139=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P10 > work/kat/gul_S2_pltcalc_P10 & pid140=$!
+
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P1 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P1 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P1 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P1 work/gul_S1_summaryaalcalc/P1.bin work/gul_S1_summaryleccalc/P1.bin > /dev/null & pid141=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P1 /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P1 /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P1 /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P1 work/gul_S2_summaryaalcalc/P1.bin work/gul_S2_summaryleccalc/P1.bin > /dev/null & pid142=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P2 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P2 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P2 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P2 work/gul_S1_summaryaalcalc/P2.bin work/gul_S1_summaryleccalc/P2.bin > /dev/null & pid143=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P2 /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P2 /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P2 /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P2 work/gul_S2_summaryaalcalc/P2.bin work/gul_S2_summaryleccalc/P2.bin > /dev/null & pid144=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P3 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P3 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P3 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P3 work/gul_S1_summaryaalcalc/P3.bin work/gul_S1_summaryleccalc/P3.bin > /dev/null & pid145=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P3 /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P3 /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P3 /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P3 work/gul_S2_summaryaalcalc/P3.bin work/gul_S2_summaryleccalc/P3.bin > /dev/null & pid146=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P4 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P4 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P4 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P4 work/gul_S1_summaryaalcalc/P4.bin work/gul_S1_summaryleccalc/P4.bin > /dev/null & pid147=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P4 /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P4 /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P4 /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P4 work/gul_S2_summaryaalcalc/P4.bin work/gul_S2_summaryleccalc/P4.bin > /dev/null & pid148=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P5 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P5 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P5 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P5 work/gul_S1_summaryaalcalc/P5.bin work/gul_S1_summaryleccalc/P5.bin > /dev/null & pid149=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P5 /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P5 /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P5 /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P5 work/gul_S2_summaryaalcalc/P5.bin work/gul_S2_summaryleccalc/P5.bin > /dev/null & pid150=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P6 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P6 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P6 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P6 work/gul_S1_summaryaalcalc/P6.bin work/gul_S1_summaryleccalc/P6.bin > /dev/null & pid151=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P6 /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P6 /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P6 /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P6 work/gul_S2_summaryaalcalc/P6.bin work/gul_S2_summaryleccalc/P6.bin > /dev/null & pid152=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P7 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P7 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P7 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P7 work/gul_S1_summaryaalcalc/P7.bin work/gul_S1_summaryleccalc/P7.bin > /dev/null & pid153=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P7 /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P7 /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P7 /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P7 work/gul_S2_summaryaalcalc/P7.bin work/gul_S2_summaryleccalc/P7.bin > /dev/null & pid154=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P8 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P8 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P8 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P8 work/gul_S1_summaryaalcalc/P8.bin work/gul_S1_summaryleccalc/P8.bin > /dev/null & pid155=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P8 /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P8 /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P8 /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P8 work/gul_S2_summaryaalcalc/P8.bin work/gul_S2_summaryleccalc/P8.bin > /dev/null & pid156=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P9 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P9 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P9 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P9 work/gul_S1_summaryaalcalc/P9.bin work/gul_S1_summaryleccalc/P9.bin > /dev/null & pid157=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P9 /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P9 /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P9 /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P9 work/gul_S2_summaryaalcalc/P9.bin work/gul_S2_summaryleccalc/P9.bin > /dev/null & pid158=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P10 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P10 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P10 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P10 work/gul_S1_summaryaalcalc/P10.bin work/gul_S1_summaryleccalc/P10.bin > /dev/null & pid159=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P10 /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P10 /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P10 /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P10 work/gul_S2_summaryaalcalc/P10.bin work/gul_S2_summaryleccalc/P10.bin > /dev/null & pid160=$!
+
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P1 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P1 < /tmp/%FIFO_DIR%/fifo/gul_P1 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P2 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P2 < /tmp/%FIFO_DIR%/fifo/gul_P2 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P3 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P3 < /tmp/%FIFO_DIR%/fifo/gul_P3 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P4 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P4 < /tmp/%FIFO_DIR%/fifo/gul_P4 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P5 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P5 < /tmp/%FIFO_DIR%/fifo/gul_P5 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P6 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P6 < /tmp/%FIFO_DIR%/fifo/gul_P6 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P7 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P7 < /tmp/%FIFO_DIR%/fifo/gul_P7 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P8 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P8 < /tmp/%FIFO_DIR%/fifo/gul_P8 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P9 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P9 < /tmp/%FIFO_DIR%/fifo/gul_P9 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P10 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P10 < /tmp/%FIFO_DIR%/fifo/gul_P10 &
+
+eve 1 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee /tmp/%FIFO_DIR%/fifo/gul_P1 | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/il_P1  &
+eve 2 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee /tmp/%FIFO_DIR%/fifo/gul_P2 | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/il_P2  &
+eve 3 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee /tmp/%FIFO_DIR%/fifo/gul_P3 | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/il_P3  &
+eve 4 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee /tmp/%FIFO_DIR%/fifo/gul_P4 | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/il_P4  &
+eve 5 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee /tmp/%FIFO_DIR%/fifo/gul_P5 | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/il_P5  &
+eve 6 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee /tmp/%FIFO_DIR%/fifo/gul_P6 | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/il_P6  &
+eve 7 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee /tmp/%FIFO_DIR%/fifo/gul_P7 | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/il_P7  &
+eve 8 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee /tmp/%FIFO_DIR%/fifo/gul_P8 | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/il_P8  &
+eve 9 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee /tmp/%FIFO_DIR%/fifo/gul_P9 | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/il_P9  &
+eve 10 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee /tmp/%FIFO_DIR%/fifo/gul_P10 | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/il_P10  &
+
+wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 $pid13 $pid14 $pid15 $pid16 $pid17 $pid18 $pid19 $pid20 $pid21 $pid22 $pid23 $pid24 $pid25 $pid26 $pid27 $pid28 $pid29 $pid30 $pid31 $pid32 $pid33 $pid34 $pid35 $pid36 $pid37 $pid38 $pid39 $pid40 $pid41 $pid42 $pid43 $pid44 $pid45 $pid46 $pid47 $pid48 $pid49 $pid50 $pid51 $pid52 $pid53 $pid54 $pid55 $pid56 $pid57 $pid58 $pid59 $pid60 $pid61 $pid62 $pid63 $pid64 $pid65 $pid66 $pid67 $pid68 $pid69 $pid70 $pid71 $pid72 $pid73 $pid74 $pid75 $pid76 $pid77 $pid78 $pid79 $pid80 $pid81 $pid82 $pid83 $pid84 $pid85 $pid86 $pid87 $pid88 $pid89 $pid90 $pid91 $pid92 $pid93 $pid94 $pid95 $pid96 $pid97 $pid98 $pid99 $pid100 $pid101 $pid102 $pid103 $pid104 $pid105 $pid106 $pid107 $pid108 $pid109 $pid110 $pid111 $pid112 $pid113 $pid114 $pid115 $pid116 $pid117 $pid118 $pid119 $pid120 $pid121 $pid122 $pid123 $pid124 $pid125 $pid126 $pid127 $pid128 $pid129 $pid130 $pid131 $pid132 $pid133 $pid134 $pid135 $pid136 $pid137 $pid138 $pid139 $pid140 $pid141 $pid142 $pid143 $pid144 $pid145 $pid146 $pid147 $pid148 $pid149 $pid150 $pid151 $pid152 $pid153 $pid154 $pid155 $pid156 $pid157 $pid158 $pid159 $pid160
+
+
+# --- Do insured loss kats ---
+
+kat -s work/kat/il_S1_eltcalc_P1 work/kat/il_S1_eltcalc_P2 work/kat/il_S1_eltcalc_P3 work/kat/il_S1_eltcalc_P4 work/kat/il_S1_eltcalc_P5 work/kat/il_S1_eltcalc_P6 work/kat/il_S1_eltcalc_P7 work/kat/il_S1_eltcalc_P8 work/kat/il_S1_eltcalc_P9 work/kat/il_S1_eltcalc_P10 > output/il_S1_eltcalc.csv & kpid1=$!
+kat work/kat/il_S1_pltcalc_P1 work/kat/il_S1_pltcalc_P2 work/kat/il_S1_pltcalc_P3 work/kat/il_S1_pltcalc_P4 work/kat/il_S1_pltcalc_P5 work/kat/il_S1_pltcalc_P6 work/kat/il_S1_pltcalc_P7 work/kat/il_S1_pltcalc_P8 work/kat/il_S1_pltcalc_P9 work/kat/il_S1_pltcalc_P10 > output/il_S1_pltcalc.csv & kpid2=$!
+kat work/kat/il_S1_summarycalc_P1 work/kat/il_S1_summarycalc_P2 work/kat/il_S1_summarycalc_P3 work/kat/il_S1_summarycalc_P4 work/kat/il_S1_summarycalc_P5 work/kat/il_S1_summarycalc_P6 work/kat/il_S1_summarycalc_P7 work/kat/il_S1_summarycalc_P8 work/kat/il_S1_summarycalc_P9 work/kat/il_S1_summarycalc_P10 > output/il_S1_summarycalc.csv & kpid3=$!
+kat -s work/kat/il_S2_eltcalc_P1 work/kat/il_S2_eltcalc_P2 work/kat/il_S2_eltcalc_P3 work/kat/il_S2_eltcalc_P4 work/kat/il_S2_eltcalc_P5 work/kat/il_S2_eltcalc_P6 work/kat/il_S2_eltcalc_P7 work/kat/il_S2_eltcalc_P8 work/kat/il_S2_eltcalc_P9 work/kat/il_S2_eltcalc_P10 > output/il_S2_eltcalc.csv & kpid4=$!
+kat work/kat/il_S2_pltcalc_P1 work/kat/il_S2_pltcalc_P2 work/kat/il_S2_pltcalc_P3 work/kat/il_S2_pltcalc_P4 work/kat/il_S2_pltcalc_P5 work/kat/il_S2_pltcalc_P6 work/kat/il_S2_pltcalc_P7 work/kat/il_S2_pltcalc_P8 work/kat/il_S2_pltcalc_P9 work/kat/il_S2_pltcalc_P10 > output/il_S2_pltcalc.csv & kpid5=$!
+kat work/kat/il_S2_summarycalc_P1 work/kat/il_S2_summarycalc_P2 work/kat/il_S2_summarycalc_P3 work/kat/il_S2_summarycalc_P4 work/kat/il_S2_summarycalc_P5 work/kat/il_S2_summarycalc_P6 work/kat/il_S2_summarycalc_P7 work/kat/il_S2_summarycalc_P8 work/kat/il_S2_summarycalc_P9 work/kat/il_S2_summarycalc_P10 > output/il_S2_summarycalc.csv & kpid6=$!
+
+# --- Do ground up loss kats ---
+
+kat -s work/kat/gul_S1_eltcalc_P1 work/kat/gul_S1_eltcalc_P2 work/kat/gul_S1_eltcalc_P3 work/kat/gul_S1_eltcalc_P4 work/kat/gul_S1_eltcalc_P5 work/kat/gul_S1_eltcalc_P6 work/kat/gul_S1_eltcalc_P7 work/kat/gul_S1_eltcalc_P8 work/kat/gul_S1_eltcalc_P9 work/kat/gul_S1_eltcalc_P10 > output/gul_S1_eltcalc.csv & kpid7=$!
+kat work/kat/gul_S1_pltcalc_P1 work/kat/gul_S1_pltcalc_P2 work/kat/gul_S1_pltcalc_P3 work/kat/gul_S1_pltcalc_P4 work/kat/gul_S1_pltcalc_P5 work/kat/gul_S1_pltcalc_P6 work/kat/gul_S1_pltcalc_P7 work/kat/gul_S1_pltcalc_P8 work/kat/gul_S1_pltcalc_P9 work/kat/gul_S1_pltcalc_P10 > output/gul_S1_pltcalc.csv & kpid8=$!
+kat work/kat/gul_S1_summarycalc_P1 work/kat/gul_S1_summarycalc_P2 work/kat/gul_S1_summarycalc_P3 work/kat/gul_S1_summarycalc_P4 work/kat/gul_S1_summarycalc_P5 work/kat/gul_S1_summarycalc_P6 work/kat/gul_S1_summarycalc_P7 work/kat/gul_S1_summarycalc_P8 work/kat/gul_S1_summarycalc_P9 work/kat/gul_S1_summarycalc_P10 > output/gul_S1_summarycalc.csv & kpid9=$!
+kat -s work/kat/gul_S2_eltcalc_P1 work/kat/gul_S2_eltcalc_P2 work/kat/gul_S2_eltcalc_P3 work/kat/gul_S2_eltcalc_P4 work/kat/gul_S2_eltcalc_P5 work/kat/gul_S2_eltcalc_P6 work/kat/gul_S2_eltcalc_P7 work/kat/gul_S2_eltcalc_P8 work/kat/gul_S2_eltcalc_P9 work/kat/gul_S2_eltcalc_P10 > output/gul_S2_eltcalc.csv & kpid10=$!
+kat work/kat/gul_S2_pltcalc_P1 work/kat/gul_S2_pltcalc_P2 work/kat/gul_S2_pltcalc_P3 work/kat/gul_S2_pltcalc_P4 work/kat/gul_S2_pltcalc_P5 work/kat/gul_S2_pltcalc_P6 work/kat/gul_S2_pltcalc_P7 work/kat/gul_S2_pltcalc_P8 work/kat/gul_S2_pltcalc_P9 work/kat/gul_S2_pltcalc_P10 > output/gul_S2_pltcalc.csv & kpid11=$!
+kat work/kat/gul_S2_summarycalc_P1 work/kat/gul_S2_summarycalc_P2 work/kat/gul_S2_summarycalc_P3 work/kat/gul_S2_summarycalc_P4 work/kat/gul_S2_summarycalc_P5 work/kat/gul_S2_summarycalc_P6 work/kat/gul_S2_summarycalc_P7 work/kat/gul_S2_summarycalc_P8 work/kat/gul_S2_summarycalc_P9 work/kat/gul_S2_summarycalc_P10 > output/gul_S2_summarycalc.csv & kpid12=$!
+wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpid11 $kpid12
+
+
+aalcalc -Kil_S1_summaryaalcalc > output/il_S1_aalcalc.csv & lpid1=$!
+ordleccalc -r -Kil_S1_summaryleccalc -F -S -s -M -m -W -w -O output/il_S1_ept.csv -o output/il_S1_psept.csv & lpid2=$!
+aalcalc -Kil_S2_summaryaalcalc > output/il_S2_aalcalc.csv & lpid3=$!
+ordleccalc -r -Kil_S2_summaryleccalc -F -S -s -M -m -W -w -O output/il_S2_ept.csv -o output/il_S2_psept.csv & lpid4=$!
+aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv & lpid5=$!
+ordleccalc -r -Kgul_S1_summaryleccalc -F -S -s -M -m -W -w -O output/gul_S1_ept.csv -o output/gul_S1_psept.csv & lpid6=$!
+aalcalc -Kgul_S2_summaryaalcalc > output/gul_S2_aalcalc.csv & lpid7=$!
+ordleccalc -r -Kgul_S2_summaryleccalc -F -S -s -M -m -W -w -O output/gul_S2_ept.csv -o output/gul_S2_psept.csv & lpid8=$!
+wait $lpid1 $lpid2 $lpid3 $lpid4 $lpid5 $lpid6 $lpid7 $lpid8
+
+rm -R -f work/*
+rm -R -f /tmp/%FIFO_DIR%/

--- a/tests/model_execution/tmp_kparse_reference/gul_il_ord_psept_lec_1_output_10_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_il_ord_psept_lec_1_output_10_partition.sh
@@ -1,0 +1,296 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+
+rm -R -f work/*
+mkdir work/kat/
+
+rm -R -f /tmp/%FIFO_DIR%/
+mkdir -p /tmp/%FIFO_DIR%/fifo/
+mkdir work/gul_S1_summaryleccalc
+mkdir work/gul_S1_summaryaalcalc
+mkdir work/il_S1_summaryleccalc
+mkdir work/il_S1_summaryaalcalc
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P10
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P1
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P2
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P3
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P4
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P5
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P6
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P7
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P8
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P9
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P10
+
+mkfifo /tmp/%FIFO_DIR%/fifo/il_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/il_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/il_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/il_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/il_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/il_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/il_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/il_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/il_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/il_P10
+
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summary_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P1
+
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summary_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P2
+
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summary_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P3
+
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summary_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P4
+
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summary_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P5
+
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summary_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P6
+
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summary_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P7
+
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summary_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P8
+
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summary_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P9
+
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summary_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P10
+
+
+
+# --- Do insured loss computes ---
+
+eltcalc < /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P1 > work/kat/il_S1_eltcalc_P1 & pid1=$!
+summarycalctocsv < /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P1 > work/kat/il_S1_summarycalc_P1 & pid2=$!
+pltcalc < /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P1 > work/kat/il_S1_pltcalc_P1 & pid3=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P2 > work/kat/il_S1_eltcalc_P2 & pid4=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P2 > work/kat/il_S1_summarycalc_P2 & pid5=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P2 > work/kat/il_S1_pltcalc_P2 & pid6=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P3 > work/kat/il_S1_eltcalc_P3 & pid7=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P3 > work/kat/il_S1_summarycalc_P3 & pid8=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P3 > work/kat/il_S1_pltcalc_P3 & pid9=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P4 > work/kat/il_S1_eltcalc_P4 & pid10=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P4 > work/kat/il_S1_summarycalc_P4 & pid11=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P4 > work/kat/il_S1_pltcalc_P4 & pid12=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P5 > work/kat/il_S1_eltcalc_P5 & pid13=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P5 > work/kat/il_S1_summarycalc_P5 & pid14=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P5 > work/kat/il_S1_pltcalc_P5 & pid15=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P6 > work/kat/il_S1_eltcalc_P6 & pid16=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P6 > work/kat/il_S1_summarycalc_P6 & pid17=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P6 > work/kat/il_S1_pltcalc_P6 & pid18=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P7 > work/kat/il_S1_eltcalc_P7 & pid19=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P7 > work/kat/il_S1_summarycalc_P7 & pid20=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P7 > work/kat/il_S1_pltcalc_P7 & pid21=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P8 > work/kat/il_S1_eltcalc_P8 & pid22=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P8 > work/kat/il_S1_summarycalc_P8 & pid23=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P8 > work/kat/il_S1_pltcalc_P8 & pid24=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P9 > work/kat/il_S1_eltcalc_P9 & pid25=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P9 > work/kat/il_S1_summarycalc_P9 & pid26=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P9 > work/kat/il_S1_pltcalc_P9 & pid27=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P10 > work/kat/il_S1_eltcalc_P10 & pid28=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P10 > work/kat/il_S1_summarycalc_P10 & pid29=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P10 > work/kat/il_S1_pltcalc_P10 & pid30=$!
+
+tee < /tmp/%FIFO_DIR%/fifo/il_S1_summary_P1 /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P1 /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P1 /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P1 work/il_S1_summaryaalcalc/P1.bin work/il_S1_summaryleccalc/P1.bin > /dev/null & pid31=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S1_summary_P2 /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P2 /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P2 /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P2 work/il_S1_summaryaalcalc/P2.bin work/il_S1_summaryleccalc/P2.bin > /dev/null & pid32=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S1_summary_P3 /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P3 /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P3 /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P3 work/il_S1_summaryaalcalc/P3.bin work/il_S1_summaryleccalc/P3.bin > /dev/null & pid33=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S1_summary_P4 /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P4 /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P4 /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P4 work/il_S1_summaryaalcalc/P4.bin work/il_S1_summaryleccalc/P4.bin > /dev/null & pid34=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S1_summary_P5 /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P5 /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P5 /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P5 work/il_S1_summaryaalcalc/P5.bin work/il_S1_summaryleccalc/P5.bin > /dev/null & pid35=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S1_summary_P6 /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P6 /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P6 /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P6 work/il_S1_summaryaalcalc/P6.bin work/il_S1_summaryleccalc/P6.bin > /dev/null & pid36=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S1_summary_P7 /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P7 /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P7 /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P7 work/il_S1_summaryaalcalc/P7.bin work/il_S1_summaryleccalc/P7.bin > /dev/null & pid37=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S1_summary_P8 /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P8 /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P8 /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P8 work/il_S1_summaryaalcalc/P8.bin work/il_S1_summaryleccalc/P8.bin > /dev/null & pid38=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S1_summary_P9 /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P9 /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P9 /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P9 work/il_S1_summaryaalcalc/P9.bin work/il_S1_summaryleccalc/P9.bin > /dev/null & pid39=$!
+tee < /tmp/%FIFO_DIR%/fifo/il_S1_summary_P10 /tmp/%FIFO_DIR%/fifo/il_S1_eltcalc_P10 /tmp/%FIFO_DIR%/fifo/il_S1_summarycalc_P10 /tmp/%FIFO_DIR%/fifo/il_S1_pltcalc_P10 work/il_S1_summaryaalcalc/P10.bin work/il_S1_summaryleccalc/P10.bin > /dev/null & pid40=$!
+
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/il_S1_summary_P1 < /tmp/%FIFO_DIR%/fifo/il_P1 &
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/il_S1_summary_P2 < /tmp/%FIFO_DIR%/fifo/il_P2 &
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/il_S1_summary_P3 < /tmp/%FIFO_DIR%/fifo/il_P3 &
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/il_S1_summary_P4 < /tmp/%FIFO_DIR%/fifo/il_P4 &
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/il_S1_summary_P5 < /tmp/%FIFO_DIR%/fifo/il_P5 &
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/il_S1_summary_P6 < /tmp/%FIFO_DIR%/fifo/il_P6 &
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/il_S1_summary_P7 < /tmp/%FIFO_DIR%/fifo/il_P7 &
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/il_S1_summary_P8 < /tmp/%FIFO_DIR%/fifo/il_P8 &
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/il_S1_summary_P9 < /tmp/%FIFO_DIR%/fifo/il_P9 &
+summarycalc -f  -1 /tmp/%FIFO_DIR%/fifo/il_S1_summary_P10 < /tmp/%FIFO_DIR%/fifo/il_P10 &
+
+# --- Do ground up loss computes ---
+
+eltcalc < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P1 > work/kat/gul_S1_eltcalc_P1 & pid41=$!
+summarycalctocsv < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P1 > work/kat/gul_S1_summarycalc_P1 & pid42=$!
+pltcalc < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P1 > work/kat/gul_S1_pltcalc_P1 & pid43=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P2 > work/kat/gul_S1_eltcalc_P2 & pid44=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P2 > work/kat/gul_S1_summarycalc_P2 & pid45=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P2 > work/kat/gul_S1_pltcalc_P2 & pid46=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P3 > work/kat/gul_S1_eltcalc_P3 & pid47=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P3 > work/kat/gul_S1_summarycalc_P3 & pid48=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P3 > work/kat/gul_S1_pltcalc_P3 & pid49=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P4 > work/kat/gul_S1_eltcalc_P4 & pid50=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P4 > work/kat/gul_S1_summarycalc_P4 & pid51=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P4 > work/kat/gul_S1_pltcalc_P4 & pid52=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P5 > work/kat/gul_S1_eltcalc_P5 & pid53=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P5 > work/kat/gul_S1_summarycalc_P5 & pid54=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P5 > work/kat/gul_S1_pltcalc_P5 & pid55=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P6 > work/kat/gul_S1_eltcalc_P6 & pid56=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P6 > work/kat/gul_S1_summarycalc_P6 & pid57=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P6 > work/kat/gul_S1_pltcalc_P6 & pid58=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P7 > work/kat/gul_S1_eltcalc_P7 & pid59=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P7 > work/kat/gul_S1_summarycalc_P7 & pid60=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P7 > work/kat/gul_S1_pltcalc_P7 & pid61=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P8 > work/kat/gul_S1_eltcalc_P8 & pid62=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P8 > work/kat/gul_S1_summarycalc_P8 & pid63=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P8 > work/kat/gul_S1_pltcalc_P8 & pid64=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P9 > work/kat/gul_S1_eltcalc_P9 & pid65=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P9 > work/kat/gul_S1_summarycalc_P9 & pid66=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P9 > work/kat/gul_S1_pltcalc_P9 & pid67=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P10 > work/kat/gul_S1_eltcalc_P10 & pid68=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P10 > work/kat/gul_S1_summarycalc_P10 & pid69=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P10 > work/kat/gul_S1_pltcalc_P10 & pid70=$!
+
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P1 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P1 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P1 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P1 work/gul_S1_summaryaalcalc/P1.bin work/gul_S1_summaryleccalc/P1.bin > /dev/null & pid71=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P2 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P2 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P2 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P2 work/gul_S1_summaryaalcalc/P2.bin work/gul_S1_summaryleccalc/P2.bin > /dev/null & pid72=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P3 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P3 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P3 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P3 work/gul_S1_summaryaalcalc/P3.bin work/gul_S1_summaryleccalc/P3.bin > /dev/null & pid73=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P4 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P4 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P4 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P4 work/gul_S1_summaryaalcalc/P4.bin work/gul_S1_summaryleccalc/P4.bin > /dev/null & pid74=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P5 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P5 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P5 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P5 work/gul_S1_summaryaalcalc/P5.bin work/gul_S1_summaryleccalc/P5.bin > /dev/null & pid75=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P6 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P6 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P6 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P6 work/gul_S1_summaryaalcalc/P6.bin work/gul_S1_summaryleccalc/P6.bin > /dev/null & pid76=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P7 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P7 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P7 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P7 work/gul_S1_summaryaalcalc/P7.bin work/gul_S1_summaryleccalc/P7.bin > /dev/null & pid77=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P8 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P8 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P8 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P8 work/gul_S1_summaryaalcalc/P8.bin work/gul_S1_summaryleccalc/P8.bin > /dev/null & pid78=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P9 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P9 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P9 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P9 work/gul_S1_summaryaalcalc/P9.bin work/gul_S1_summaryleccalc/P9.bin > /dev/null & pid79=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P10 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P10 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P10 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P10 work/gul_S1_summaryaalcalc/P10.bin work/gul_S1_summaryleccalc/P10.bin > /dev/null & pid80=$!
+
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P1 < /tmp/%FIFO_DIR%/fifo/gul_P1 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P2 < /tmp/%FIFO_DIR%/fifo/gul_P2 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P3 < /tmp/%FIFO_DIR%/fifo/gul_P3 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P4 < /tmp/%FIFO_DIR%/fifo/gul_P4 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P5 < /tmp/%FIFO_DIR%/fifo/gul_P5 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P6 < /tmp/%FIFO_DIR%/fifo/gul_P6 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P7 < /tmp/%FIFO_DIR%/fifo/gul_P7 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P8 < /tmp/%FIFO_DIR%/fifo/gul_P8 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P9 < /tmp/%FIFO_DIR%/fifo/gul_P9 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P10 < /tmp/%FIFO_DIR%/fifo/gul_P10 &
+
+eve 1 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee /tmp/%FIFO_DIR%/fifo/gul_P1 | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/il_P1  &
+eve 2 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee /tmp/%FIFO_DIR%/fifo/gul_P2 | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/il_P2  &
+eve 3 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee /tmp/%FIFO_DIR%/fifo/gul_P3 | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/il_P3  &
+eve 4 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee /tmp/%FIFO_DIR%/fifo/gul_P4 | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/il_P4  &
+eve 5 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee /tmp/%FIFO_DIR%/fifo/gul_P5 | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/il_P5  &
+eve 6 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee /tmp/%FIFO_DIR%/fifo/gul_P6 | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/il_P6  &
+eve 7 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee /tmp/%FIFO_DIR%/fifo/gul_P7 | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/il_P7  &
+eve 8 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee /tmp/%FIFO_DIR%/fifo/gul_P8 | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/il_P8  &
+eve 9 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee /tmp/%FIFO_DIR%/fifo/gul_P9 | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/il_P9  &
+eve 10 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - | tee /tmp/%FIFO_DIR%/fifo/gul_P10 | fmcalc -a2 > /tmp/%FIFO_DIR%/fifo/il_P10  &
+
+wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 $pid13 $pid14 $pid15 $pid16 $pid17 $pid18 $pid19 $pid20 $pid21 $pid22 $pid23 $pid24 $pid25 $pid26 $pid27 $pid28 $pid29 $pid30 $pid31 $pid32 $pid33 $pid34 $pid35 $pid36 $pid37 $pid38 $pid39 $pid40 $pid41 $pid42 $pid43 $pid44 $pid45 $pid46 $pid47 $pid48 $pid49 $pid50 $pid51 $pid52 $pid53 $pid54 $pid55 $pid56 $pid57 $pid58 $pid59 $pid60 $pid61 $pid62 $pid63 $pid64 $pid65 $pid66 $pid67 $pid68 $pid69 $pid70 $pid71 $pid72 $pid73 $pid74 $pid75 $pid76 $pid77 $pid78 $pid79 $pid80
+
+
+# --- Do insured loss kats ---
+
+kat -s work/kat/il_S1_eltcalc_P1 work/kat/il_S1_eltcalc_P2 work/kat/il_S1_eltcalc_P3 work/kat/il_S1_eltcalc_P4 work/kat/il_S1_eltcalc_P5 work/kat/il_S1_eltcalc_P6 work/kat/il_S1_eltcalc_P7 work/kat/il_S1_eltcalc_P8 work/kat/il_S1_eltcalc_P9 work/kat/il_S1_eltcalc_P10 > output/il_S1_eltcalc.csv & kpid1=$!
+kat work/kat/il_S1_pltcalc_P1 work/kat/il_S1_pltcalc_P2 work/kat/il_S1_pltcalc_P3 work/kat/il_S1_pltcalc_P4 work/kat/il_S1_pltcalc_P5 work/kat/il_S1_pltcalc_P6 work/kat/il_S1_pltcalc_P7 work/kat/il_S1_pltcalc_P8 work/kat/il_S1_pltcalc_P9 work/kat/il_S1_pltcalc_P10 > output/il_S1_pltcalc.csv & kpid2=$!
+kat work/kat/il_S1_summarycalc_P1 work/kat/il_S1_summarycalc_P2 work/kat/il_S1_summarycalc_P3 work/kat/il_S1_summarycalc_P4 work/kat/il_S1_summarycalc_P5 work/kat/il_S1_summarycalc_P6 work/kat/il_S1_summarycalc_P7 work/kat/il_S1_summarycalc_P8 work/kat/il_S1_summarycalc_P9 work/kat/il_S1_summarycalc_P10 > output/il_S1_summarycalc.csv & kpid3=$!
+
+# --- Do ground up loss kats ---
+
+kat -s work/kat/gul_S1_eltcalc_P1 work/kat/gul_S1_eltcalc_P2 work/kat/gul_S1_eltcalc_P3 work/kat/gul_S1_eltcalc_P4 work/kat/gul_S1_eltcalc_P5 work/kat/gul_S1_eltcalc_P6 work/kat/gul_S1_eltcalc_P7 work/kat/gul_S1_eltcalc_P8 work/kat/gul_S1_eltcalc_P9 work/kat/gul_S1_eltcalc_P10 > output/gul_S1_eltcalc.csv & kpid4=$!
+kat work/kat/gul_S1_pltcalc_P1 work/kat/gul_S1_pltcalc_P2 work/kat/gul_S1_pltcalc_P3 work/kat/gul_S1_pltcalc_P4 work/kat/gul_S1_pltcalc_P5 work/kat/gul_S1_pltcalc_P6 work/kat/gul_S1_pltcalc_P7 work/kat/gul_S1_pltcalc_P8 work/kat/gul_S1_pltcalc_P9 work/kat/gul_S1_pltcalc_P10 > output/gul_S1_pltcalc.csv & kpid5=$!
+kat work/kat/gul_S1_summarycalc_P1 work/kat/gul_S1_summarycalc_P2 work/kat/gul_S1_summarycalc_P3 work/kat/gul_S1_summarycalc_P4 work/kat/gul_S1_summarycalc_P5 work/kat/gul_S1_summarycalc_P6 work/kat/gul_S1_summarycalc_P7 work/kat/gul_S1_summarycalc_P8 work/kat/gul_S1_summarycalc_P9 work/kat/gul_S1_summarycalc_P10 > output/gul_S1_summarycalc.csv & kpid6=$!
+wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
+
+
+aalcalc -Kil_S1_summaryaalcalc > output/il_S1_aalcalc.csv & lpid1=$!
+ordleccalc -r -Kil_S1_summaryleccalc -W -w -o output/il_S1_psept.csv & lpid2=$!
+leccalc -r -Kil_S1_summaryleccalc -F output/il_S1_leccalc_full_uncertainty_aep.csv -f output/il_S1_leccalc_full_uncertainty_oep.csv -S output/il_S1_leccalc_sample_mean_aep.csv -s output/il_S1_leccalc_sample_mean_oep.csv -W output/il_S1_leccalc_wheatsheaf_aep.csv -M output/il_S1_leccalc_wheatsheaf_mean_aep.csv -m output/il_S1_leccalc_wheatsheaf_mean_oep.csv -w output/il_S1_leccalc_wheatsheaf_oep.csv & lpid3=$!
+aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv & lpid4=$!
+ordleccalc  -Kgul_S1_summaryleccalc -W -w -o output/gul_S1_psept.csv & lpid5=$!
+leccalc -r -Kgul_S1_summaryleccalc -F output/gul_S1_leccalc_full_uncertainty_aep.csv -f output/gul_S1_leccalc_full_uncertainty_oep.csv -S output/gul_S1_leccalc_sample_mean_aep.csv -s output/gul_S1_leccalc_sample_mean_oep.csv -W output/gul_S1_leccalc_wheatsheaf_aep.csv -M output/gul_S1_leccalc_wheatsheaf_mean_aep.csv -m output/gul_S1_leccalc_wheatsheaf_mean_oep.csv -w output/gul_S1_leccalc_wheatsheaf_oep.csv & lpid6=$!
+wait $lpid1 $lpid2 $lpid3 $lpid4 $lpid5 $lpid6
+
+rm -R -f work/*
+rm -R -f /tmp/%FIFO_DIR%/

--- a/tests/model_execution/tmp_kparse_reference/gul_ord_ept_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_ord_ept_1_output_1_partition.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+
+rm -R -f work/*
+mkdir work/kat/
+
+rm -R -f /tmp/%FIFO_DIR%/
+mkdir -p /tmp/%FIFO_DIR%/fifo/
+mkdir work/gul_S1_summaryleccalc
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P1
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P1
+
+
+
+# --- Do ground up loss computes ---
+
+
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P1 work/gul_S1_summaryleccalc/P1.bin > /dev/null & pid1=$!
+
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P1 < /tmp/%FIFO_DIR%/fifo/gul_P1 &
+
+eve 1 1 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P1  &
+
+wait $pid1
+
+
+# --- Do ground up loss kats ---
+
+
+ordleccalc -r -Kgul_S1_summaryleccalc -F -f -S -s -M -m -O output/gul_S1_ept.csv & lpid1=$!
+wait $lpid1
+
+rm -R -f work/*
+rm -R -f /tmp/%FIFO_DIR%/

--- a/tests/model_execution/tmp_kparse_reference/gul_ord_ept_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_ord_ept_1_output_20_partition.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+
+rm -R -f work/*
+mkdir work/kat/
+
+rm -R -f /tmp/%FIFO_DIR%/
+mkdir -p /tmp/%FIFO_DIR%/fifo/
+mkdir work/gul_S1_summaryleccalc
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P11
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P12
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P13
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P14
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P15
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P16
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P17
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P18
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P19
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P20
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P1
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P2
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P3
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P4
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P5
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P6
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P7
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P8
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P9
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P10
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P11
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P12
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P13
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P14
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P15
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P16
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P17
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P18
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P19
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P20
+
+
+
+# --- Do ground up loss computes ---
+
+
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P1 work/gul_S1_summaryleccalc/P1.bin > /dev/null & pid1=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P2 work/gul_S1_summaryleccalc/P2.bin > /dev/null & pid2=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P3 work/gul_S1_summaryleccalc/P3.bin > /dev/null & pid3=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P4 work/gul_S1_summaryleccalc/P4.bin > /dev/null & pid4=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P5 work/gul_S1_summaryleccalc/P5.bin > /dev/null & pid5=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P6 work/gul_S1_summaryleccalc/P6.bin > /dev/null & pid6=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P7 work/gul_S1_summaryleccalc/P7.bin > /dev/null & pid7=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P8 work/gul_S1_summaryleccalc/P8.bin > /dev/null & pid8=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P9 work/gul_S1_summaryleccalc/P9.bin > /dev/null & pid9=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P10 work/gul_S1_summaryleccalc/P10.bin > /dev/null & pid10=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P11 work/gul_S1_summaryleccalc/P11.bin > /dev/null & pid11=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P12 work/gul_S1_summaryleccalc/P12.bin > /dev/null & pid12=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P13 work/gul_S1_summaryleccalc/P13.bin > /dev/null & pid13=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P14 work/gul_S1_summaryleccalc/P14.bin > /dev/null & pid14=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P15 work/gul_S1_summaryleccalc/P15.bin > /dev/null & pid15=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P16 work/gul_S1_summaryleccalc/P16.bin > /dev/null & pid16=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P17 work/gul_S1_summaryleccalc/P17.bin > /dev/null & pid17=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P18 work/gul_S1_summaryleccalc/P18.bin > /dev/null & pid18=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P19 work/gul_S1_summaryleccalc/P19.bin > /dev/null & pid19=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P20 work/gul_S1_summaryleccalc/P20.bin > /dev/null & pid20=$!
+
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P1 < /tmp/%FIFO_DIR%/fifo/gul_P1 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P2 < /tmp/%FIFO_DIR%/fifo/gul_P2 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P3 < /tmp/%FIFO_DIR%/fifo/gul_P3 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P4 < /tmp/%FIFO_DIR%/fifo/gul_P4 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P5 < /tmp/%FIFO_DIR%/fifo/gul_P5 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P6 < /tmp/%FIFO_DIR%/fifo/gul_P6 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P7 < /tmp/%FIFO_DIR%/fifo/gul_P7 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P8 < /tmp/%FIFO_DIR%/fifo/gul_P8 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P9 < /tmp/%FIFO_DIR%/fifo/gul_P9 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P10 < /tmp/%FIFO_DIR%/fifo/gul_P10 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P11 < /tmp/%FIFO_DIR%/fifo/gul_P11 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P12 < /tmp/%FIFO_DIR%/fifo/gul_P12 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P13 < /tmp/%FIFO_DIR%/fifo/gul_P13 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P14 < /tmp/%FIFO_DIR%/fifo/gul_P14 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P15 < /tmp/%FIFO_DIR%/fifo/gul_P15 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P16 < /tmp/%FIFO_DIR%/fifo/gul_P16 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P17 < /tmp/%FIFO_DIR%/fifo/gul_P17 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P18 < /tmp/%FIFO_DIR%/fifo/gul_P18 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P19 < /tmp/%FIFO_DIR%/fifo/gul_P19 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P20 < /tmp/%FIFO_DIR%/fifo/gul_P20 &
+
+eve 1 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P1  &
+eve 2 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P2  &
+eve 3 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P3  &
+eve 4 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P4  &
+eve 5 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P5  &
+eve 6 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P6  &
+eve 7 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P7  &
+eve 8 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P8  &
+eve 9 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P9  &
+eve 10 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P10  &
+eve 11 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P11  &
+eve 12 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P12  &
+eve 13 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P13  &
+eve 14 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P14  &
+eve 15 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P15  &
+eve 16 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P16  &
+eve 17 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P17  &
+eve 18 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P18  &
+eve 19 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P19  &
+eve 20 20 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P20  &
+
+wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 $pid13 $pid14 $pid15 $pid16 $pid17 $pid18 $pid19 $pid20
+
+
+# --- Do ground up loss kats ---
+
+
+ordleccalc -r -Kgul_S1_summaryleccalc -F -f -S -s -M -m -O output/gul_S1_ept.csv & lpid1=$!
+wait $lpid1
+
+rm -R -f work/*
+rm -R -f /tmp/%FIFO_DIR%/

--- a/tests/model_execution/tmp_kparse_reference/gul_ord_ept_psept_lec_2_output_10_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_ord_ept_psept_lec_2_output_10_partition.sh
@@ -1,0 +1,257 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+
+rm -R -f work/*
+mkdir work/kat/
+
+rm -R -f /tmp/%FIFO_DIR%/
+mkdir -p /tmp/%FIFO_DIR%/fifo/
+mkdir work/gul_S1_summaryleccalc
+mkdir work/gul_S1_summaryaalcalc
+mkdir work/gul_S2_summaryleccalc
+mkdir work/gul_S2_summaryaalcalc
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P10
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P1
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P2
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P3
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P4
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P5
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P6
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P7
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P8
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P9
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P10
+
+
+
+# --- Do ground up loss computes ---
+
+eltcalc < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P1 > work/kat/gul_S1_eltcalc_P1 & pid1=$!
+summarycalctocsv < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P1 > work/kat/gul_S1_summarycalc_P1 & pid2=$!
+pltcalc < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P1 > work/kat/gul_S1_pltcalc_P1 & pid3=$!
+eltcalc < /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P1 > work/kat/gul_S2_eltcalc_P1 & pid4=$!
+summarycalctocsv < /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P1 > work/kat/gul_S2_summarycalc_P1 & pid5=$!
+pltcalc < /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P1 > work/kat/gul_S2_pltcalc_P1 & pid6=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P2 > work/kat/gul_S1_eltcalc_P2 & pid7=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P2 > work/kat/gul_S1_summarycalc_P2 & pid8=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P2 > work/kat/gul_S1_pltcalc_P2 & pid9=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P2 > work/kat/gul_S2_eltcalc_P2 & pid10=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P2 > work/kat/gul_S2_summarycalc_P2 & pid11=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P2 > work/kat/gul_S2_pltcalc_P2 & pid12=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P3 > work/kat/gul_S1_eltcalc_P3 & pid13=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P3 > work/kat/gul_S1_summarycalc_P3 & pid14=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P3 > work/kat/gul_S1_pltcalc_P3 & pid15=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P3 > work/kat/gul_S2_eltcalc_P3 & pid16=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P3 > work/kat/gul_S2_summarycalc_P3 & pid17=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P3 > work/kat/gul_S2_pltcalc_P3 & pid18=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P4 > work/kat/gul_S1_eltcalc_P4 & pid19=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P4 > work/kat/gul_S1_summarycalc_P4 & pid20=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P4 > work/kat/gul_S1_pltcalc_P4 & pid21=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P4 > work/kat/gul_S2_eltcalc_P4 & pid22=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P4 > work/kat/gul_S2_summarycalc_P4 & pid23=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P4 > work/kat/gul_S2_pltcalc_P4 & pid24=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P5 > work/kat/gul_S1_eltcalc_P5 & pid25=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P5 > work/kat/gul_S1_summarycalc_P5 & pid26=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P5 > work/kat/gul_S1_pltcalc_P5 & pid27=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P5 > work/kat/gul_S2_eltcalc_P5 & pid28=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P5 > work/kat/gul_S2_summarycalc_P5 & pid29=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P5 > work/kat/gul_S2_pltcalc_P5 & pid30=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P6 > work/kat/gul_S1_eltcalc_P6 & pid31=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P6 > work/kat/gul_S1_summarycalc_P6 & pid32=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P6 > work/kat/gul_S1_pltcalc_P6 & pid33=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P6 > work/kat/gul_S2_eltcalc_P6 & pid34=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P6 > work/kat/gul_S2_summarycalc_P6 & pid35=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P6 > work/kat/gul_S2_pltcalc_P6 & pid36=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P7 > work/kat/gul_S1_eltcalc_P7 & pid37=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P7 > work/kat/gul_S1_summarycalc_P7 & pid38=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P7 > work/kat/gul_S1_pltcalc_P7 & pid39=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P7 > work/kat/gul_S2_eltcalc_P7 & pid40=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P7 > work/kat/gul_S2_summarycalc_P7 & pid41=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P7 > work/kat/gul_S2_pltcalc_P7 & pid42=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P8 > work/kat/gul_S1_eltcalc_P8 & pid43=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P8 > work/kat/gul_S1_summarycalc_P8 & pid44=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P8 > work/kat/gul_S1_pltcalc_P8 & pid45=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P8 > work/kat/gul_S2_eltcalc_P8 & pid46=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P8 > work/kat/gul_S2_summarycalc_P8 & pid47=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P8 > work/kat/gul_S2_pltcalc_P8 & pid48=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P9 > work/kat/gul_S1_eltcalc_P9 & pid49=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P9 > work/kat/gul_S1_summarycalc_P9 & pid50=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P9 > work/kat/gul_S1_pltcalc_P9 & pid51=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P9 > work/kat/gul_S2_eltcalc_P9 & pid52=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P9 > work/kat/gul_S2_summarycalc_P9 & pid53=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P9 > work/kat/gul_S2_pltcalc_P9 & pid54=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P10 > work/kat/gul_S1_eltcalc_P10 & pid55=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P10 > work/kat/gul_S1_summarycalc_P10 & pid56=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P10 > work/kat/gul_S1_pltcalc_P10 & pid57=$!
+eltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P10 > work/kat/gul_S2_eltcalc_P10 & pid58=$!
+summarycalctocsv -s < /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P10 > work/kat/gul_S2_summarycalc_P10 & pid59=$!
+pltcalc -s < /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P10 > work/kat/gul_S2_pltcalc_P10 & pid60=$!
+
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P1 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P1 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P1 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P1 work/gul_S1_summaryaalcalc/P1.bin work/gul_S1_summaryleccalc/P1.bin > /dev/null & pid61=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P1 /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P1 /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P1 /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P1 work/gul_S2_summaryaalcalc/P1.bin work/gul_S2_summaryleccalc/P1.bin > /dev/null & pid62=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P2 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P2 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P2 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P2 work/gul_S1_summaryaalcalc/P2.bin work/gul_S1_summaryleccalc/P2.bin > /dev/null & pid63=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P2 /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P2 /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P2 /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P2 work/gul_S2_summaryaalcalc/P2.bin work/gul_S2_summaryleccalc/P2.bin > /dev/null & pid64=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P3 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P3 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P3 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P3 work/gul_S1_summaryaalcalc/P3.bin work/gul_S1_summaryleccalc/P3.bin > /dev/null & pid65=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P3 /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P3 /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P3 /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P3 work/gul_S2_summaryaalcalc/P3.bin work/gul_S2_summaryleccalc/P3.bin > /dev/null & pid66=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P4 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P4 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P4 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P4 work/gul_S1_summaryaalcalc/P4.bin work/gul_S1_summaryleccalc/P4.bin > /dev/null & pid67=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P4 /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P4 /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P4 /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P4 work/gul_S2_summaryaalcalc/P4.bin work/gul_S2_summaryleccalc/P4.bin > /dev/null & pid68=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P5 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P5 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P5 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P5 work/gul_S1_summaryaalcalc/P5.bin work/gul_S1_summaryleccalc/P5.bin > /dev/null & pid69=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P5 /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P5 /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P5 /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P5 work/gul_S2_summaryaalcalc/P5.bin work/gul_S2_summaryleccalc/P5.bin > /dev/null & pid70=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P6 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P6 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P6 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P6 work/gul_S1_summaryaalcalc/P6.bin work/gul_S1_summaryleccalc/P6.bin > /dev/null & pid71=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P6 /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P6 /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P6 /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P6 work/gul_S2_summaryaalcalc/P6.bin work/gul_S2_summaryleccalc/P6.bin > /dev/null & pid72=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P7 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P7 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P7 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P7 work/gul_S1_summaryaalcalc/P7.bin work/gul_S1_summaryleccalc/P7.bin > /dev/null & pid73=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P7 /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P7 /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P7 /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P7 work/gul_S2_summaryaalcalc/P7.bin work/gul_S2_summaryleccalc/P7.bin > /dev/null & pid74=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P8 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P8 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P8 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P8 work/gul_S1_summaryaalcalc/P8.bin work/gul_S1_summaryleccalc/P8.bin > /dev/null & pid75=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P8 /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P8 /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P8 /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P8 work/gul_S2_summaryaalcalc/P8.bin work/gul_S2_summaryleccalc/P8.bin > /dev/null & pid76=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P9 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P9 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P9 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P9 work/gul_S1_summaryaalcalc/P9.bin work/gul_S1_summaryleccalc/P9.bin > /dev/null & pid77=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P9 /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P9 /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P9 /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P9 work/gul_S2_summaryaalcalc/P9.bin work/gul_S2_summaryleccalc/P9.bin > /dev/null & pid78=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P10 /tmp/%FIFO_DIR%/fifo/gul_S1_eltcalc_P10 /tmp/%FIFO_DIR%/fifo/gul_S1_summarycalc_P10 /tmp/%FIFO_DIR%/fifo/gul_S1_pltcalc_P10 work/gul_S1_summaryaalcalc/P10.bin work/gul_S1_summaryleccalc/P10.bin > /dev/null & pid79=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P10 /tmp/%FIFO_DIR%/fifo/gul_S2_eltcalc_P10 /tmp/%FIFO_DIR%/fifo/gul_S2_summarycalc_P10 /tmp/%FIFO_DIR%/fifo/gul_S2_pltcalc_P10 work/gul_S2_summaryaalcalc/P10.bin work/gul_S2_summaryleccalc/P10.bin > /dev/null & pid80=$!
+
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P1 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P1 < /tmp/%FIFO_DIR%/fifo/gul_P1 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P2 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P2 < /tmp/%FIFO_DIR%/fifo/gul_P2 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P3 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P3 < /tmp/%FIFO_DIR%/fifo/gul_P3 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P4 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P4 < /tmp/%FIFO_DIR%/fifo/gul_P4 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P5 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P5 < /tmp/%FIFO_DIR%/fifo/gul_P5 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P6 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P6 < /tmp/%FIFO_DIR%/fifo/gul_P6 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P7 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P7 < /tmp/%FIFO_DIR%/fifo/gul_P7 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P8 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P8 < /tmp/%FIFO_DIR%/fifo/gul_P8 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P9 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P9 < /tmp/%FIFO_DIR%/fifo/gul_P9 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P10 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P10 < /tmp/%FIFO_DIR%/fifo/gul_P10 &
+
+eve 1 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P1  &
+eve 2 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P2  &
+eve 3 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P3  &
+eve 4 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P4  &
+eve 5 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P5  &
+eve 6 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P6  &
+eve 7 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P7  &
+eve 8 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P8  &
+eve 9 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P9  &
+eve 10 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P10  &
+
+wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 $pid13 $pid14 $pid15 $pid16 $pid17 $pid18 $pid19 $pid20 $pid21 $pid22 $pid23 $pid24 $pid25 $pid26 $pid27 $pid28 $pid29 $pid30 $pid31 $pid32 $pid33 $pid34 $pid35 $pid36 $pid37 $pid38 $pid39 $pid40 $pid41 $pid42 $pid43 $pid44 $pid45 $pid46 $pid47 $pid48 $pid49 $pid50 $pid51 $pid52 $pid53 $pid54 $pid55 $pid56 $pid57 $pid58 $pid59 $pid60 $pid61 $pid62 $pid63 $pid64 $pid65 $pid66 $pid67 $pid68 $pid69 $pid70 $pid71 $pid72 $pid73 $pid74 $pid75 $pid76 $pid77 $pid78 $pid79 $pid80
+
+
+# --- Do ground up loss kats ---
+
+kat -s work/kat/gul_S1_eltcalc_P1 work/kat/gul_S1_eltcalc_P2 work/kat/gul_S1_eltcalc_P3 work/kat/gul_S1_eltcalc_P4 work/kat/gul_S1_eltcalc_P5 work/kat/gul_S1_eltcalc_P6 work/kat/gul_S1_eltcalc_P7 work/kat/gul_S1_eltcalc_P8 work/kat/gul_S1_eltcalc_P9 work/kat/gul_S1_eltcalc_P10 > output/gul_S1_eltcalc.csv & kpid1=$!
+kat work/kat/gul_S1_pltcalc_P1 work/kat/gul_S1_pltcalc_P2 work/kat/gul_S1_pltcalc_P3 work/kat/gul_S1_pltcalc_P4 work/kat/gul_S1_pltcalc_P5 work/kat/gul_S1_pltcalc_P6 work/kat/gul_S1_pltcalc_P7 work/kat/gul_S1_pltcalc_P8 work/kat/gul_S1_pltcalc_P9 work/kat/gul_S1_pltcalc_P10 > output/gul_S1_pltcalc.csv & kpid2=$!
+kat work/kat/gul_S1_summarycalc_P1 work/kat/gul_S1_summarycalc_P2 work/kat/gul_S1_summarycalc_P3 work/kat/gul_S1_summarycalc_P4 work/kat/gul_S1_summarycalc_P5 work/kat/gul_S1_summarycalc_P6 work/kat/gul_S1_summarycalc_P7 work/kat/gul_S1_summarycalc_P8 work/kat/gul_S1_summarycalc_P9 work/kat/gul_S1_summarycalc_P10 > output/gul_S1_summarycalc.csv & kpid3=$!
+kat -s work/kat/gul_S2_eltcalc_P1 work/kat/gul_S2_eltcalc_P2 work/kat/gul_S2_eltcalc_P3 work/kat/gul_S2_eltcalc_P4 work/kat/gul_S2_eltcalc_P5 work/kat/gul_S2_eltcalc_P6 work/kat/gul_S2_eltcalc_P7 work/kat/gul_S2_eltcalc_P8 work/kat/gul_S2_eltcalc_P9 work/kat/gul_S2_eltcalc_P10 > output/gul_S2_eltcalc.csv & kpid4=$!
+kat work/kat/gul_S2_pltcalc_P1 work/kat/gul_S2_pltcalc_P2 work/kat/gul_S2_pltcalc_P3 work/kat/gul_S2_pltcalc_P4 work/kat/gul_S2_pltcalc_P5 work/kat/gul_S2_pltcalc_P6 work/kat/gul_S2_pltcalc_P7 work/kat/gul_S2_pltcalc_P8 work/kat/gul_S2_pltcalc_P9 work/kat/gul_S2_pltcalc_P10 > output/gul_S2_pltcalc.csv & kpid5=$!
+kat work/kat/gul_S2_summarycalc_P1 work/kat/gul_S2_summarycalc_P2 work/kat/gul_S2_summarycalc_P3 work/kat/gul_S2_summarycalc_P4 work/kat/gul_S2_summarycalc_P5 work/kat/gul_S2_summarycalc_P6 work/kat/gul_S2_summarycalc_P7 work/kat/gul_S2_summarycalc_P8 work/kat/gul_S2_summarycalc_P9 work/kat/gul_S2_summarycalc_P10 > output/gul_S2_summarycalc.csv & kpid6=$!
+wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
+
+
+aalcalc -Kgul_S1_summaryaalcalc > output/gul_S1_aalcalc.csv & lpid1=$!
+ordleccalc -r -Kgul_S1_summaryleccalc -F -S -s -M -m -W -w -O output/gul_S1_ept.csv -o output/gul_S1_psept.csv & lpid2=$!
+leccalc -r -Kgul_S1_summaryleccalc -F output/gul_S1_leccalc_full_uncertainty_aep.csv -f output/gul_S1_leccalc_full_uncertainty_oep.csv -S output/gul_S1_leccalc_sample_mean_aep.csv -s output/gul_S1_leccalc_sample_mean_oep.csv -W output/gul_S1_leccalc_wheatsheaf_aep.csv -M output/gul_S1_leccalc_wheatsheaf_mean_aep.csv -m output/gul_S1_leccalc_wheatsheaf_mean_oep.csv -w output/gul_S1_leccalc_wheatsheaf_oep.csv & lpid3=$!
+aalcalc -Kgul_S2_summaryaalcalc > output/gul_S2_aalcalc.csv & lpid4=$!
+ordleccalc -r -Kgul_S2_summaryleccalc -F -S -s -M -m -W -w -O output/gul_S2_ept.csv -o output/gul_S2_psept.csv & lpid5=$!
+leccalc -r -Kgul_S2_summaryleccalc -F output/gul_S2_leccalc_full_uncertainty_aep.csv -f output/gul_S2_leccalc_full_uncertainty_oep.csv -S output/gul_S2_leccalc_sample_mean_aep.csv -s output/gul_S2_leccalc_sample_mean_oep.csv -W output/gul_S2_leccalc_wheatsheaf_aep.csv -M output/gul_S2_leccalc_wheatsheaf_mean_aep.csv -m output/gul_S2_leccalc_wheatsheaf_mean_oep.csv -w output/gul_S2_leccalc_wheatsheaf_oep.csv & lpid6=$!
+wait $lpid1 $lpid2 $lpid3 $lpid4 $lpid5 $lpid6
+
+rm -R -f work/*
+rm -R -f /tmp/%FIFO_DIR%/

--- a/tests/model_execution/tmp_kparse_reference/gul_ord_psept_2_output_10_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_ord_psept_2_output_10_partition.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
+
+# --- Script Init ---
+
+set -e
+set -o pipefail
+mkdir -p log
+rm -R -f log/*
+
+# --- Setup run dirs ---
+
+find output -type f -not -name '*summary-info*' -exec rm -R -f {} +
+
+rm -R -f work/*
+mkdir work/kat/
+
+rm -R -f /tmp/%FIFO_DIR%/
+mkdir -p /tmp/%FIFO_DIR%/fifo/
+mkdir work/gul_S1_summaryleccalc
+mkdir work/gul_S2_summaryleccalc
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_P10
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P1
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P1
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P2
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P2
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P3
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P3
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P4
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P4
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P5
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P5
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P6
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P6
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P7
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P7
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P8
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P8
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P9
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P9
+
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P10
+mkfifo /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P10
+
+
+
+# --- Do ground up loss computes ---
+
+
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P1 work/gul_S1_summaryleccalc/P1.bin > /dev/null & pid1=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P1 work/gul_S2_summaryleccalc/P1.bin > /dev/null & pid2=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P2 work/gul_S1_summaryleccalc/P2.bin > /dev/null & pid3=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P2 work/gul_S2_summaryleccalc/P2.bin > /dev/null & pid4=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P3 work/gul_S1_summaryleccalc/P3.bin > /dev/null & pid5=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P3 work/gul_S2_summaryleccalc/P3.bin > /dev/null & pid6=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P4 work/gul_S1_summaryleccalc/P4.bin > /dev/null & pid7=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P4 work/gul_S2_summaryleccalc/P4.bin > /dev/null & pid8=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P5 work/gul_S1_summaryleccalc/P5.bin > /dev/null & pid9=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P5 work/gul_S2_summaryleccalc/P5.bin > /dev/null & pid10=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P6 work/gul_S1_summaryleccalc/P6.bin > /dev/null & pid11=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P6 work/gul_S2_summaryleccalc/P6.bin > /dev/null & pid12=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P7 work/gul_S1_summaryleccalc/P7.bin > /dev/null & pid13=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P7 work/gul_S2_summaryleccalc/P7.bin > /dev/null & pid14=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P8 work/gul_S1_summaryleccalc/P8.bin > /dev/null & pid15=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P8 work/gul_S2_summaryleccalc/P8.bin > /dev/null & pid16=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P9 work/gul_S1_summaryleccalc/P9.bin > /dev/null & pid17=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P9 work/gul_S2_summaryleccalc/P9.bin > /dev/null & pid18=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P10 work/gul_S1_summaryleccalc/P10.bin > /dev/null & pid19=$!
+tee < /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P10 work/gul_S2_summaryleccalc/P10.bin > /dev/null & pid20=$!
+
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P1 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P1 < /tmp/%FIFO_DIR%/fifo/gul_P1 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P2 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P2 < /tmp/%FIFO_DIR%/fifo/gul_P2 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P3 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P3 < /tmp/%FIFO_DIR%/fifo/gul_P3 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P4 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P4 < /tmp/%FIFO_DIR%/fifo/gul_P4 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P5 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P5 < /tmp/%FIFO_DIR%/fifo/gul_P5 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P6 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P6 < /tmp/%FIFO_DIR%/fifo/gul_P6 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P7 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P7 < /tmp/%FIFO_DIR%/fifo/gul_P7 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P8 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P8 < /tmp/%FIFO_DIR%/fifo/gul_P8 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P9 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P9 < /tmp/%FIFO_DIR%/fifo/gul_P9 &
+summarycalc -i  -1 /tmp/%FIFO_DIR%/fifo/gul_S1_summary_P10 -2 /tmp/%FIFO_DIR%/fifo/gul_S2_summary_P10 < /tmp/%FIFO_DIR%/fifo/gul_P10 &
+
+eve 1 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P1  &
+eve 2 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P2  &
+eve 3 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P3  &
+eve 4 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P4  &
+eve 5 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P5  &
+eve 6 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P6  &
+eve 7 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P7  &
+eve 8 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P8  &
+eve 9 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P9  &
+eve 10 10 | getmodel | gulcalc -S0 -L0 -r -a1 -i - > /tmp/%FIFO_DIR%/fifo/gul_P10  &
+
+wait $pid1 $pid2 $pid3 $pid4 $pid5 $pid6 $pid7 $pid8 $pid9 $pid10 $pid11 $pid12 $pid13 $pid14 $pid15 $pid16 $pid17 $pid18 $pid19 $pid20
+
+
+# --- Do ground up loss kats ---
+
+
+ordleccalc  -Kgul_S1_summaryleccalc -W -w -o output/gul_S1_psept.csv & lpid1=$!
+ordleccalc -r -Kgul_S2_summaryleccalc -W -w -o output/gul_S2_psept.csv & lpid2=$!
+wait $lpid1 $lpid2
+
+rm -R -f work/*
+rm -R -f /tmp/%FIFO_DIR%/

--- a/tests/model_execution/tmp_kparse_reference/update-tmp-tests.sh
+++ b/tests/model_execution/tmp_kparse_reference/update-tmp-tests.sh
@@ -84,6 +84,13 @@ all_files=(
     il_pltcalc_1_output_20_partition.sh
     il_summarycalc_1_output_1_partition.sh
     il_summarycalc_1_output_20_partition.sh
+    analysis_settings_5_1_reins_layer_1_partition.sh
+	gul_il_ord_ept_psept_2_output_10_partition.sh
+	gul_il_ord_psept_lec_1_output_10_partition.sh
+	gul_ord_ept_1_output_1_partition.sh
+	gul_ord_ept_1_output_20_partition.sh
+	gul_ord_ept_psept_lec_2_output_10_partition.sh
+	gul_ord_psept_2_output_10_partition.sh
 )
 
 for f in "${all_files[@]}"; do 


### PR DESCRIPTION
Analysis settings schema update and integration for [Ktools PR195](https://github.com/OasisLMF/ktools/pull/195)
- [x] Added `ept` / `psept` to bash generation 
- [x] Update bash tests & added ord checks 
- [x] Extended [model_settings schema](https://github.com/OasisLMF/OasisLMF/blob/feature/ord-integration/oasislmf/schema/model_settings.json#L130-L171) with  `valid_output_metrics`
- [x] Update [analysis_settings schema](https://github.com/OasisLMF/OasisLMF/blob/feature/ord-integration/oasislmf/schema/analysis_settings.json#L122-L224) with ord options
- [x] Aligned ktools version tag with new ktools release 
- [x] Update schema in OasisPlatform 
- [ ] Test ktools in OasisPlatform 
- [x] Test schema validation in OasisPlatform 

### Supported ORD outputs
> **Exceedance Probability Table:** `output/<gul | il |ri>_S<summary_id>_ept.csv`  

> **Per Sample Exceedance Probability Table:**   `output/<gul | il | ri>_S<summary_id>_psept.csv`

### New analysis_settings options

```
    "gul_summaries": [ 
        {   
            "id": 1,
            "ord_output": { 
                "ept_full_uncertainty_aep": true, 
                "ept_full_uncertainty_oep": true, 
                "ept_mean_sample_aep": true, 
                "ept_mean_sample_oep": true, 
                "ept_per_sample_mean_aep": true, 
                "ept_per_sample_mean_oep": true,                                                                                             
                "psept_aep": true, 
                "psept_oep": true, 
                "return_period_file": true
            }   
        }   
    ],  
```
* Using the above will create two files `output/gul_S1_ept.csv`  and `output/gul_S1_psept.csv`.  
* At least one option from `psept_*` or `ept_*` must be set to true for the associated file to be created.  
* Each selected metric will add more data into the linked file type. 


### Unsupported ORD outputs 
The following ORD boolean flags are now part of the `analysis_settings.json` schema, however they are not supported yet. 
```
    "gul_summaries": [ 
        {   
            "id": 1,
            "ord_output": { 
                "elt_sample": true,
                "elt_quantile": true,
                "elt_moment": true,
                "plt_sample": true,
                "plt_quantile": true,
                "plt_moment": true,
                "alt_period": true,

            }   
        }   
    ],  
```
