### PR TITLE
fix for null loss in max deductible case

### DIFF
--- a/oasislmf/pytools/fm/compute.py
+++ b/oasislmf/pytools/fm/compute.py
@@ -29,6 +29,9 @@ def back_allocate(node, children, nodes_array, losses, loss_indexes, loss_i, com
                         use_loss[i] = 1
                         for c in range(node['children'] + 1, node['children'] + len_children + 1):
                             sum_loss[i] += losses[loss_indexes[nodes_array[children[c]]['loss'] + layer]][i]
+                        if sum_loss[i] < float_equal_precision:
+                            proportion[i] = 0
+                            continue
                     proportion[i] = ba_loss[i] / sum_loss[i]
 
             for c in range(node['children'] + 1, node['children'] + len_children + 1):


### PR DESCRIPTION
In the test case that Nasdaq run they have a case that can be simplified like that:
level 1, 4 nodes with deductible 10
level 2, 2 nodes pass through (rule 100)
(1,1) and (1,2) go to (2,1)
(1,3) and (1,4) go to (2,2)
level 3, 1 node max deductible 20
now if the initial loss for the 4 nodes are 10,
the loss out of level 1 is 0
the loss out of level 2 is 0
the loss out of level 3 is 20

when we do the back allocation, we normally take the loss of the subnodes after the profile is apply but if it is 0 we take the loss before the profile is apply.

However in that case it is also 0, so fmcalc back allocate 0 loss and fmpy return nan. For me both results are incorrect as the value of loss is lost in the process and never back allocated

As a quick fix to align fmcalc and fmpy, fmpy will return 0 loss too and we will plan work to perform the correct allocation later.