### PR TITLE
reset loss to 0 after event

### DIFF
--- a/oasislmf/pytools/fm/compute.py
+++ b/oasislmf/pytools/fm/compute.py
@@ -234,6 +234,7 @@ def init_variable(compute_info, len_sample, temp_dir, low_memory):
 
 
 @njit(cache=True)
-def reset_variabe(children, compute_i, computes):
+def reset_variabe(children, compute_i, computes, loss_i, losses):
     computes[:compute_i].fill(0)
+    losses[:loss_i].fill(0)
     children.fill(0)

--- a/oasislmf/pytools/fm/manager.py
+++ b/oasislmf/pytools/fm/manager.py
@@ -66,7 +66,7 @@ def run_synchronous(allocation_rule, static_path, files_in, files_out, low_memor
                                                                fm_profile,
                                                                stepped)
                     compute_i = event_writer.write(event_id, compute_i)
-                    reset_variabe(children, compute_i, computes)
+                    reset_variabe(children, compute_i, computes, loss_i, losses)
     finally:
         if files_in is not None:
             for stream_in in streams_in:


### PR DESCRIPTION
In non step use-cases we overwrite the loss so there is no issue but in the steeped policy we add loss to the previous step so we need to make sure loss are null when the step policies start to be applied.