### PR TITLE
Fix ordering of item_id column for gulsummaryxref

### DIFF
--- a/oasislmf/preparation/summaries.py
+++ b/oasislmf/preparation/summaries.py
@@ -469,6 +469,7 @@ def get_summary_xref_df(map_df, exposure_df, accounts_df, summaries_info_dict, s
         all_cols.update(accounts_df.columns.to_list())
 
     # Extract the summary id index column depending on id_set_index
+    map_df.sort_values(id_set_index, inplace=True)
     ids_set_df = map_df.loc[:, [id_set_index]].rename(columns={'output_id': "output"})
 
     # For each granularity build a set grouping


### PR DESCRIPTION
The issue was introduced in `1.15.2` from  https://github.com/OasisLMF/OasisLMF/pull/774

Before this change, the 'gul' summary groups were created using 'gul_summary_map.csv', but its now using 'fm_summary_map.csv' to include the IL fields.  

The problem happens because the summary group code expects that the column `id_set_index` is sorted before running the grouping, however these are different columns between, **gul**  and **fm** and `fm_summary_map` defaults to sorting by output_id 

**id_set_index columns**
```
gul == item_id
fm == output_id
```



**fm_summary_map**
```
   acc_idx accnumber  agg_id  coverage_id  coverage_type_id  layer_id  loc_id  loc_idx locnumber peril_id polnumber portnumber         tiv  output_id  item_id
0        0      PPT3       1            1                 1         1       1        0      PPT3      WTC      PPT3  T20100_C1  10000000.0          1        1   
1        0      PPT3       3            1                 1         1       1        0      PPT3      WSS      PPT3  T20100_C1  10000000.0          2        3   
2        0      PPT3       2            2                 3         1       1        0      PPT3      WTC      PPT3  T20100_C1  20000000.0          3        2   
3        0      PPT3       4            2                 3         1       1        0      PPT3      WSS      PPT3  T20100_C1  20000000.0          4        4
```

**gul_summary_map**
```
   acc_idx accnumber  agg_id  coverage_id  coverage_type_id  layer_id  loc_id  loc_idx locnumber peril_id polnumber portnumber         tiv  output_id  item_id
0        0      PPT3       1            1                 1         1       1        0      PPT3      WTC      PPT3  T20100_C1  10000000.0          1        1
1        0      PPT3       3            1                 1         1       1        0      PPT3      WSS      PPT3  T20100_C1  10000000.0          2        3
2        0      PPT3       2            2                 3         1       1        0      PPT3      WTC      PPT3  T20100_C1  20000000.0          3        2
3        0      PPT3       4            2                 3         1       1        0      PPT3      WSS      PPT3  T20100_C1  20000000.0          4        4
```