### PR TITLE
Fix/809 update json error handling

### DIFF
--- a/oasislmf/_data/config_compatibility_profile.json
+++ b/oasislmf/_data/config_compatibility_profile.json
@@ -148,5 +148,15 @@
         "from_ver": "1.9.1",
         "deleted": false,
         "updated_to": "test_case_dir"
+    },
+    "oed_locations_csv":{
+        "from_ver": "1.17.0",
+        "deleted": false,
+        "updated_to": "oed_location_csv"
+    },
+    "oed_account_csv":{
+        "from_ver": "1.17.0",
+        "deleted": false,
+        "updated_to": "oed_accounts_csv"
     }
 }

--- a/oasislmf/utils/inputs.py
+++ b/oasislmf/utils/inputs.py
@@ -33,8 +33,8 @@ class InputValues(object):
                 self.config = self.load_config_file()
                 self.config_dir = os.path.dirname(self.config_fp)
                 self.list_unknown_keys()
-            except JSONDecodeError:
-                raise OasisException('Error: The package configuration file is not valid JSON. "{}"'.format(self.config_fp))
+            except JSONDecodeError as e:
+                raise OasisException('Error: Invalid configuration file "{}"'.format(self.config_fp), e)
 
         self.obsolete_keys = set(self.config) & set(self.config_mapping)
         self.list_obsolete_keys()

--- a/oasislmf/utils/inputs.py
+++ b/oasislmf/utils/inputs.py
@@ -48,6 +48,7 @@ class InputValues(object):
         valid_arg_names = set(arg[0] for arg in self.args._get_kwargs())
         config_arg_names = set(self.config.keys())
         unknown_args = config_arg_names - valid_arg_names - set(self.config_mapping.keys())
+
         if unknown_args:
             self.logger.warning('Warning: Unknown options(s) set in MDK config:')
             for k in unknown_args:
@@ -80,7 +81,7 @@ class InputValues(object):
     def load_config_file(self):
         try:
             with io.open(self.config_fp, 'r', encoding='utf-8') as f:
-                return json.load(f)
+                return dict((k.lower(), v) for k, v in json.load(f).items())
         except FileNotFoundError:
             raise OasisException('MDK config. file path {} provided does not exist'.format(self.config_fp))
 

--- a/oasislmf/utils/inputs.py
+++ b/oasislmf/utils/inputs.py
@@ -34,7 +34,7 @@ class InputValues(object):
                 self.config_dir = os.path.dirname(self.config_fp)
                 self.list_unknown_keys()
             except JSONDecodeError as e:
-                raise OasisException('Error: Invalid configuration file "{}"'.format(self.config_fp), e)
+                raise OasisException(f"Configuration file {self.config_fp} is not a valid json file", e)
 
         self.obsolete_keys = set(self.config) & set(self.config_mapping)
         self.list_obsolete_keys()
@@ -81,7 +81,7 @@ class InputValues(object):
     def load_config_file(self):
         try:
             with io.open(self.config_fp, 'r', encoding='utf-8') as f:
-                return dict((k.lower(), v) for k, v in json.load(f).items())
+                return {k.lower(): v for k,v in json.load(f).items()}
         except FileNotFoundError:
             raise OasisException('MDK config. file path {} provided does not exist'.format(self.config_fp))
 


### PR DESCRIPTION
Update the package config file loading `oasislmf.json` to check for errors and report warnings/errors 

## 1. Check for JSON decode errors 

Catch `JSONDecodeError` exception and inform the user
```
$ oasislmf model run --config has_errors_oasislmf.json 
Configuration file /home/sam/repos/models/piwind/has_errors_oasislmf.json is not a valid json file, JSONDecodeError: Expecting ',' delimiter: line 5 column 5 (char 162)
```

## 2. Remove case sensitivity issues 
Remove issues with key name case sensitivity by lower casing keys after loading. This only applies to the keys not the values. 

**JSON input**
```
{
    "ANalysis_settings_json": "analysis_settings.json",
    "LookUP_config_json": "keys_data/PiWind/lookup.json",
    "LOOkup_data_dir": "keys_data/PiWind",
    "MOdel_data_dir": "model_data/PiWind",
    "Model_settings_json": "meta-data/model_settings.json",
    "Oed_locations_csv": "tests/inputs/SourceLocOEDPiWind10.csv",                                                                            
    "OED_account_csv": "tests/inputs/SourceAccOEDPiWind.csv",
    "oed_INFO_csv": "tests/inputs/SourceReinsInfoOEDPiWind.csv",
    "oed_scope_csv": "tests/inputs/SourceReinsScopeOEDPiWind.csv",
    "ktools_alloc_rule_GUL": 1,
}    
```

**Dict() output**
```
ipdb> print(json.dumps(self.load_config_file(), indent=4))
{
    "analysis_settings_json": "analysis_settings.json",
    "lookup_config_json": "keys_data/PiWind/lookup.json",
    "lookup_data_dir": "keys_data/PiWind",
    "model_data_dir": "model_data/PiWind",
    "model_settings_json": "meta-data/model_settings.json",
    "oed_locations_csv": "tests/inputs/SourceLocOEDPiWind10.csv",
    "oed_account_csv": "tests/inputs/SourceAccOEDPiWind.csv",
    "oed_info_csv": "tests/inputs/SourceReinsInfoOEDPiWind.csv",
    "oed_scope_csv": "tests/inputs/SourceReinsScopeOEDPiWind.csv",
    "ktools_alloc_rule_gul": 1
}
```


## 3. Add warnings for unknown keys
Print warnings when an unrecognized options are found in `oasislmf.json`

**JSON input**
```
{
    ...
    "ktools_alloc_rule_gul": 1,
    "Unknown_key_1": "foo",
    "Unknown_key_2": true,
    "ALLOWED_HOSTS": "*"
    "token_key": "not-a-real-key-R5IAXkqs8DCrMGAGy3PI24Zk5MCr0exowdHOo2WR"
}
```

**CLI output**
```
$ oasislmf model run
Warning: Unknown options(s) set in MDK config:
   token_key : not-a-real-key-R5IAXkqs8DCrMGAGy3PI24Zk5MCr0exowdHOo2WR
   allowed_hosts : *
   unknown_key_1 : foo
   unknown_key_2 : True

```

## 4. Update compatibility map for `account` / `locations` confusion  
**JSON input**
```
{
    "oed_locations_csv": "tests/inputs/SourceLocOEDPiWind10.csv",
    "oed_account_csv": "tests/inputs/SourceAccOEDPiWind.csv",
    ...
}
```


**CLI output**
```
$ oasislmf model run
Deprecated key(s) in MDK config:
   oed_account_csv : {'from_ver': '1.17.0', 'deleted': False, 'updated_to': 'oed_accounts_csv'}
   oed_locations_csv : {'from_ver': '1.17.0', 'deleted': False, 'updated_to': 'oed_location_csv'}

  To fix run: oasislmf config update

Stating oasislmf command - RunModel
RUNNING: oasislmf.manager.interface
  ... etc ...
```