### PR TITLE
Add missing items to data settings

### DIFF
--- a/oasislmf/schema/model_settings.json
+++ b/oasislmf/schema/model_settings.json
@@ -915,7 +915,7 @@
                "type":"string",
                "title":"Keys data version",
                "description":"Version ID of the lookup keys data.",
-               "minLength":1
+               "minLength":0
             },
             "worker_image": {
                "type":"string",
@@ -927,6 +927,18 @@
                "type":"string",
                "title":"Worker image version",
                "description":"The model worker's version ID",
+               "minLength":1
+            },
+            "docs_version": {
+               "type":"string",
+               "title":"Documents version",
+               "description":"Version ID of the model documents",
+               "minLength":1
+            },
+            "test_files_version": {
+               "type":"string",
+               "title":"Test files version",
+               "description":"Version ID of the test files",
                "minLength":1
             },
             "countries":{
@@ -974,6 +986,12 @@
                         "type":"string",
                         "title":"Asset path",
                         "description":"Filesystem path to the asset",
+                        "minLength":1
+                     },
+                     "deploy":{
+                        "type":"string",
+                        "title":"Deployment target",
+                        "description":"Target for deploying this additional asset",
                         "minLength":1
                      }
                   },


### PR DESCRIPTION
* docs_version and test_files_version: as a way to track metadata for model specific documentation and test files versions
* keys_data_version: some model have their keys_data included in model_data, in which case item could be empty
* additional_assets.deploy: needed to target specific deployments (default value for all is "always")