### PR TITLE
Fix/831 log func timestamps

### DIFF
--- a/oasislmf/preparation/summaries.py
+++ b/oasislmf/preparation/summaries.py
@@ -213,6 +213,7 @@ def group_by_oed(oed_col_group, summary_map_df, exposure_df, sort_by, accounts_d
     return summary_ids[0], summary_ids[1], summary_tiv
 
 
+@oasis_log
 def write_summary_levels(exposure_df, accounts_fp, target_dir):
     '''
     Json file with list Available / Recommended columns for use in the summary reporting
@@ -379,7 +380,6 @@ def get_ri_settings(run_dir):
     return get_json(src_fp=os.path.join(run_dir, 'ri_layers.json'))
 
 
-@oasis_log
 def write_df_to_file(df, target_dir, filename):
     """
     Write a generated summary xref dataframe to disk
@@ -410,7 +410,6 @@ def write_df_to_file(df, target_dir, filename):
     return csv_fp
 
 
-@oasis_log
 def get_summary_xref_df(map_df, exposure_df, accounts_df, summaries_info_dict, summaries_type, id_set_index='output_id'):
     """
     Create a Dataframe for either gul / il / ri  based on a section
@@ -664,7 +663,6 @@ def generate_summaryxref_files(model_run_fp, analysis_settings, il=False, ri=Fal
             write_df_to_file(ri_summary_desc[desc_key], os.path.join(model_run_fp, 'output'), desc_key)
 
 
-@oasis_log
 def get_exposure_summary_by_status(df, exposure_summary, peril_id, status):
     """
     Populate dictionary of TIV and number of locations, grouped by peril and
@@ -708,7 +706,6 @@ def get_exposure_summary_by_status(df, exposure_summary, peril_id, status):
 
     return exposure_summary
 
-@oasis_log
 def get_exposure_summary_all(df, exposure_summary, peril_id):
     """
     Populate dictionary of TIV and number of locations, grouped by peril
@@ -795,6 +792,7 @@ def get_exposure_totals(df):
 
 
 
+@oasis_log
 def get_exposure_summary(
     exposure_df,
     keys_df,

--- a/oasislmf/utils/log.py
+++ b/oasislmf/utils/log.py
@@ -85,11 +85,11 @@ def oasis_log(*args, **kwargs):
         def wrapper(*args, **kwargs):
             func_name = func.__name__
             caller_module_name = func.__globals__.get('__name__')
-            
+
             if func_name == '__init__':
                 logger.debug("RUNNING: {}.{}".format(
                     caller_module_name, func_name))
-            else:    
+            else:
                 logger.info("RUNNING: {}.{}".format(
                     caller_module_name, func_name))
 
@@ -110,9 +110,16 @@ def oasis_log(*args, **kwargs):
             start = time.time()
             result = func(*args, **kwargs)
             end = time.time()
-            logger.debug(
-                "COMPLETED: {}.{} in {}s".format(
-                    caller_module_name, func_name, round(end - start, 2)))
+
+            # Only log timestamps on functions which took longer than 10ms
+            if (end-start) > 0.01:
+                logger.info(
+                    "COMPLETED: {}.{} in {}s".format(
+                        caller_module_name, func_name, round(end - start, 2)))
+            else:
+                logger.debug(
+                    "COMPLETED: {}.{} in {}s".format(
+                        caller_module_name, func_name, round(end - start, 2)))
             return result
         return wrapper
 


### PR DESCRIPTION
<!--start_release_notes-->
### Added function timestamps to 'info' log level 
Log execution times If a function takes longer than `0.01 sec` to complete

**Example Output**
```
COMPLETED: oasislmf.execution.bin.csv_to_bin in 0.02s
RUNNING: oasislmf.execution.bin.csv_to_bin
COMPLETED: oasislmf.execution.bin.csv_to_bin in 0.01s
RUNNING: oasislmf.execution.bin.prepare_run_inputs
RUNNING: oasislmf.execution.runner.run
[OK] eve
[OK] getmodel
[OK] gulcalc
[OK] summarycalc
[OK] eltcalc
[OK] aalcalc
[OK] leccalc
Run Completed
Run Completed

COMPLETED: oasislmf.execution.runner.run in 4.25s
```

<!--end_release_notes-->
