### PR TITLE
Fix CVE-2021-33503

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -238,7 +238,7 @@ tqdm==4.60.0
     # via -r ./requirements-package.in
 traitlets==5.0.5
     # via ipython
-urllib3==1.26.4
+urllib3==1.26.5
     # via
     #   requests
     #   responses


### PR DESCRIPTION
Update urllib3 in the requirements file for CVE-2021-33503
https://github.com/OasisLMF/OasisLMF/pull/848 