### PR TITLE
Fix/852 custom lookup relative path

### DIFF
--- a/oasislmf/lookup/builtin.py
+++ b/oasislmf/lookup/builtin.py
@@ -99,7 +99,7 @@ class Lookup(AbstractBasicKeyLookup, MultiprocLookupMixin):
     Built-in Lookup class that implement the OasisLookupInterface
     The aim of this class is to provide a data driven lookup capability that will be both flexible and efficient.
 
-    it provide several generic function factory that can be define in the config under the "mapper" key (ex:)
+    it provide several generic function factory that can be define in the config under the "step_definition" key (ex:)
     "step_definition": {
         "split_loc_perils_covered":{
             "type": "split_loc_perils_covered" ,

--- a/oasislmf/lookup/factory.py
+++ b/oasislmf/lookup/factory.py
@@ -222,8 +222,11 @@ class BasicKeyServer:
         self.lookup_cls = self.get_lookup_cls()
 
     def get_lookup_cls(self):
-        if self.config.get('lookup_module_path'): # custom lookup
-            lookup_module = get_custom_module(self.config.get('lookup_module_path'), 'lookup_module_path')
+        lookup_module_path = self.config.get('lookup_module_path')
+        if lookup_module_path: # custom lookup
+            if not os.path.isabs(lookup_module_path):
+                lookup_module_path = os.path.join(self.config_dir, lookup_module_path)
+            lookup_module = get_custom_module(lookup_module_path, 'lookup_module_path')
             lookup_cls = getattr(lookup_module, '{}KeysLookup'.format(self.config['model']['model_id']))
         else: # built-in lookup
             if self.config.get('builtin_lookup_type') == 'deterministic':

--- a/oasislmf/lookup/factory.py
+++ b/oasislmf/lookup/factory.py
@@ -21,7 +21,7 @@ import pandas as pd
 from ..utils.data import get_json, get_location_df
 from ..utils.exceptions import OasisException
 from ..utils.log import oasis_log
-from ..utils.path import get_custom_module, as_path
+from ..utils.path import import_from_string, get_custom_module, as_path
 from ..utils.status import OASIS_KEYS_STATUS
 
 from .rtree import RTreeLookup, DeterministicLookup
@@ -222,8 +222,15 @@ class BasicKeyServer:
         self.lookup_cls = self.get_lookup_cls()
 
     def get_lookup_cls(self):
-        lookup_module_path = self.config.get('lookup_module_path')
-        if lookup_module_path: # custom lookup
+        if self.config.get('lookup_class'):
+            lookup_cls = import_from_string(self.config.get('lookup_class'))
+
+        elif self.config.get('lookup_module'):
+            lookup_module = import_from_string(self.config.get('lookup_module'))
+            lookup_cls = getattr(lookup_module, '{}KeysLookup'.format(self.config['model']['model_id']))
+
+        elif self.config.get('lookup_module_path'):
+            lookup_module_path = self.config.get('lookup_module_path')
             if not os.path.isabs(lookup_module_path):
                 lookup_module_path = os.path.join(self.config_dir, lookup_module_path)
             lookup_module = get_custom_module(lookup_module_path, 'lookup_module_path')
@@ -231,7 +238,7 @@ class BasicKeyServer:
         else: # built-in lookup
             if self.config.get('builtin_lookup_type') == 'deterministic':
                 lookup_cls = DeterministicLookup
-            elif self.config.get('builtin_lookup_type')  == 'new_lookup':
+            elif self.config.get('builtin_lookup_type') == 'new_lookup':
                 lookup_cls = NewLookup
             else:
                 lookup_cls = RTreeLookup

--- a/oasislmf/utils/path.py
+++ b/oasislmf/utils/path.py
@@ -2,6 +2,7 @@ __all__ = [
     'as_path',
     'empty_dir',
     'PathCleaner',
+    'import_from_string',
     'get_custom_module',
     'setcwd'
 ]
@@ -91,6 +92,26 @@ class PathCleaner(object):
 
     def __call__(self, path):
         return as_path(path, self.label, preexists=self.preexists)
+
+
+def import_from_string(name):
+    """
+    return the object or module from the path given
+    >>> import os.path
+    >>> mod = import_from_string('os.path')
+    >>> os.path is mod
+    True
+
+    >>> from os.path import isabs
+    >>> cls = import_from_string('os.path.isabs')
+    >>> isabs is cls
+    True
+    """
+    components = name.split('.')
+    res = __import__(components[0])
+    for comp in components[1:]:
+        res = getattr(res, comp)
+    return res
 
 
 def get_custom_module(custom_module_path, label):


### PR DESCRIPTION
<!--start_release_notes-->
### Release notes feature title 
1. fix the relative path reference for lookup_module_path from execution path to model config path
2. allow lookup class to be specify using the python environment
using 'lookup_module' will load the module and use the class named f'{self.config['model']['model_id']}KeysLookup'
using 'lookup_class' will load and return the class from the env.
"lookup_class": "jba_fly_oasis.lookup.MySpecialLookup" will do like "from jba_fly_oasis.lookup import MySpecialLookup"

<!--end_release_notes-->

Closes #852 


