### PR TITLE
Feature/fmpy: areaperil_Id 8 bytes support

### DIFF
--- a/oasislmf/pytools/fm/common.py
+++ b/oasislmf/pytools/fm/common.py
@@ -1,3 +1,4 @@
+import os
 import numpy as np
 import numba as nb
 
@@ -5,6 +6,9 @@ allowed_allocation_rule = [0, 1, 2, 3]
 
 np_oasis_int = np.int32
 nb_oasis_int = nb.int32
+
+areaperil_int = os.environ.get('AREAPERIL_TYPE', 'u4')
+
 np_oasis_float = np.float32
 nb_oasis_float = nb.float32
 
@@ -73,7 +77,7 @@ coverages_dtype = np.dtype([('coverage_id', 'i4'), ('tiv', 'f4')])
 
 items_dtype = np.dtype([('item_id', 'i4'),
                         ('coverage_id', 'i4'),
-                        ('areaperil_id', 'i4'),
+                        ('areaperil_id', areaperil_int),
                         ('vulnerability_id', 'i4'),
                         ('group_id', 'i4')])
 


### PR DESCRIPTION
<!--start_release_notes-->
### fmpy: areaperil_id 8 bytes support
allow area peril to be passed as a 8 bytes unsigned int via environment variable AREAPERIL_TYPE as a numpy dtype string
default is 4 bytes
 - export AREAPERIL_TYPE=u8  # for 8 bytes
 - export AREAPERIL_TYPE=u4  # for 4 bytes
<!--end_release_notes-->
