### PR TITLE
Generate Quantile Event Loss Table (QELT) and Quantile Period Loss Table (QPLT)

### DIFF
--- a/oasislmf/execution/bash.py
+++ b/oasislmf/execution/bash.py
@@ -68,12 +68,18 @@ ORD_PLT_OUTPUT_SWITCHES = {
     "plt_sample": {
         'flag': '-S', 'ktools_exe': 'pltcalc', 'table_name': 'splt'
     },
+    "plt_quantile": {
+        'flag': '-Q', 'ktools_exe': 'pltcalc', 'table_name': 'qplt'
+    },
     "plt_moment": {
         'flag': '-M', 'ktools_exe': 'pltcalc', 'table_name': 'mplt'
     }
 }
 
 ORD_ELT_OUTPUT_SWITCHES = {
+    "elt_quantile": {
+        'flag': '-Q', 'ktools_exe': 'eltcalc', 'table_name': 'qelt'
+    },
     "elt_moment": {
         'flag': '-M', 'ktools_exe': 'eltcalc', 'table_name': 'melt'
     }
@@ -90,17 +96,6 @@ OUTPUT_SWITCHES = {
     "elt_ord": ORD_ELT_OUTPUT_SWITCHES,
     "selt_ord": ORD_SELT_OUTPUT_SWITCH
 }
-
-# placeholder warning for upcomming ORD ouputs
-ORD_NOT_IMPLEMENTED = [
-#    "elt_sample",
-    "elt_quantile",
-#    "elt_moment",
-#    "plt_sample",
-    "plt_quantile",
-#    "plt_moment",
-#    "alt_period",
-]
 
 EVE_SHUFFLE_OPTIONS = {
     EVE_NO_SHUFFLE: {'eve': '-n ', 'kat_sorting': False},

--- a/oasislmf/execution/bin.py
+++ b/oasislmf/execution/bin.py
@@ -298,11 +298,17 @@ def prepare_run_inputs(analysis_settings, run_dir, ri=False):
                 _prepare_input_bin(run_dir, 'returnperiods', model_settings)
 
             _prepare_input_bin(run_dir, 'occurrence', model_settings, setting_key='event_occurrence_id', ri=ri)
-        elif _calc_selected(analysis_settings, ['pltcalc', 'aalcalc', 'alt_period', 'elt_moment', 'elt_sample', 'plt_moment', 'plt_sample']):
+        elif _calc_selected(analysis_settings, [
+            'pltcalc', 'aalcalc', 'alt_period', 'elt_moment', 'elt_quantile',
+            'elt_sample', 'plt_moment', 'plt_quantile', 'plt_sample'
+        ]):
             _prepare_input_bin(run_dir, 'occurrence', model_settings, setting_key='event_occurrence_id', ri=ri)
 
         if os.path.exists(os.path.join(run_dir, 'static', 'periods.bin')):
             _prepare_input_bin(run_dir, 'periods', model_settings, ri=ri)
+
+        if os.path.exists(os.path.join(run_dir, 'static', 'quantile.bin')):
+            _prepare_input_bin(run_dir, 'quantile', model_settings, ri=ri)
     except (OSError, IOError) as e:
         raise OasisException("Error preparing the model 'inputs' directory: {}".format(e))
 


### PR DESCRIPTION
<!--start_release_notes-->
### Generate Quantile Event Loss Table (QELT) and Quantile Period Loss Table (QPLT)
The following Open Results Data (ORD) tables can be generated:

| Table Name | analysis_settings file flag |
| :--: | --- |
| Quantile Event Loss Table (QELT) | `elt_quantile` |
| Quantile Period Loss Table (QPLT) | `plt_quantile` |

#### Example analysis_settings
```
    "gul_summaries": [
        {
            "id": 1,
            "ord_output": {
                "plt_quantile": true,
                "elt_quantile": true
            }
        }
    ]
```
<!--end_release_notes-->