### PR TITLE
Fix/936 bash error capture

### DIFF
--- a/oasislmf/execution/bash.py
+++ b/oasislmf/execution/bash.py
@@ -179,7 +179,7 @@ if [ $(bash_logging_supported) == 1 ]; then
     export BASH_XTRACEFD="19"
     set -x
 else
-    echo "WARNING: logging disabled, bash version $BASH_VERSION is not supported."
+    echo "WARNING: logging disabled, bash version '$BASH_VERSION' is not supported, minimum requirement is bash v4.4"
 fi """
 
 

--- a/oasislmf/execution/bash.py
+++ b/oasislmf/execution/bash.py
@@ -964,15 +964,15 @@ def do_kwaits(filename, process_counter):
 
 
 def get_getmodel_itm_cmd(
-        number_of_samples, 
-        gul_threshold, 
+        number_of_samples,
+        gul_threshold,
         use_random_number_file,
-        gul_alloc_rule, 
+        gul_alloc_rule,
         item_output,
-        process_id, 
-        max_process_id, 
-        correlated_output, 
-        eve_shuffle_flag,  
+        process_id,
+        max_process_id,
+        correlated_output,
+        eve_shuffle_flag,
         getmodelpy=False,
         **kwargs):
     """
@@ -1002,14 +1002,14 @@ def get_getmodel_itm_cmd(
 
 
 def get_getmodel_cov_cmd(
-        number_of_samples, 
-        gul_threshold, 
+        number_of_samples,
+        gul_threshold,
         use_random_number_file,
-        coverage_output, 
+        coverage_output,
         item_output,
-        process_id, 
-        max_process_id, 
-        eve_shuffle_flag, 
+        process_id,
+        max_process_id,
+        eve_shuffle_flag,
         getmodelpy=False,
         **kwargs):
     """
@@ -1387,10 +1387,13 @@ def bash_params(
 @contextlib.contextmanager
 def bash_wrapper(filename, bash_trace, stderr_guard):
     # Header
-    print_command(filename, '#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit')
+    print_command(filename, '#!/bin/bash')
     print_command(filename, 'SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")')
     print_command(filename, '')
     print_command(filename, '# --- Script Init ---')
+    print_command(filename, 'set -euET -o pipefail')
+    print_command(filename, 'shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."')
+
     print_command(filename, '')
     print_command(filename, 'mkdir -p log')
     print_command(filename, 'rm -R -f log/*')

--- a/oasislmf/execution/runner.py
+++ b/oasislmf/execution/runner.py
@@ -95,7 +95,7 @@ def run(analysis_settings,
         _get_getmodel_cmd=custom_get_getmodel_cmd,
         **kwargs,
     )
-    bash_trace = subprocess.check_output(['bash', filename])
+    bash_trace = subprocess.check_output(['bash_4', filename])
     logging.info(bash_trace.decode('utf-8'))
 
 

--- a/oasislmf/execution/runner.py
+++ b/oasislmf/execution/runner.py
@@ -95,7 +95,7 @@ def run(analysis_settings,
         _get_getmodel_cmd=custom_get_getmodel_cmd,
         **kwargs,
     )
-    bash_trace = subprocess.check_output(['bash_4', filename])
+    bash_trace = subprocess.check_output(['bash', filename])
     logging.info(bash_trace.decode('utf-8'))
 
 

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_1_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_1_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_20_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_20_partition.1.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_20_partition.10.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_20_partition.11.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_20_partition.12.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_20_partition.13.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_20_partition.14.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_20_partition.15.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_20_partition.16.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_20_partition.17.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_20_partition.18.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_20_partition.19.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_20_partition.2.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_20_partition.3.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_20_partition.4.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_20_partition.5.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_20_partition.6.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_20_partition.7.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_20_partition.8.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_20_partition.9.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_20_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_20_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.1.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.10.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.11.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.12.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.13.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.14.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.15.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.16.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.17.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.18.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.19.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.2.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.20.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.20.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.21.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.21.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.22.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.22.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.23.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.23.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.24.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.24.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.25.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.25.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.26.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.26.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.27.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.27.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.28.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.28.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.29.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.29.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.3.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.30.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.30.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.31.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.31.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.32.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.32.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.33.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.33.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.34.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.34.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.35.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.35.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.36.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.36.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.37.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.37.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.38.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.38.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.39.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.39.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.4.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.5.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.6.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.7.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.8.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.9.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/analysis_settings_1_1_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/analysis_settings_1_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/analysis_settings_1_1_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/analysis_settings_1_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/analysis_settings_1_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/analysis_settings_1_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/analysis_settings_2_1_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/analysis_settings_2_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/analysis_settings_2_1_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/analysis_settings_2_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/analysis_settings_2_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/analysis_settings_2_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/analysis_settings_5_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/analysis_settings_5_1_reins_layer_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_aalcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_aalcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_aalcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_aalcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_aalcalc_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_aalcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_aalcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_aalcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_aalcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_aalcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_aalcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_aalcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_aalcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_aalcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_aalcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_aalcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_aalcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_aalcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_aalcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_aalcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_aalcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_aalcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_aalcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_aalcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_aalcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_aalcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_aalcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_aalcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_aalcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_aalcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_aalcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_aalcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_aalcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_aalcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_aalcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_aalcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_aalcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_aalcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_aalcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_aalcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_aalcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_aalcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_aalcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_aalcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_aalcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_aalcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_aalcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_aalcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_aalcalc_1_output_20_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_aalcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_fu_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_fu_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_fu_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_fu_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_fu_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_fu_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_fu_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_fu_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_fu_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_fu_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_fu_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_fu_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_fu_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_fu_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_fu_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_fu_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_fu_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_fu_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_fu_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_fu_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_fu_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_fu_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_fu_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_ws_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_ws_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_ws_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_ws_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_ws_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_ws_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_ws_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_ws_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_ws_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_ws_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_ws_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_ws_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_ws_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_ws_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_ws_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_ws_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_ws_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_ws_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_ws_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_ws_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_ws_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_ws_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_ws_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_eltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_eltcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_eltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_eltcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_eltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_eltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_eltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_eltcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_eltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_eltcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_eltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_eltcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_eltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_eltcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_eltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_eltcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_eltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_eltcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_eltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_eltcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_eltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_eltcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_eltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_eltcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_eltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_eltcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_eltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_eltcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_eltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_eltcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_eltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_eltcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_eltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_eltcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_eltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_eltcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_eltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_eltcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_eltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_eltcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_eltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_eltcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_eltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_eltcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_eltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_eltcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_eltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_eltcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_eltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_eltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_il_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_il_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_il_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_il_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_il_lec_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_il_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_il_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_il_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_il_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_il_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_il_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_il_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_il_lec_1_output_2_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_il_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_il_lec_2_output_10_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_il_lec_2_output_10_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_il_lec_2_output_10_partition.1.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_il_lec_2_output_10_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_il_lec_2_output_10_partition.2.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_il_lec_2_output_10_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_il_lec_2_output_10_partition.3.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_il_lec_2_output_10_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_il_lec_2_output_10_partition.4.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_il_lec_2_output_10_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_il_lec_2_output_10_partition.5.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_il_lec_2_output_10_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_il_lec_2_output_10_partition.6.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_il_lec_2_output_10_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_il_lec_2_output_10_partition.7.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_il_lec_2_output_10_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_il_lec_2_output_10_partition.8.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_il_lec_2_output_10_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_il_lec_2_output_10_partition.9.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_il_lec_2_output_10_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_il_lec_2_output_10_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_il_lec_2_output_10_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_il_lec_2_output_10_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_il_lec_2_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_il_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_il_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_il_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_il_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_il_lec_2_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_il_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_il_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_il_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_il_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_il_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_il_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_il_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_il_lec_2_output_2_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_il_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_il_no_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_il_no_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_il_no_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_il_no_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_il_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_il_no_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_il_no_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_il_no_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_il_no_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_il_no_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_il_no_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_il_no_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_il_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_il_no_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_il_no_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_il_no_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_il_no_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_il_no_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_il_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_il_no_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_il_no_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_il_no_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_il_no_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_il_no_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_il_no_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_il_no_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_il_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_il_no_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_il_ord_ept_psept_2_output_10_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_il_ord_ept_psept_2_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_il_ord_palt_output_10_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_il_ord_palt_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_il_ord_psept_lec_1_output_10_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_il_ord_psept_lec_1_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_lec_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_lec_1_output_2_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_lec_2_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_lec_2_output_2_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_no_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_no_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_no_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_no_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_no_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_no_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_no_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_no_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_no_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_no_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_no_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_no_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_no_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_no_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_no_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_no_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_no_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_no_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_no_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_no_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_no_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_no_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_no_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_no_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_fu_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_fu_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_fu_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_fu_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_fu_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_fu_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_fu_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_fu_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_fu_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_fu_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_fu_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_fu_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_fu_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_fu_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_fu_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_fu_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_fu_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_fu_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_fu_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_fu_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_fu_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_fu_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_fu_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_ws_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_ws_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_ws_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_ws_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_ws_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_ws_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_ws_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_ws_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_ws_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_ws_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_ws_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_ws_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_ws_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_ws_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_ws_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_ws_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_ws_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_ws_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_ws_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_ws_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_ws_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_ws_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_ws_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_ord_ept_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_ord_ept_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_ord_ept_1_output_20_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_ord_ept_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_ord_ept_psept_lec_2_output_10_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_ord_ept_psept_lec_2_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_ord_palt_output_10_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_ord_palt_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_ord_psept_2_output_10_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_ord_psept_2_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_pltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_pltcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_pltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_pltcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_pltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_pltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_pltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_pltcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_pltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_pltcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_pltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_pltcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_pltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_pltcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_pltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_pltcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_pltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_pltcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_pltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_pltcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_pltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_pltcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_pltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_pltcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_pltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_pltcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_pltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_pltcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_pltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_pltcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_pltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_pltcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_pltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_pltcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_pltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_pltcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_pltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_pltcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_pltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_pltcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_pltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_pltcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_pltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_pltcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_pltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_pltcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_pltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_pltcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_pltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_pltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_summarycalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_summarycalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_summarycalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_summarycalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_summarycalc_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_summarycalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_summarycalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_summarycalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_summarycalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_summarycalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_summarycalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_summarycalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_summarycalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_summarycalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_summarycalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_summarycalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_summarycalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_summarycalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_summarycalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_summarycalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_summarycalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_summarycalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_summarycalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_summarycalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_summarycalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_summarycalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_summarycalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_summarycalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_summarycalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_summarycalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_summarycalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_summarycalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_summarycalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_summarycalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_summarycalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_summarycalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_summarycalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_summarycalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_summarycalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_summarycalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_summarycalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_summarycalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_summarycalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_summarycalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_summarycalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_summarycalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_summarycalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_summarycalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_summarycalc_1_output_20_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_summarycalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_aalcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/il_aalcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_aalcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/il_aalcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_aalcalc_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_aalcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_aalcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/il_aalcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_aalcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/cov_kparse_reference/il_aalcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_aalcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/cov_kparse_reference/il_aalcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_aalcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/cov_kparse_reference/il_aalcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_aalcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/cov_kparse_reference/il_aalcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_aalcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/cov_kparse_reference/il_aalcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_aalcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/cov_kparse_reference/il_aalcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_aalcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/cov_kparse_reference/il_aalcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_aalcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/cov_kparse_reference/il_aalcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_aalcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/cov_kparse_reference/il_aalcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_aalcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/cov_kparse_reference/il_aalcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_aalcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/cov_kparse_reference/il_aalcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_aalcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/cov_kparse_reference/il_aalcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_aalcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/cov_kparse_reference/il_aalcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_aalcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/cov_kparse_reference/il_aalcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_aalcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/cov_kparse_reference/il_aalcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_aalcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/cov_kparse_reference/il_aalcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_aalcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/cov_kparse_reference/il_aalcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_aalcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/cov_kparse_reference/il_aalcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_aalcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/cov_kparse_reference/il_aalcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_aalcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/il_aalcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_aalcalc_1_output_20_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_aalcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_fu_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_fu_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_fu_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_fu_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_fu_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_fu_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_fu_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_fu_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_fu_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_fu_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_fu_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_fu_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_fu_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_fu_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_fu_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_fu_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_fu_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_fu_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_fu_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_fu_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_fu_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_fu_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_fu_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_ws_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_ws_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_ws_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_ws_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_ws_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_ws_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_ws_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_ws_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_ws_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_ws_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_ws_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_ws_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_ws_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_ws_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_ws_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_ws_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_ws_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_ws_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_ws_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_ws_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_ws_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_ws_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_ws_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_eltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/il_eltcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_eltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/il_eltcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_eltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_eltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_eltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/il_eltcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_eltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/cov_kparse_reference/il_eltcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_eltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/cov_kparse_reference/il_eltcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_eltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/cov_kparse_reference/il_eltcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_eltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/cov_kparse_reference/il_eltcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_eltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/cov_kparse_reference/il_eltcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_eltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/cov_kparse_reference/il_eltcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_eltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/cov_kparse_reference/il_eltcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_eltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/cov_kparse_reference/il_eltcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_eltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/cov_kparse_reference/il_eltcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_eltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/cov_kparse_reference/il_eltcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_eltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/cov_kparse_reference/il_eltcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_eltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/cov_kparse_reference/il_eltcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_eltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/cov_kparse_reference/il_eltcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_eltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/cov_kparse_reference/il_eltcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_eltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/cov_kparse_reference/il_eltcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_eltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/cov_kparse_reference/il_eltcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_eltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/cov_kparse_reference/il_eltcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_eltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/cov_kparse_reference/il_eltcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_eltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/cov_kparse_reference/il_eltcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_eltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/il_eltcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_eltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_eltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/il_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/il_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_lec_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/il_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/cov_kparse_reference/il_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/il_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_lec_1_output_2_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/il_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/il_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_lec_2_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/il_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/cov_kparse_reference/il_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/il_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_lec_2_output_2_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_no_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/il_no_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_no_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/il_no_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_no_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_no_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/il_no_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_no_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/cov_kparse_reference/il_no_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_no_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/il_no_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_no_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_no_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/il_no_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_no_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/il_no_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_no_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_no_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/il_no_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_no_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/cov_kparse_reference/il_no_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_no_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/il_no_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_no_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_fu_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_fu_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_fu_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_fu_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_fu_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_fu_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_fu_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_fu_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_fu_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_fu_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_fu_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_fu_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_fu_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_fu_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_fu_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_fu_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_fu_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_fu_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_fu_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_fu_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_fu_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_fu_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_fu_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_ws_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_ws_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_ws_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_ws_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_ws_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_ws_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_ws_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_ws_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_ws_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_ws_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_ws_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_ws_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_ws_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_ws_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_ws_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_ws_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_ws_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_ws_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_ws_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_ws_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_ws_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_ws_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_ws_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_pltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/il_pltcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_pltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/il_pltcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_pltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_pltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_pltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/il_pltcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_pltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/cov_kparse_reference/il_pltcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_pltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/cov_kparse_reference/il_pltcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_pltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/cov_kparse_reference/il_pltcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_pltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/cov_kparse_reference/il_pltcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_pltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/cov_kparse_reference/il_pltcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_pltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/cov_kparse_reference/il_pltcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_pltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/cov_kparse_reference/il_pltcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_pltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/cov_kparse_reference/il_pltcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_pltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/cov_kparse_reference/il_pltcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_pltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/cov_kparse_reference/il_pltcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_pltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/cov_kparse_reference/il_pltcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_pltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/cov_kparse_reference/il_pltcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_pltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/cov_kparse_reference/il_pltcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_pltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/cov_kparse_reference/il_pltcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_pltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/cov_kparse_reference/il_pltcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_pltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/cov_kparse_reference/il_pltcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_pltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/cov_kparse_reference/il_pltcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_pltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/cov_kparse_reference/il_pltcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_pltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/cov_kparse_reference/il_pltcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_pltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/il_pltcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_pltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_pltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_summarycalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/il_summarycalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_summarycalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/il_summarycalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_summarycalc_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_summarycalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_summarycalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/cov_kparse_reference/il_summarycalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_summarycalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/cov_kparse_reference/il_summarycalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_summarycalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/cov_kparse_reference/il_summarycalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_summarycalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/cov_kparse_reference/il_summarycalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_summarycalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/cov_kparse_reference/il_summarycalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_summarycalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/cov_kparse_reference/il_summarycalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_summarycalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/cov_kparse_reference/il_summarycalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_summarycalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/cov_kparse_reference/il_summarycalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_summarycalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/cov_kparse_reference/il_summarycalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_summarycalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/cov_kparse_reference/il_summarycalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_summarycalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/cov_kparse_reference/il_summarycalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_summarycalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/cov_kparse_reference/il_summarycalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_summarycalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/cov_kparse_reference/il_summarycalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_summarycalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/cov_kparse_reference/il_summarycalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_summarycalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/cov_kparse_reference/il_summarycalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_summarycalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/cov_kparse_reference/il_summarycalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_summarycalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/cov_kparse_reference/il_summarycalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_summarycalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/cov_kparse_reference/il_summarycalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_summarycalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/cov_kparse_reference/il_summarycalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_summarycalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/cov_kparse_reference/il_summarycalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_summarycalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/cov_kparse_reference/il_summarycalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_summarycalc_1_output_20_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_summarycalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.20.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.20.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.21.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.21.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.22.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.22.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.23.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.23.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.24.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.24.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.25.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.25.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.26.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.26.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.27.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.27.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.28.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.28.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.29.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.29.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.30.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.30.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.31.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.31.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.32.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.32.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.33.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.33.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.34.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.34.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.35.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.35.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.36.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.36.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.37.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.37.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.38.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.38.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.39.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.39.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/analysis_settings_1_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/analysis_settings_1_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/analysis_settings_1_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/analysis_settings_1_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/analysis_settings_1_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/analysis_settings_1_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/analysis_settings_2_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/analysis_settings_2_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/analysis_settings_2_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/analysis_settings_2_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/analysis_settings_2_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/analysis_settings_2_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/analysis_settings_5_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/analysis_settings_5_1_reins_layer_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_1_output_2_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_2_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_ord_ept_psept_2_output_10_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_ord_ept_psept_2_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_ord_palt_output_10_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_ord_palt_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_ord_psept_lec_1_output_10_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_ord_psept_lec_1_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/gul_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/gul_lec_1_output_2_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/gul_lec_2_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/gul_lec_2_output_2_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_no_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_no_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_no_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_no_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/gul_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_no_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_no_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_no_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_no_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_no_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_no_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_no_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/gul_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_no_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_no_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_no_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_no_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_no_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/gul_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_no_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_no_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_no_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_no_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_no_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_no_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_no_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/gul_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_no_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_ord_ept_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_ord_ept_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_ord_ept_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_ord_ept_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_ord_ept_psept_lec_2_output_10_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_ord_ept_psept_lec_2_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_ord_palt_output_10_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_ord_palt_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_ord_psept_2_output_10_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_ord_psept_2_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/il_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/il_lec_1_output_2_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/il_lec_2_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/il_lec_2_output_2_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_no_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_no_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_no_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_no_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/il_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_no_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_no_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_no_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_no_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_no_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_no_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_no_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/il_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_no_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_no_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_no_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_no_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_no_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/il_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_no_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_no_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_no_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_no_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_no_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_no_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_no_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/il_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_no_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.20.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.20.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.21.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.21.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.22.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.22.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.23.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.23.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.24.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.24.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.25.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.25.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.26.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.26.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.27.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.27.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.28.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.28.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.29.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.29.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.30.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.30.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.31.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.31.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.32.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.32.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.33.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.33.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.34.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.34.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.35.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.35.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.36.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.36.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.37.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.37.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.38.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.38.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.39.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.39.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/analysis_settings_1_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/analysis_settings_1_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/analysis_settings_1_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/analysis_settings_1_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/analysis_settings_1_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/analysis_settings_1_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/analysis_settings_2_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/analysis_settings_2_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/analysis_settings_2_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/analysis_settings_2_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/analysis_settings_2_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/analysis_settings_2_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/analysis_settings_5_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/analysis_settings_5_1_reins_layer_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_1_output_2_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_2_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_il_no_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_no_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_il_no_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_no_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/gul_il_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_no_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_il_no_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_no_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_il_no_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_no_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_il_no_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_no_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/gul_il_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_no_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_il_no_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_no_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_il_no_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_no_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/gul_il_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_no_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_il_no_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_no_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_il_no_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_no_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_il_no_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_no_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/gul_il_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_no_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_il_ord_ept_psept_2_output_10_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_ord_ept_psept_2_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_il_ord_palt_output_10_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_ord_palt_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_il_ord_psept_lec_1_output_10_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_ord_psept_lec_1_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/gul_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/gul_lec_1_output_2_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/gul_lec_2_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/gul_lec_2_output_2_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_no_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_no_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_no_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_no_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/gul_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_no_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_no_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_no_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_no_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_no_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_no_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_no_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/gul_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_no_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_no_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_no_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_no_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_no_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/gul_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_no_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_no_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_no_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_no_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_no_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_no_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_no_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/gul_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_no_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_ord_ept_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_ord_ept_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_ord_ept_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_ord_ept_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_ord_ept_psept_lec_2_output_10_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_ord_ept_psept_lec_2_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_ord_palt_output_10_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_ord_palt_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_ord_psept_2_output_10_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_ord_psept_2_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/il_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/il_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/il_lec_1_output_2_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/il_lec_2_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/il_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/il_lec_2_output_2_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_no_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_no_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_no_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_no_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/il_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_no_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_no_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_no_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_no_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/il_no_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_no_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_no_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/il_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_no_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_no_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_no_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_no_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_no_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/il_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_no_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_no_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_no_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_no_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/il_no_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_no_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_no_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/il_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_no_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*
@@ -14,23 +16,25 @@ exit_handler(){
    exit_code=$?
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
+       # Error - run process clean up
        echo 'Ktools Run Error - exitcode='$exit_code
-   else
-       echo 'Run Completed'
-   fi
 
-   set +x
-   group_pid=$(ps -p $$ -o pgid --no-headers)
-   sess_pid=$(ps -p $$ -o sess --no-headers)
-   script_pid=$$
-   printf "Script PID:%d, GPID:%s, SPID:%d
+       set +x
+       group_pid=$(ps -p $$ -o pgid --no-headers)
+       sess_pid=$(ps -p $$ -o sess --no-headers)
+       script_pid=$$
+       printf "Script PID:%d, GPID:%s, SPID:%d
 " $script_pid $group_pid $sess_pid >> log/killout.txt
 
-   ps -jf f -g $sess_pid > log/subprocess_list
-   PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
-   echo "$PIDS_KILL" >> log/killout.txt
-   kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
-   exit $exit_code
+       ps -jf f -g $sess_pid > log/subprocess_list
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *\\.sh$ | sort -n -r)
+       echo "$PIDS_KILL" >> log/killout.txt
+       kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
+       exit $exit_code
+   else
+       # script successful
+       exit 0
+   fi
 }
 trap exit_handler QUIT HUP INT KILL TERM ERR EXIT
 
@@ -50,6 +54,8 @@ check_complete(){
     done
     if [ "$has_error" -ne 0 ]; then
         false # raise non-zero exit code
+    else
+        echo 'Run Completed'
     fi
 }
 # --- Setup run dirs ---

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_20_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_20_partition.1.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_20_partition.10.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_20_partition.11.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_20_partition.12.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_20_partition.13.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_20_partition.14.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_20_partition.15.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_20_partition.16.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_20_partition.17.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_20_partition.18.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_20_partition.19.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_20_partition.2.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_20_partition.3.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_20_partition.4.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_20_partition.5.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_20_partition.6.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_20_partition.7.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_20_partition.8.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_20_partition.9.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_20_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.1.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.10.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.11.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.12.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.13.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.14.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.15.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.16.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.17.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.18.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.19.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.2.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.20.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.20.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.21.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.21.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.22.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.22.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.23.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.23.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.24.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.24.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.25.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.25.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.26.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.26.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.27.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.27.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.28.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.28.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.29.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.29.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.3.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.30.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.30.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.31.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.31.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.32.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.32.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.33.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.33.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.34.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.34.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.35.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.35.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.36.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.36.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.37.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.37.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.38.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.38.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.39.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.39.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.4.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.5.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.6.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.7.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.8.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.9.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.sh
+++ b/tests/model_execution/eve_kparse_output/all_calcs_1_output_40_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/analysis_settings_1_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/analysis_settings_1_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/analysis_settings_1_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/analysis_settings_1_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/analysis_settings_1_1_partition.sh
+++ b/tests/model_execution/eve_kparse_output/analysis_settings_1_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/analysis_settings_2_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/analysis_settings_2_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/analysis_settings_2_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/analysis_settings_2_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/analysis_settings_2_1_partition.sh
+++ b/tests/model_execution/eve_kparse_output/analysis_settings_2_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/analysis_settings_3_1_reins_layer_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/analysis_settings_3_1_reins_layer_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/analysis_settings_3_1_reins_layer_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/analysis_settings_3_1_reins_layer_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/analysis_settings_3_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/eve_kparse_output/analysis_settings_3_1_reins_layer_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/analysis_settings_4_1_reins_layer_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/analysis_settings_4_1_reins_layer_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/analysis_settings_4_1_reins_layer_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/analysis_settings_4_1_reins_layer_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/analysis_settings_4_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/eve_kparse_output/analysis_settings_4_1_reins_layer_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/analysis_settings_5_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/eve_kparse_output/analysis_settings_5_1_reins_layer_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_aalcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/gul_aalcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_aalcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/gul_aalcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_aalcalc_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_output/gul_aalcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_aalcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/gul_aalcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_aalcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/eve_kparse_output/gul_aalcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_aalcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/eve_kparse_output/gul_aalcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_aalcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/eve_kparse_output/gul_aalcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_aalcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/eve_kparse_output/gul_aalcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_aalcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/eve_kparse_output/gul_aalcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_aalcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/eve_kparse_output/gul_aalcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_aalcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/eve_kparse_output/gul_aalcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_aalcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/eve_kparse_output/gul_aalcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_aalcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/eve_kparse_output/gul_aalcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_aalcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/eve_kparse_output/gul_aalcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_aalcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/eve_kparse_output/gul_aalcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_aalcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/eve_kparse_output/gul_aalcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_aalcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/eve_kparse_output/gul_aalcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_aalcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/eve_kparse_output/gul_aalcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_aalcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/eve_kparse_output/gul_aalcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_aalcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/eve_kparse_output/gul_aalcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_aalcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/eve_kparse_output/gul_aalcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_aalcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/eve_kparse_output/gul_aalcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_aalcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/eve_kparse_output/gul_aalcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_aalcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/gul_aalcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_aalcalc_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_output/gul_aalcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_fu_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_fu_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_fu_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_fu_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_fu_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_fu_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_fu_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_fu_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_fu_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_fu_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_fu_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_fu_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_fu_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_fu_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_fu_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_fu_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_fu_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_fu_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_fu_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_fu_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_fu_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_fu_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_fu_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_ws_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_ws_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_ws_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_ws_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_ws_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_ws_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_ws_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_ws_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_ws_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_ws_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_ws_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_ws_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_ws_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_ws_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_ws_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_ws_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_ws_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_ws_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_ws_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_ws_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_ws_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_ws_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_ws_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_ws_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_ws_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_ws_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_ws_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_ws_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_ws_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_ws_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_ws_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_ws_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_ws_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_ws_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_ws_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_ws_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_ws_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_ws_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_ws_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_ws_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_ws_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_ws_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_ws_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_ws_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_ws_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_ws_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_agg_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_output/gul_agg_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_eltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/gul_eltcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_eltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/gul_eltcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_eltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_output/gul_eltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_eltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/gul_eltcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_eltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/eve_kparse_output/gul_eltcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_eltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/eve_kparse_output/gul_eltcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_eltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/eve_kparse_output/gul_eltcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_eltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/eve_kparse_output/gul_eltcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_eltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/eve_kparse_output/gul_eltcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_eltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/eve_kparse_output/gul_eltcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_eltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/eve_kparse_output/gul_eltcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_eltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/eve_kparse_output/gul_eltcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_eltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/eve_kparse_output/gul_eltcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_eltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/eve_kparse_output/gul_eltcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_eltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/eve_kparse_output/gul_eltcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_eltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/eve_kparse_output/gul_eltcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_eltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/eve_kparse_output/gul_eltcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_eltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/eve_kparse_output/gul_eltcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_eltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/eve_kparse_output/gul_eltcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_eltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/eve_kparse_output/gul_eltcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_eltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/eve_kparse_output/gul_eltcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_eltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/eve_kparse_output/gul_eltcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_eltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/eve_kparse_output/gul_eltcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_eltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/gul_eltcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_eltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_output/gul_eltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_il_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/gul_il_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_il_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/gul_il_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_il_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_output/gul_il_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_il_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/gul_il_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_il_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/eve_kparse_output/gul_il_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_il_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/gul_il_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_il_lec_1_output_2_partition.sh
+++ b/tests/model_execution/eve_kparse_output/gul_il_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_il_lec_2_output_10_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/gul_il_lec_2_output_10_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_il_lec_2_output_10_partition.1.sh
+++ b/tests/model_execution/eve_kparse_output/gul_il_lec_2_output_10_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_il_lec_2_output_10_partition.2.sh
+++ b/tests/model_execution/eve_kparse_output/gul_il_lec_2_output_10_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_il_lec_2_output_10_partition.3.sh
+++ b/tests/model_execution/eve_kparse_output/gul_il_lec_2_output_10_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_il_lec_2_output_10_partition.4.sh
+++ b/tests/model_execution/eve_kparse_output/gul_il_lec_2_output_10_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_il_lec_2_output_10_partition.5.sh
+++ b/tests/model_execution/eve_kparse_output/gul_il_lec_2_output_10_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_il_lec_2_output_10_partition.6.sh
+++ b/tests/model_execution/eve_kparse_output/gul_il_lec_2_output_10_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_il_lec_2_output_10_partition.7.sh
+++ b/tests/model_execution/eve_kparse_output/gul_il_lec_2_output_10_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_il_lec_2_output_10_partition.8.sh
+++ b/tests/model_execution/eve_kparse_output/gul_il_lec_2_output_10_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_il_lec_2_output_10_partition.9.sh
+++ b/tests/model_execution/eve_kparse_output/gul_il_lec_2_output_10_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_il_lec_2_output_10_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/gul_il_lec_2_output_10_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_il_lec_2_output_10_partition.sh
+++ b/tests/model_execution/eve_kparse_output/gul_il_lec_2_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_il_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/gul_il_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_il_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/gul_il_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_il_lec_2_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_output/gul_il_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_il_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/gul_il_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_il_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/eve_kparse_output/gul_il_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_il_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/gul_il_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_il_lec_2_output_2_partition.sh
+++ b/tests/model_execution/eve_kparse_output/gul_il_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_il_no_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/gul_il_no_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_il_no_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/gul_il_no_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_il_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_output/gul_il_no_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_il_no_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/gul_il_no_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_il_no_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/eve_kparse_output/gul_il_no_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_il_no_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/gul_il_no_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_il_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/eve_kparse_output/gul_il_no_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_il_no_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/gul_il_no_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_il_no_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/gul_il_no_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_il_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_output/gul_il_no_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_il_no_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/gul_il_no_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_il_no_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/eve_kparse_output/gul_il_no_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_il_no_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/gul_il_no_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_il_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/eve_kparse_output/gul_il_no_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_il_ord_ept_psept_2_output_10_partition.sh
+++ b/tests/model_execution/eve_kparse_output/gul_il_ord_ept_psept_2_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_il_ord_psept_lec_1_output_10_partition.sh
+++ b/tests/model_execution/eve_kparse_output/gul_il_ord_psept_lec_1_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/gul_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/gul_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_output/gul_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/gul_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/eve_kparse_output/gul_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/gul_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_lec_1_output_2_partition.sh
+++ b/tests/model_execution/eve_kparse_output/gul_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/gul_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/gul_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_lec_2_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_output/gul_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/gul_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/eve_kparse_output/gul_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/gul_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_lec_2_output_2_partition.sh
+++ b/tests/model_execution/eve_kparse_output/gul_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_no_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/gul_no_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_no_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/gul_no_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_output/gul_no_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_no_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/gul_no_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_no_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/eve_kparse_output/gul_no_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_no_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/gul_no_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/eve_kparse_output/gul_no_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_no_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/gul_no_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_no_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/gul_no_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_output/gul_no_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_no_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/gul_no_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_no_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/eve_kparse_output/gul_no_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_no_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/gul_no_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/eve_kparse_output/gul_no_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_fu_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_fu_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_fu_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_fu_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_fu_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_fu_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_fu_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_fu_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_fu_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_fu_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_fu_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_fu_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_fu_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_fu_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_fu_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_fu_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_fu_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_fu_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_fu_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_fu_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_fu_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_fu_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_fu_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_ws_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_ws_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_ws_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_ws_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_ws_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_ws_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_ws_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_ws_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_ws_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_ws_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_ws_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_ws_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_ws_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_ws_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_ws_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_ws_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_ws_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_ws_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_ws_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_ws_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_ws_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_ws_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_ws_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_ws_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_ws_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_ws_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_ws_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_ws_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_ws_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_ws_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_ws_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_ws_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_ws_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_ws_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_ws_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_ws_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_ws_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_ws_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_ws_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_ws_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_ws_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_ws_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_ws_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_ws_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_ws_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_ws_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_occ_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_output/gul_occ_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_ord_ept_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_output/gul_ord_ept_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_ord_ept_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_output/gul_ord_ept_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_ord_ept_psept_lec_2_output_10_partition.sh
+++ b/tests/model_execution/eve_kparse_output/gul_ord_ept_psept_lec_2_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_ord_psept_2_output_10_partition.sh
+++ b/tests/model_execution/eve_kparse_output/gul_ord_psept_2_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_pltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/gul_pltcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_pltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/gul_pltcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_pltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_output/gul_pltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_pltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/gul_pltcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_pltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/eve_kparse_output/gul_pltcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_pltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/eve_kparse_output/gul_pltcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_pltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/eve_kparse_output/gul_pltcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_pltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/eve_kparse_output/gul_pltcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_pltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/eve_kparse_output/gul_pltcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_pltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/eve_kparse_output/gul_pltcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_pltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/eve_kparse_output/gul_pltcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_pltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/eve_kparse_output/gul_pltcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_pltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/eve_kparse_output/gul_pltcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_pltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/eve_kparse_output/gul_pltcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_pltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/eve_kparse_output/gul_pltcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_pltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/eve_kparse_output/gul_pltcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_pltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/eve_kparse_output/gul_pltcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_pltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/eve_kparse_output/gul_pltcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_pltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/eve_kparse_output/gul_pltcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_pltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/eve_kparse_output/gul_pltcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_pltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/eve_kparse_output/gul_pltcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_pltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/eve_kparse_output/gul_pltcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_pltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/eve_kparse_output/gul_pltcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_pltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/gul_pltcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_pltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_output/gul_pltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_summarycalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/gul_summarycalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_summarycalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/gul_summarycalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_summarycalc_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_output/gul_summarycalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_summarycalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/gul_summarycalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_summarycalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/eve_kparse_output/gul_summarycalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_summarycalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/eve_kparse_output/gul_summarycalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_summarycalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/eve_kparse_output/gul_summarycalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_summarycalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/eve_kparse_output/gul_summarycalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_summarycalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/eve_kparse_output/gul_summarycalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_summarycalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/eve_kparse_output/gul_summarycalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_summarycalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/eve_kparse_output/gul_summarycalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_summarycalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/eve_kparse_output/gul_summarycalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_summarycalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/eve_kparse_output/gul_summarycalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_summarycalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/eve_kparse_output/gul_summarycalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_summarycalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/eve_kparse_output/gul_summarycalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_summarycalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/eve_kparse_output/gul_summarycalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_summarycalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/eve_kparse_output/gul_summarycalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_summarycalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/eve_kparse_output/gul_summarycalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_summarycalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/eve_kparse_output/gul_summarycalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_summarycalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/eve_kparse_output/gul_summarycalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_summarycalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/eve_kparse_output/gul_summarycalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_summarycalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/eve_kparse_output/gul_summarycalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_summarycalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/eve_kparse_output/gul_summarycalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_summarycalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/gul_summarycalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/gul_summarycalc_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_output/gul_summarycalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_aalcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/il_aalcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_aalcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/il_aalcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_aalcalc_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_output/il_aalcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_aalcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/il_aalcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_aalcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/eve_kparse_output/il_aalcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_aalcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/eve_kparse_output/il_aalcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_aalcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/eve_kparse_output/il_aalcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_aalcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/eve_kparse_output/il_aalcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_aalcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/eve_kparse_output/il_aalcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_aalcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/eve_kparse_output/il_aalcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_aalcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/eve_kparse_output/il_aalcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_aalcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/eve_kparse_output/il_aalcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_aalcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/eve_kparse_output/il_aalcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_aalcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/eve_kparse_output/il_aalcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_aalcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/eve_kparse_output/il_aalcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_aalcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/eve_kparse_output/il_aalcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_aalcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/eve_kparse_output/il_aalcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_aalcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/eve_kparse_output/il_aalcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_aalcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/eve_kparse_output/il_aalcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_aalcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/eve_kparse_output/il_aalcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_aalcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/eve_kparse_output/il_aalcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_aalcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/eve_kparse_output/il_aalcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_aalcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/eve_kparse_output/il_aalcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_aalcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/il_aalcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_aalcalc_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_output/il_aalcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_fu_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_fu_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_fu_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_fu_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_fu_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_fu_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_fu_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_fu_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_fu_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_fu_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_fu_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_fu_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_fu_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_fu_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_fu_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_fu_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_fu_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_fu_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_fu_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_fu_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_fu_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_fu_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_fu_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_sample_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_sample_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_sample_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_sample_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_sample_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_sample_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_sample_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_sample_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_sample_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_sample_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_sample_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_sample_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_sample_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_sample_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_sample_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_sample_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_sample_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_sample_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_sample_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_sample_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_sample_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_sample_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_sample_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_sample_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_sample_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_sample_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_sample_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_sample_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_sample_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_sample_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_sample_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_sample_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_sample_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_sample_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_sample_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_sample_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_sample_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_sample_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_sample_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_sample_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_sample_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_sample_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_sample_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_sample_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_sample_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_sample_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_sample_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_sample_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_sample_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_sample_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_ws_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_ws_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_ws_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_ws_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_ws_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_ws_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_ws_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_ws_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_ws_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_ws_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_ws_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_ws_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_ws_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_ws_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_ws_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_ws_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_ws_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_ws_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_ws_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_ws_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_ws_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_ws_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_ws_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_ws_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_ws_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_ws_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_ws_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_ws_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_ws_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_ws_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_ws_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_ws_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_ws_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_ws_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_ws_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_ws_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_ws_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_ws_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_ws_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_ws_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_ws_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_ws_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_ws_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_ws_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_ws_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_ws_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_agg_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_output/il_agg_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_eltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/il_eltcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_eltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/il_eltcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_eltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_output/il_eltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_eltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/il_eltcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_eltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/eve_kparse_output/il_eltcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_eltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/eve_kparse_output/il_eltcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_eltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/eve_kparse_output/il_eltcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_eltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/eve_kparse_output/il_eltcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_eltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/eve_kparse_output/il_eltcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_eltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/eve_kparse_output/il_eltcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_eltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/eve_kparse_output/il_eltcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_eltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/eve_kparse_output/il_eltcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_eltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/eve_kparse_output/il_eltcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_eltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/eve_kparse_output/il_eltcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_eltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/eve_kparse_output/il_eltcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_eltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/eve_kparse_output/il_eltcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_eltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/eve_kparse_output/il_eltcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_eltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/eve_kparse_output/il_eltcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_eltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/eve_kparse_output/il_eltcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_eltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/eve_kparse_output/il_eltcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_eltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/eve_kparse_output/il_eltcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_eltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/eve_kparse_output/il_eltcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_eltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/eve_kparse_output/il_eltcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_eltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/il_eltcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_eltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_output/il_eltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/il_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/il_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_output/il_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/il_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/eve_kparse_output/il_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/il_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_lec_1_output_2_partition.sh
+++ b/tests/model_execution/eve_kparse_output/il_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/il_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/il_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_lec_2_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_output/il_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/il_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/eve_kparse_output/il_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/il_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_lec_2_output_2_partition.sh
+++ b/tests/model_execution/eve_kparse_output/il_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_no_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/il_no_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_no_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/il_no_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_output/il_no_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_no_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/il_no_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_no_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/eve_kparse_output/il_no_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_no_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/il_no_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/eve_kparse_output/il_no_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_no_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/il_no_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_no_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/il_no_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_output/il_no_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_no_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/il_no_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_no_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/eve_kparse_output/il_no_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_no_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/il_no_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/eve_kparse_output/il_no_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_fu_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_fu_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_fu_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_fu_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_fu_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_fu_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_fu_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_fu_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_fu_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_fu_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_fu_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_fu_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_fu_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_fu_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_fu_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_fu_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_fu_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_fu_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_fu_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_fu_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_fu_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_fu_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_fu_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_sample_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_sample_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_sample_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_sample_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_sample_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_sample_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_sample_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_sample_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_sample_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_sample_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_sample_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_sample_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_sample_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_sample_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_sample_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_sample_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_sample_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_sample_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_sample_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_sample_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_sample_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_sample_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_sample_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_sample_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_sample_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_sample_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_sample_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_sample_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_sample_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_sample_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_sample_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_sample_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_sample_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_sample_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_sample_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_sample_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_sample_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_sample_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_sample_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_sample_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_sample_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_sample_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_sample_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_sample_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_sample_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_sample_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_sample_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_sample_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_sample_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_sample_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_ws_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_ws_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_ws_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_ws_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_ws_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_ws_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_ws_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_ws_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_ws_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_ws_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_ws_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_ws_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_ws_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_ws_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_ws_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_ws_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_ws_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_ws_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_ws_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_ws_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_ws_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_ws_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_ws_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_ws_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_ws_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_ws_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_ws_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_ws_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_ws_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_ws_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_ws_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_ws_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_ws_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_ws_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_ws_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_ws_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_ws_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_ws_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_ws_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_ws_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_ws_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_ws_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_ws_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_ws_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_ws_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_ws_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_occ_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_output/il_occ_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_pltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/il_pltcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_pltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/il_pltcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_pltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_output/il_pltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_pltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/il_pltcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_pltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/eve_kparse_output/il_pltcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_pltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/eve_kparse_output/il_pltcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_pltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/eve_kparse_output/il_pltcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_pltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/eve_kparse_output/il_pltcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_pltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/eve_kparse_output/il_pltcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_pltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/eve_kparse_output/il_pltcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_pltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/eve_kparse_output/il_pltcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_pltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/eve_kparse_output/il_pltcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_pltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/eve_kparse_output/il_pltcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_pltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/eve_kparse_output/il_pltcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_pltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/eve_kparse_output/il_pltcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_pltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/eve_kparse_output/il_pltcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_pltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/eve_kparse_output/il_pltcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_pltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/eve_kparse_output/il_pltcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_pltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/eve_kparse_output/il_pltcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_pltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/eve_kparse_output/il_pltcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_pltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/eve_kparse_output/il_pltcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_pltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/eve_kparse_output/il_pltcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_pltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/eve_kparse_output/il_pltcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_pltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/il_pltcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_pltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_output/il_pltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_summarycalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/il_summarycalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_summarycalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/il_summarycalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_summarycalc_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_output/il_summarycalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_summarycalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/eve_kparse_output/il_summarycalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_summarycalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/eve_kparse_output/il_summarycalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_summarycalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/eve_kparse_output/il_summarycalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_summarycalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/eve_kparse_output/il_summarycalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_summarycalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/eve_kparse_output/il_summarycalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_summarycalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/eve_kparse_output/il_summarycalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_summarycalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/eve_kparse_output/il_summarycalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_summarycalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/eve_kparse_output/il_summarycalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_summarycalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/eve_kparse_output/il_summarycalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_summarycalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/eve_kparse_output/il_summarycalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_summarycalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/eve_kparse_output/il_summarycalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_summarycalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/eve_kparse_output/il_summarycalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_summarycalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/eve_kparse_output/il_summarycalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_summarycalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/eve_kparse_output/il_summarycalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_summarycalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/eve_kparse_output/il_summarycalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_summarycalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/eve_kparse_output/il_summarycalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_summarycalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/eve_kparse_output/il_summarycalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_summarycalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/eve_kparse_output/il_summarycalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_summarycalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/eve_kparse_output/il_summarycalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_summarycalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/eve_kparse_output/il_summarycalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_summarycalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/eve_kparse_output/il_summarycalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_output/il_summarycalc_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_output/il_summarycalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_20_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_20_partition.1.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_20_partition.10.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_20_partition.11.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_20_partition.12.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_20_partition.13.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_20_partition.14.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_20_partition.15.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_20_partition.16.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_20_partition.17.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_20_partition.18.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_20_partition.19.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_20_partition.2.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_20_partition.3.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_20_partition.4.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_20_partition.5.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_20_partition.6.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_20_partition.7.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_20_partition.8.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_20_partition.9.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_20_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.1.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.10.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.11.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.12.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.13.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.14.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.15.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.16.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.17.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.18.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.19.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.2.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.20.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.20.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.21.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.21.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.22.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.22.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.23.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.23.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.24.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.24.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.25.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.25.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.26.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.26.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.27.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.27.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.28.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.28.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.29.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.29.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.3.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.30.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.30.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.31.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.31.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.32.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.32.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.33.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.33.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.34.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.34.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.35.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.35.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.36.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.36.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.37.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.37.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.38.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.38.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.39.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.39.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.4.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.5.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.6.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.7.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.8.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.9.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/analysis_settings_1_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/analysis_settings_1_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/analysis_settings_1_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/analysis_settings_1_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/analysis_settings_1_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/analysis_settings_1_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/analysis_settings_2_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/analysis_settings_2_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/analysis_settings_2_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/analysis_settings_2_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/analysis_settings_2_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/analysis_settings_2_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/analysis_settings_5_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/analysis_settings_5_1_reins_layer_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_aalcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_aalcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_aalcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_aalcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_aalcalc_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_aalcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_aalcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_aalcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_aalcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_aalcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_aalcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_aalcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_aalcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_aalcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_aalcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_aalcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_aalcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_aalcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_aalcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_aalcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_aalcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_aalcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_aalcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_aalcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_aalcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_aalcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_aalcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_aalcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_aalcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_aalcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_aalcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_aalcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_aalcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_aalcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_aalcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_aalcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_aalcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_aalcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_aalcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_aalcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_aalcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_aalcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_aalcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_aalcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_aalcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_aalcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_aalcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_aalcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_aalcalc_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_aalcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_fu_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_fu_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_fu_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_fu_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_fu_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_fu_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_fu_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_fu_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_fu_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_fu_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_fu_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_fu_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_fu_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_fu_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_fu_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_fu_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_fu_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_fu_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_fu_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_fu_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_fu_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_fu_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_fu_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_ws_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_ws_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_ws_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_ws_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_ws_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_ws_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_ws_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_ws_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_ws_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_ws_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_ws_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_ws_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_ws_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_ws_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_ws_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_ws_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_ws_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_ws_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_ws_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_ws_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_ws_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_ws_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_ws_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_eltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_eltcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_eltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_eltcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_eltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_eltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_eltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_eltcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_eltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_eltcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_eltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_eltcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_eltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_eltcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_eltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_eltcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_eltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_eltcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_eltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_eltcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_eltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_eltcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_eltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_eltcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_eltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_eltcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_eltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_eltcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_eltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_eltcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_eltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_eltcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_eltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_eltcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_eltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_eltcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_eltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_eltcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_eltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_eltcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_eltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_eltcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_eltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_eltcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_eltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_eltcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_eltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_eltcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_eltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_eltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_il_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_il_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_il_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_il_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_il_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_il_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_il_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_il_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_il_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_il_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_il_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_il_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_il_lec_1_output_2_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_il_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_il_lec_2_output_10_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_il_lec_2_output_10_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_il_lec_2_output_10_partition.1.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_il_lec_2_output_10_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_il_lec_2_output_10_partition.2.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_il_lec_2_output_10_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_il_lec_2_output_10_partition.3.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_il_lec_2_output_10_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_il_lec_2_output_10_partition.4.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_il_lec_2_output_10_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_il_lec_2_output_10_partition.5.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_il_lec_2_output_10_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_il_lec_2_output_10_partition.6.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_il_lec_2_output_10_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_il_lec_2_output_10_partition.7.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_il_lec_2_output_10_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_il_lec_2_output_10_partition.8.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_il_lec_2_output_10_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_il_lec_2_output_10_partition.9.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_il_lec_2_output_10_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_il_lec_2_output_10_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_il_lec_2_output_10_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_il_lec_2_output_10_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_il_lec_2_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_il_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_il_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_il_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_il_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_il_lec_2_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_il_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_il_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_il_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_il_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_il_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_il_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_il_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_il_lec_2_output_2_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_il_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_il_no_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_il_no_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_il_no_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_il_no_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_il_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_il_no_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_il_no_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_il_no_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_il_no_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_il_no_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_il_no_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_il_no_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_il_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_il_no_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_il_no_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_il_no_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_il_no_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_il_no_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_il_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_il_no_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_il_no_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_il_no_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_il_no_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_il_no_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_il_no_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_il_no_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_il_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_il_no_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_il_ord_ept_psept_2_output_10_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_il_ord_ept_psept_2_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_il_ord_palt_output_10_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_il_ord_palt_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_il_ord_psept_lec_1_output_10_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_il_ord_psept_lec_1_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_lec_1_output_2_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_lec_2_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_lec_2_output_2_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_no_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_no_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_no_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_no_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_no_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_no_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_no_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_no_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_no_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_no_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_no_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_no_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_no_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_no_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_no_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_no_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_no_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_no_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_no_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_no_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_no_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_no_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_no_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_no_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_fu_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_fu_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_fu_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_fu_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_fu_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_fu_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_fu_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_fu_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_fu_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_fu_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_fu_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_fu_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_fu_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_fu_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_fu_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_fu_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_fu_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_fu_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_fu_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_fu_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_fu_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_fu_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_fu_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_ws_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_ws_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_ws_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_ws_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_ws_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_ws_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_ws_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_ws_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_ws_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_ws_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_ws_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_ws_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_ws_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_ws_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_ws_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_ws_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_ws_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_ws_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_ws_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_ws_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_ws_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_ws_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_ws_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_ord_ept_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_ord_ept_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_ord_ept_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_ord_ept_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_ord_ept_psept_lec_2_output_10_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_ord_ept_psept_lec_2_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_ord_palt_output_10_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_ord_palt_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_ord_psept_2_output_10_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_ord_psept_2_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_pltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_pltcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_pltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_pltcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_pltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_pltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_pltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_pltcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_pltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_pltcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_pltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_pltcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_pltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_pltcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_pltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_pltcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_pltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_pltcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_pltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_pltcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_pltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_pltcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_pltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_pltcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_pltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_pltcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_pltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_pltcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_pltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_pltcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_pltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_pltcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_pltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_pltcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_pltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_pltcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_pltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_pltcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_pltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_pltcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_pltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_pltcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_pltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_pltcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_pltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_pltcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_pltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_pltcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_pltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_pltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_summarycalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_summarycalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_summarycalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_summarycalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_summarycalc_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_summarycalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_summarycalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_summarycalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_summarycalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_summarycalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_summarycalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_summarycalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_summarycalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_summarycalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_summarycalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_summarycalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_summarycalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_summarycalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_summarycalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_summarycalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_summarycalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_summarycalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_summarycalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_summarycalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_summarycalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_summarycalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_summarycalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_summarycalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_summarycalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_summarycalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_summarycalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_summarycalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_summarycalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_summarycalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_summarycalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_summarycalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_summarycalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_summarycalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_summarycalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_summarycalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_summarycalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_summarycalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_summarycalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_summarycalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_summarycalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_summarycalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_summarycalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_summarycalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_summarycalc_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_summarycalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_aalcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/il_aalcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_aalcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/il_aalcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_aalcalc_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_aalcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_aalcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/il_aalcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_aalcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/eve_kparse_reference/il_aalcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_aalcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/eve_kparse_reference/il_aalcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_aalcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/eve_kparse_reference/il_aalcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_aalcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/eve_kparse_reference/il_aalcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_aalcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/eve_kparse_reference/il_aalcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_aalcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/eve_kparse_reference/il_aalcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_aalcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/eve_kparse_reference/il_aalcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_aalcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/eve_kparse_reference/il_aalcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_aalcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/eve_kparse_reference/il_aalcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_aalcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/eve_kparse_reference/il_aalcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_aalcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/eve_kparse_reference/il_aalcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_aalcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/eve_kparse_reference/il_aalcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_aalcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/eve_kparse_reference/il_aalcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_aalcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/eve_kparse_reference/il_aalcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_aalcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/eve_kparse_reference/il_aalcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_aalcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/eve_kparse_reference/il_aalcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_aalcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/eve_kparse_reference/il_aalcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_aalcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/eve_kparse_reference/il_aalcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_aalcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/eve_kparse_reference/il_aalcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_aalcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/il_aalcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_aalcalc_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_aalcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_fu_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_fu_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_fu_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_fu_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_fu_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_fu_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_fu_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_fu_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_fu_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_fu_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_fu_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_fu_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_fu_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_fu_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_fu_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_fu_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_fu_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_fu_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_fu_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_fu_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_fu_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_fu_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_fu_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_ws_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_ws_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_ws_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_ws_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_ws_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_ws_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_ws_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_ws_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_ws_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_ws_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_ws_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_ws_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_ws_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_ws_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_ws_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_ws_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_ws_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_ws_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_ws_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_ws_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_ws_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_ws_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_ws_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_eltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/il_eltcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_eltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/il_eltcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_eltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_eltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_eltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/il_eltcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_eltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/eve_kparse_reference/il_eltcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_eltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/eve_kparse_reference/il_eltcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_eltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/eve_kparse_reference/il_eltcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_eltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/eve_kparse_reference/il_eltcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_eltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/eve_kparse_reference/il_eltcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_eltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/eve_kparse_reference/il_eltcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_eltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/eve_kparse_reference/il_eltcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_eltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/eve_kparse_reference/il_eltcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_eltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/eve_kparse_reference/il_eltcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_eltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/eve_kparse_reference/il_eltcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_eltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/eve_kparse_reference/il_eltcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_eltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/eve_kparse_reference/il_eltcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_eltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/eve_kparse_reference/il_eltcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_eltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/eve_kparse_reference/il_eltcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_eltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/eve_kparse_reference/il_eltcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_eltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/eve_kparse_reference/il_eltcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_eltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/eve_kparse_reference/il_eltcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_eltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/eve_kparse_reference/il_eltcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_eltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/eve_kparse_reference/il_eltcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_eltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/il_eltcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_eltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_eltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/il_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/il_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/il_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/eve_kparse_reference/il_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/il_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_lec_1_output_2_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/il_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/il_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_lec_2_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/il_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/eve_kparse_reference/il_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/il_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_lec_2_output_2_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_no_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/il_no_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_no_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/il_no_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_no_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_no_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/il_no_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_no_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/eve_kparse_reference/il_no_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_no_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/il_no_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_no_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_no_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/il_no_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_no_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/il_no_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_no_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_no_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/il_no_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_no_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/eve_kparse_reference/il_no_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_no_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/il_no_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_no_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_fu_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_fu_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_fu_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_fu_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_fu_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_fu_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_fu_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_fu_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_fu_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_fu_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_fu_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_fu_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_fu_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_fu_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_fu_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_fu_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_fu_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_fu_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_fu_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_fu_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_fu_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_fu_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_fu_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_ws_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_ws_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_ws_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_ws_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_ws_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_ws_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_ws_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_ws_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_ws_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_ws_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_ws_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_ws_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_ws_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_ws_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_ws_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_ws_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_ws_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_ws_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_ws_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_ws_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_ws_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_ws_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_ws_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_pltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/il_pltcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_pltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/il_pltcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_pltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_pltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_pltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/il_pltcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_pltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/eve_kparse_reference/il_pltcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_pltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/eve_kparse_reference/il_pltcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_pltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/eve_kparse_reference/il_pltcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_pltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/eve_kparse_reference/il_pltcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_pltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/eve_kparse_reference/il_pltcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_pltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/eve_kparse_reference/il_pltcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_pltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/eve_kparse_reference/il_pltcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_pltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/eve_kparse_reference/il_pltcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_pltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/eve_kparse_reference/il_pltcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_pltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/eve_kparse_reference/il_pltcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_pltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/eve_kparse_reference/il_pltcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_pltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/eve_kparse_reference/il_pltcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_pltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/eve_kparse_reference/il_pltcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_pltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/eve_kparse_reference/il_pltcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_pltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/eve_kparse_reference/il_pltcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_pltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/eve_kparse_reference/il_pltcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_pltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/eve_kparse_reference/il_pltcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_pltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/eve_kparse_reference/il_pltcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_pltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/eve_kparse_reference/il_pltcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_pltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/il_pltcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_pltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_pltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_summarycalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/il_summarycalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_summarycalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/il_summarycalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_summarycalc_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_summarycalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_summarycalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/eve_kparse_reference/il_summarycalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_summarycalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/eve_kparse_reference/il_summarycalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_summarycalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/eve_kparse_reference/il_summarycalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_summarycalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/eve_kparse_reference/il_summarycalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_summarycalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/eve_kparse_reference/il_summarycalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_summarycalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/eve_kparse_reference/il_summarycalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_summarycalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/eve_kparse_reference/il_summarycalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_summarycalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/eve_kparse_reference/il_summarycalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_summarycalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/eve_kparse_reference/il_summarycalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_summarycalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/eve_kparse_reference/il_summarycalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_summarycalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/eve_kparse_reference/il_summarycalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_summarycalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/eve_kparse_reference/il_summarycalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_summarycalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/eve_kparse_reference/il_summarycalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_summarycalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/eve_kparse_reference/il_summarycalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_summarycalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/eve_kparse_reference/il_summarycalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_summarycalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/eve_kparse_reference/il_summarycalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_summarycalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/eve_kparse_reference/il_summarycalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_summarycalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/eve_kparse_reference/il_summarycalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_summarycalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/eve_kparse_reference/il_summarycalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_summarycalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/eve_kparse_reference/il_summarycalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_summarycalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/eve_kparse_reference/il_summarycalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_summarycalc_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_summarycalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_20_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_20_partition.1.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_20_partition.10.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_20_partition.11.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_20_partition.12.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_20_partition.13.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_20_partition.14.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_20_partition.15.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_20_partition.16.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_20_partition.17.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_20_partition.18.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_20_partition.19.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_20_partition.2.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_20_partition.3.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_20_partition.4.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_20_partition.5.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_20_partition.6.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_20_partition.7.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_20_partition.8.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_20_partition.9.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_20_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_20_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.1.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.10.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.11.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.12.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.13.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.14.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.15.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.16.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.17.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.18.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.19.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.2.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.20.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.20.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.21.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.21.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.22.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.22.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.23.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.23.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.24.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.24.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.25.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.25.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.26.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.26.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.27.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.27.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.28.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.28.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.29.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.29.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.3.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.30.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.30.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.31.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.31.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.32.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.32.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.33.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.33.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.34.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.34.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.35.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.35.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.36.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.36.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.37.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.37.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.38.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.38.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.39.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.39.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.4.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.5.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.6.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.7.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.8.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.9.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/analysis_settings_1_1_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/analysis_settings_1_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/analysis_settings_1_1_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/analysis_settings_1_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/analysis_settings_1_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/analysis_settings_1_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/analysis_settings_2_1_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/analysis_settings_2_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/analysis_settings_2_1_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/analysis_settings_2_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/analysis_settings_2_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/analysis_settings_2_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/analysis_settings_5_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/analysis_settings_5_1_reins_layer_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_aalcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_aalcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_aalcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_aalcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_aalcalc_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_aalcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_aalcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_aalcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_aalcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_aalcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_aalcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_aalcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_aalcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_aalcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_aalcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_aalcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_aalcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_aalcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_aalcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_aalcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_aalcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_aalcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_aalcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_aalcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_aalcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_aalcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_aalcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_aalcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_aalcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_aalcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_aalcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_aalcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_aalcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_aalcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_aalcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_aalcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_aalcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_aalcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_aalcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_aalcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_aalcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_aalcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_aalcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_aalcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_aalcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_aalcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_aalcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_aalcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_aalcalc_1_output_20_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_aalcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_fu_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_fu_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_eltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_eltcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_eltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_eltcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_eltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_eltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_eltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_eltcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_eltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_eltcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_eltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_eltcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_eltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_eltcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_eltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_eltcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_eltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_eltcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_eltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_eltcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_eltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_eltcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_eltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_eltcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_eltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_eltcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_eltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_eltcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_eltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_eltcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_eltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_eltcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_eltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_eltcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_eltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_eltcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_eltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_eltcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_eltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_eltcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_eltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_eltcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_eltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_eltcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_eltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_eltcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_eltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_eltcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_eltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_eltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_1_output_2_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_2_output_10_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_2_output_10_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_2_output_10_partition.1.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_2_output_10_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_2_output_10_partition.2.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_2_output_10_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_2_output_10_partition.3.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_2_output_10_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_2_output_10_partition.4.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_2_output_10_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_2_output_10_partition.5.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_2_output_10_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_2_output_10_partition.6.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_2_output_10_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_2_output_10_partition.7.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_2_output_10_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_2_output_10_partition.8.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_2_output_10_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_2_output_10_partition.9.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_2_output_10_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_2_output_10_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_2_output_10_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_2_output_10_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_2_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_2_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_2_output_2_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_il_no_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_il_no_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_il_no_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_il_no_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_il_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_il_no_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_il_no_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_il_no_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_il_no_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_il_no_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_il_no_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_il_no_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_il_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_il_no_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_il_no_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_il_no_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_il_no_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_il_no_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_il_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_il_no_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_il_no_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_il_no_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_il_no_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_il_no_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_il_no_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_il_no_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_il_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_il_no_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_il_ord_ept_psept_2_output_10_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_il_ord_ept_psept_2_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_il_ord_palt_output_10_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_il_ord_palt_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_il_ord_psept_lec_1_output_10_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_il_ord_psept_lec_1_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_lec_1_output_2_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_lec_2_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_lec_2_output_2_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_no_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_no_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_no_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_no_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_no_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_no_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_no_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_no_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_no_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_no_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_no_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_no_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_no_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_no_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_no_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_no_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_no_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_no_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_no_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_no_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_no_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_no_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_no_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_no_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_fu_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_fu_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_ord_ept_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_ord_ept_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_ord_ept_1_output_20_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_ord_ept_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_ord_ept_psept_lec_2_output_10_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_ord_ept_psept_lec_2_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_ord_palt_output_10_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_ord_palt_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_ord_psept_2_output_10_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_ord_psept_2_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_pltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_pltcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_pltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_pltcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_pltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_pltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_pltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_pltcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_pltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_pltcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_pltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_pltcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_pltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_pltcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_pltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_pltcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_pltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_pltcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_pltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_pltcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_pltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_pltcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_pltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_pltcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_pltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_pltcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_pltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_pltcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_pltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_pltcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_pltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_pltcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_pltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_pltcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_pltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_pltcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_pltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_pltcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_pltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_pltcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_pltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_pltcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_pltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_pltcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_pltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_pltcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_pltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_pltcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_pltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_pltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_summarycalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_summarycalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_summarycalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_summarycalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_summarycalc_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_summarycalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_summarycalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_summarycalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_summarycalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_summarycalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_summarycalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_summarycalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_summarycalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_summarycalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_summarycalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_summarycalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_summarycalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_summarycalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_summarycalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_summarycalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_summarycalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_summarycalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_summarycalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_summarycalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_summarycalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_summarycalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_summarycalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_summarycalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_summarycalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_summarycalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_summarycalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_summarycalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_summarycalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_summarycalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_summarycalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_summarycalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_summarycalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_summarycalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_summarycalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_summarycalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_summarycalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_summarycalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_summarycalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_summarycalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_summarycalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_summarycalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_summarycalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_summarycalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_summarycalc_1_output_20_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_summarycalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_aalcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_aalcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_aalcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_aalcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_aalcalc_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_aalcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_aalcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_aalcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_aalcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_aalcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_aalcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_aalcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_aalcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_aalcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_aalcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_aalcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_aalcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_aalcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_aalcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_aalcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_aalcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_aalcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_aalcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_aalcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_aalcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_aalcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_aalcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_aalcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_aalcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_aalcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_aalcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_aalcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_aalcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_aalcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_aalcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_aalcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_aalcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_aalcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_aalcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_aalcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_aalcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_aalcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_aalcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_aalcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_aalcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_aalcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_aalcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_aalcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_aalcalc_1_output_20_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_aalcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_fu_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_fu_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_eltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_eltcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_eltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_eltcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_eltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_eltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_eltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_eltcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_eltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_eltcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_eltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_eltcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_eltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_eltcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_eltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_eltcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_eltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_eltcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_eltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_eltcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_eltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_eltcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_eltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_eltcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_eltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_eltcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_eltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_eltcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_eltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_eltcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_eltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_eltcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_eltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_eltcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_eltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_eltcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_eltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_eltcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_eltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_eltcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_eltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_eltcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_eltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_eltcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_eltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_eltcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_eltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_eltcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_eltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_eltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_lec_1_output_2_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_lec_2_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_lec_2_output_2_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_no_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_no_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_no_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_no_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_no_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_no_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_no_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_no_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_no_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_no_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_no_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_no_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_no_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_no_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_no_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_no_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_no_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_no_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_no_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_no_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_no_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_no_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_no_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_no_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_fu_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_fu_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_pltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_pltcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_pltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_pltcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_pltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_pltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_pltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_pltcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_pltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_pltcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_pltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_pltcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_pltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_pltcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_pltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_pltcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_pltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_pltcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_pltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_pltcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_pltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_pltcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_pltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_pltcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_pltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_pltcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_pltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_pltcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_pltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_pltcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_pltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_pltcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_pltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_pltcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_pltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_pltcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_pltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_pltcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_pltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_pltcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_pltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_pltcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_pltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_pltcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_pltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_pltcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_pltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_pltcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_pltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_pltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_summarycalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_summarycalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_summarycalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_summarycalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_summarycalc_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_summarycalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_summarycalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_summarycalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_summarycalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_summarycalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_summarycalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_summarycalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_summarycalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_summarycalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_summarycalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_summarycalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_summarycalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_summarycalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_summarycalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_summarycalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_summarycalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_summarycalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_summarycalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_summarycalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_summarycalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_summarycalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_summarycalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_summarycalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_summarycalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_summarycalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_summarycalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_summarycalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_summarycalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_summarycalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_summarycalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_summarycalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_summarycalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_summarycalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_summarycalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_summarycalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_summarycalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_summarycalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_summarycalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_summarycalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_summarycalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_summarycalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_summarycalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_summarycalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_summarycalc_1_output_20_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_summarycalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_20_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_20_partition.1.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_20_partition.10.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_20_partition.11.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_20_partition.12.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_20_partition.13.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_20_partition.14.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_20_partition.15.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_20_partition.16.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_20_partition.17.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_20_partition.18.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_20_partition.19.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_20_partition.2.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_20_partition.3.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_20_partition.4.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_20_partition.5.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_20_partition.6.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_20_partition.7.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_20_partition.8.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_20_partition.9.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_20_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_20_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.1.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.10.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.11.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.12.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.13.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.14.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.15.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.16.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.17.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.18.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.19.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.2.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.20.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.20.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.21.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.21.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.22.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.22.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.23.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.23.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.24.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.24.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.25.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.25.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.26.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.26.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.27.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.27.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.28.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.28.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.29.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.29.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.3.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.30.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.30.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.31.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.31.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.32.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.32.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.33.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.33.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.34.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.34.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.35.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.35.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.36.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.36.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.37.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.37.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.38.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.38.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.39.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.39.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.4.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.5.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.6.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.7.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.8.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.9.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/analysis_settings_1_1_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/analysis_settings_1_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/analysis_settings_1_1_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/analysis_settings_1_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/analysis_settings_1_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/analysis_settings_1_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/analysis_settings_2_1_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/analysis_settings_2_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/analysis_settings_2_1_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/analysis_settings_2_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/analysis_settings_2_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/analysis_settings_2_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/analysis_settings_5_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/analysis_settings_5_1_reins_layer_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_aalcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_aalcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_aalcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_aalcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_aalcalc_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_aalcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_aalcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_aalcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_aalcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_aalcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_aalcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_aalcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_aalcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_aalcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_aalcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_aalcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_aalcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_aalcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_aalcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_aalcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_aalcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_aalcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_aalcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_aalcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_aalcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_aalcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_aalcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_aalcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_aalcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_aalcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_aalcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_aalcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_aalcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_aalcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_aalcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_aalcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_aalcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_aalcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_aalcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_aalcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_aalcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_aalcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_aalcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_aalcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_aalcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_aalcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_aalcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_aalcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_aalcalc_1_output_20_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_aalcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_fu_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_fu_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_fu_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_fu_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_fu_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_fu_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_fu_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_fu_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_fu_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_fu_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_fu_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_fu_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_fu_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_fu_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_fu_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_fu_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_fu_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_fu_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_fu_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_fu_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_fu_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_fu_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_fu_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_ws_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_ws_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_ws_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_ws_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_ws_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_ws_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_ws_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_ws_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_ws_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_ws_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_ws_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_ws_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_ws_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_ws_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_ws_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_ws_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_ws_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_ws_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_ws_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_ws_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_ws_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_ws_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_ws_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_eltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_eltcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_eltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_eltcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_eltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_eltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_eltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_eltcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_eltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_eltcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_eltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_eltcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_eltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_eltcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_eltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_eltcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_eltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_eltcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_eltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_eltcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_eltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_eltcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_eltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_eltcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_eltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_eltcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_eltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_eltcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_eltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_eltcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_eltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_eltcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_eltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_eltcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_eltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_eltcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_eltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_eltcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_eltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_eltcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_eltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_eltcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_eltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_eltcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_eltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_eltcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_eltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_eltcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_eltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_eltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_il_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_il_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_il_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_il_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_il_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_il_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_il_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_il_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_il_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_il_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_il_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_il_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_il_lec_1_output_2_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_il_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_il_lec_2_output_10_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_il_lec_2_output_10_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_il_lec_2_output_10_partition.1.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_il_lec_2_output_10_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_il_lec_2_output_10_partition.2.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_il_lec_2_output_10_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_il_lec_2_output_10_partition.3.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_il_lec_2_output_10_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_il_lec_2_output_10_partition.4.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_il_lec_2_output_10_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_il_lec_2_output_10_partition.5.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_il_lec_2_output_10_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_il_lec_2_output_10_partition.6.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_il_lec_2_output_10_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_il_lec_2_output_10_partition.7.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_il_lec_2_output_10_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_il_lec_2_output_10_partition.8.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_il_lec_2_output_10_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_il_lec_2_output_10_partition.9.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_il_lec_2_output_10_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_il_lec_2_output_10_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_il_lec_2_output_10_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_il_lec_2_output_10_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_il_lec_2_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_il_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_il_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_il_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_il_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_il_lec_2_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_il_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_il_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_il_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_il_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_il_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_il_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_il_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_il_lec_2_output_2_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_il_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_il_no_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_il_no_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_il_no_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_il_no_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_il_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_il_no_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_il_no_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_il_no_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_il_no_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_il_no_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_il_no_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_il_no_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_il_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_il_no_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_il_no_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_il_no_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_il_no_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_il_no_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_il_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_il_no_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_il_no_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_il_no_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_il_no_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_il_no_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_il_no_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_il_no_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_il_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_il_no_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_il_ord_ept_psept_2_output_10_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_il_ord_ept_psept_2_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_il_ord_palt_output_10_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_il_ord_palt_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_il_ord_psept_lec_1_output_10_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_il_ord_psept_lec_1_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_lec_1_output_2_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_lec_2_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_lec_2_output_2_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_no_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_no_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_no_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_no_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_no_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_no_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_no_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_no_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_no_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_no_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_no_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_no_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_no_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_no_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_no_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_no_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_no_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_no_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_no_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_no_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_no_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_no_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_no_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_no_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_fu_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_fu_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_fu_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_fu_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_fu_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_fu_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_fu_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_fu_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_fu_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_fu_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_fu_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_fu_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_fu_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_fu_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_fu_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_fu_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_fu_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_fu_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_fu_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_fu_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_fu_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_fu_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_fu_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_ws_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_ws_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_ws_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_ws_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_ws_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_ws_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_ws_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_ws_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_ws_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_ws_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_ws_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_ws_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_ws_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_ws_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_ws_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_ws_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_ws_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_ws_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_ws_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_ws_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_ws_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_ws_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_ws_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_ord_ept_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_ord_ept_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_ord_ept_1_output_20_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_ord_ept_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_ord_ept_psept_lec_2_output_10_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_ord_ept_psept_lec_2_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_ord_palt_output_10_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_ord_palt_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_ord_psept_2_output_10_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_ord_psept_2_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_pltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_pltcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_pltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_pltcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_pltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_pltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_pltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_pltcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_pltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_pltcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_pltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_pltcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_pltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_pltcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_pltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_pltcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_pltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_pltcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_pltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_pltcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_pltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_pltcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_pltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_pltcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_pltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_pltcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_pltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_pltcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_pltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_pltcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_pltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_pltcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_pltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_pltcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_pltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_pltcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_pltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_pltcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_pltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_pltcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_pltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_pltcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_pltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_pltcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_pltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_pltcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_pltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_pltcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_pltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_pltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_summarycalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_summarycalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_summarycalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_summarycalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_summarycalc_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_summarycalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_summarycalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_summarycalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_summarycalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_summarycalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_summarycalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_summarycalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_summarycalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_summarycalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_summarycalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_summarycalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_summarycalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_summarycalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_summarycalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_summarycalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_summarycalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_summarycalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_summarycalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_summarycalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_summarycalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_summarycalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_summarycalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_summarycalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_summarycalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_summarycalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_summarycalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_summarycalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_summarycalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_summarycalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_summarycalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_summarycalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_summarycalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_summarycalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_summarycalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_summarycalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_summarycalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_summarycalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_summarycalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_summarycalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_summarycalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_summarycalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_summarycalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_summarycalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_summarycalc_1_output_20_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_summarycalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_aalcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/il_aalcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_aalcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/il_aalcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_aalcalc_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_aalcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_aalcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/il_aalcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_aalcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/itm_kparse_reference/il_aalcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_aalcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/itm_kparse_reference/il_aalcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_aalcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/itm_kparse_reference/il_aalcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_aalcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/itm_kparse_reference/il_aalcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_aalcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/itm_kparse_reference/il_aalcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_aalcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/itm_kparse_reference/il_aalcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_aalcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/itm_kparse_reference/il_aalcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_aalcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/itm_kparse_reference/il_aalcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_aalcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/itm_kparse_reference/il_aalcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_aalcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/itm_kparse_reference/il_aalcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_aalcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/itm_kparse_reference/il_aalcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_aalcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/itm_kparse_reference/il_aalcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_aalcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/itm_kparse_reference/il_aalcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_aalcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/itm_kparse_reference/il_aalcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_aalcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/itm_kparse_reference/il_aalcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_aalcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/itm_kparse_reference/il_aalcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_aalcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/itm_kparse_reference/il_aalcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_aalcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/itm_kparse_reference/il_aalcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_aalcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/itm_kparse_reference/il_aalcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_aalcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/il_aalcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_aalcalc_1_output_20_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_aalcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_fu_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_fu_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_fu_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_fu_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_fu_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_fu_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_fu_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_fu_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_fu_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_fu_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_fu_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_fu_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_fu_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_fu_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_fu_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_fu_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_fu_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_fu_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_fu_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_fu_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_fu_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_fu_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_fu_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_ws_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_ws_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_ws_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_ws_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_ws_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_ws_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_ws_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_ws_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_ws_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_ws_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_ws_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_ws_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_ws_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_ws_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_ws_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_ws_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_ws_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_ws_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_ws_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_ws_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_ws_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_ws_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_ws_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_eltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/il_eltcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_eltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/il_eltcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_eltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_eltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_eltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/il_eltcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_eltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/itm_kparse_reference/il_eltcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_eltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/itm_kparse_reference/il_eltcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_eltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/itm_kparse_reference/il_eltcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_eltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/itm_kparse_reference/il_eltcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_eltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/itm_kparse_reference/il_eltcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_eltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/itm_kparse_reference/il_eltcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_eltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/itm_kparse_reference/il_eltcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_eltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/itm_kparse_reference/il_eltcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_eltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/itm_kparse_reference/il_eltcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_eltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/itm_kparse_reference/il_eltcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_eltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/itm_kparse_reference/il_eltcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_eltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/itm_kparse_reference/il_eltcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_eltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/itm_kparse_reference/il_eltcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_eltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/itm_kparse_reference/il_eltcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_eltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/itm_kparse_reference/il_eltcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_eltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/itm_kparse_reference/il_eltcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_eltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/itm_kparse_reference/il_eltcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_eltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/itm_kparse_reference/il_eltcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_eltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/itm_kparse_reference/il_eltcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_eltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/il_eltcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_eltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_eltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/il_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/il_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/il_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/itm_kparse_reference/il_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/il_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_lec_1_output_2_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/il_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/il_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_lec_2_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/il_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/itm_kparse_reference/il_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/il_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_lec_2_output_2_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_no_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/il_no_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_no_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/il_no_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_no_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_no_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/il_no_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_no_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/itm_kparse_reference/il_no_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_no_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/il_no_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_no_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_no_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/il_no_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_no_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/il_no_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_no_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_no_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/il_no_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_no_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/itm_kparse_reference/il_no_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_no_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/il_no_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_no_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_fu_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_fu_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_fu_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_fu_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_fu_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_fu_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_fu_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_fu_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_fu_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_fu_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_fu_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_fu_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_fu_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_fu_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_fu_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_fu_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_fu_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_fu_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_fu_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_fu_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_fu_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_fu_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_fu_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_ws_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_ws_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_ws_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_ws_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_ws_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_ws_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_ws_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_ws_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_ws_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_ws_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_ws_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_ws_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_ws_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_ws_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_ws_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_ws_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_ws_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_ws_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_ws_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_ws_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_ws_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_ws_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_ws_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_pltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/il_pltcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_pltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/il_pltcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_pltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_pltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_pltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/il_pltcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_pltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/itm_kparse_reference/il_pltcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_pltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/itm_kparse_reference/il_pltcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_pltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/itm_kparse_reference/il_pltcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_pltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/itm_kparse_reference/il_pltcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_pltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/itm_kparse_reference/il_pltcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_pltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/itm_kparse_reference/il_pltcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_pltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/itm_kparse_reference/il_pltcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_pltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/itm_kparse_reference/il_pltcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_pltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/itm_kparse_reference/il_pltcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_pltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/itm_kparse_reference/il_pltcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_pltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/itm_kparse_reference/il_pltcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_pltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/itm_kparse_reference/il_pltcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_pltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/itm_kparse_reference/il_pltcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_pltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/itm_kparse_reference/il_pltcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_pltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/itm_kparse_reference/il_pltcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_pltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/itm_kparse_reference/il_pltcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_pltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/itm_kparse_reference/il_pltcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_pltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/itm_kparse_reference/il_pltcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_pltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/itm_kparse_reference/il_pltcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_pltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/il_pltcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_pltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_pltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_summarycalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/il_summarycalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_summarycalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/il_summarycalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_summarycalc_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_summarycalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_summarycalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/itm_kparse_reference/il_summarycalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_summarycalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/itm_kparse_reference/il_summarycalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_summarycalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/itm_kparse_reference/il_summarycalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_summarycalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/itm_kparse_reference/il_summarycalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_summarycalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/itm_kparse_reference/il_summarycalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_summarycalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/itm_kparse_reference/il_summarycalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_summarycalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/itm_kparse_reference/il_summarycalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_summarycalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/itm_kparse_reference/il_summarycalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_summarycalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/itm_kparse_reference/il_summarycalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_summarycalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/itm_kparse_reference/il_summarycalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_summarycalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/itm_kparse_reference/il_summarycalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_summarycalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/itm_kparse_reference/il_summarycalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_summarycalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/itm_kparse_reference/il_summarycalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_summarycalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/itm_kparse_reference/il_summarycalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_summarycalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/itm_kparse_reference/il_summarycalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_summarycalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/itm_kparse_reference/il_summarycalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_summarycalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/itm_kparse_reference/il_summarycalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_summarycalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/itm_kparse_reference/il_summarycalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_summarycalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/itm_kparse_reference/il_summarycalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_summarycalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/itm_kparse_reference/il_summarycalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_summarycalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/itm_kparse_reference/il_summarycalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_summarycalc_1_output_20_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_summarycalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_1_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_1_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_20_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_20_partition.1.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_20_partition.10.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_20_partition.11.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_20_partition.12.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_20_partition.13.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_20_partition.14.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_20_partition.15.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_20_partition.16.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_20_partition.17.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_20_partition.18.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_20_partition.19.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_20_partition.2.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_20_partition.3.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_20_partition.4.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_20_partition.5.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_20_partition.6.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_20_partition.7.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_20_partition.8.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_20_partition.9.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_20_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_20_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.1.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.10.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.11.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.12.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.13.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.14.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.15.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.16.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.17.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.18.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.19.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.2.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.20.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.20.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.21.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.21.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.22.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.22.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.23.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.23.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.24.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.24.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.25.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.25.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.26.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.26.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.27.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.27.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.28.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.28.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.29.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.29.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.3.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.30.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.30.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.31.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.31.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.32.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.32.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.33.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.33.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.34.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.34.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.35.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.35.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.36.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.36.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.37.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.37.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.38.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.38.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.39.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.39.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.4.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.5.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.6.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.7.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.8.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.9.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/analysis_settings_1_1_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/analysis_settings_1_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/analysis_settings_1_1_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/analysis_settings_1_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/analysis_settings_1_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/analysis_settings_1_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/analysis_settings_2_1_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/analysis_settings_2_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/analysis_settings_2_1_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/analysis_settings_2_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/analysis_settings_2_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/analysis_settings_2_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/analysis_settings_5_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/analysis_settings_5_1_reins_layer_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_aalcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_aalcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_aalcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_aalcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_aalcalc_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_aalcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_aalcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_aalcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_aalcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_aalcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_aalcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_aalcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_aalcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_aalcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_aalcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_aalcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_aalcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_aalcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_aalcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_aalcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_aalcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_aalcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_aalcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_aalcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_aalcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_aalcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_aalcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_aalcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_aalcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_aalcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_aalcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_aalcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_aalcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_aalcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_aalcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_aalcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_aalcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_aalcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_aalcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_aalcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_aalcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_aalcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_aalcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_aalcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_aalcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_aalcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_aalcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_aalcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_aalcalc_1_output_20_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_aalcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_fu_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_fu_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_fu_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_fu_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_fu_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_fu_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_fu_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_fu_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_fu_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_fu_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_fu_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_fu_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_fu_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_fu_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_fu_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_fu_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_fu_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_fu_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_fu_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_fu_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_fu_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_fu_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_fu_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_ws_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_ws_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_ws_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_ws_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_ws_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_ws_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_ws_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_ws_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_ws_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_ws_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_ws_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_ws_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_ws_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_ws_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_ws_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_ws_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_ws_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_ws_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_ws_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_ws_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_ws_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_ws_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_ws_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_eltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_eltcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_eltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_eltcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_eltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_eltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_eltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_eltcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_eltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_eltcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_eltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_eltcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_eltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_eltcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_eltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_eltcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_eltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_eltcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_eltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_eltcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_eltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_eltcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_eltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_eltcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_eltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_eltcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_eltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_eltcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_eltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_eltcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_eltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_eltcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_eltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_eltcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_eltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_eltcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_eltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_eltcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_eltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_eltcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_eltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_eltcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_eltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_eltcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_eltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_eltcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_eltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_eltcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_eltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_eltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_il_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_il_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_il_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_il_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_il_lec_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_il_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_il_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_il_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_il_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_il_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_il_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_il_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_il_lec_1_output_2_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_il_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_il_lec_2_output_10_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_il_lec_2_output_10_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_il_lec_2_output_10_partition.1.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_il_lec_2_output_10_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_il_lec_2_output_10_partition.2.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_il_lec_2_output_10_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_il_lec_2_output_10_partition.3.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_il_lec_2_output_10_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_il_lec_2_output_10_partition.4.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_il_lec_2_output_10_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_il_lec_2_output_10_partition.5.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_il_lec_2_output_10_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_il_lec_2_output_10_partition.6.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_il_lec_2_output_10_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_il_lec_2_output_10_partition.7.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_il_lec_2_output_10_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_il_lec_2_output_10_partition.8.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_il_lec_2_output_10_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_il_lec_2_output_10_partition.9.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_il_lec_2_output_10_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_il_lec_2_output_10_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_il_lec_2_output_10_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_il_lec_2_output_10_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_il_lec_2_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_il_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_il_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_il_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_il_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_il_lec_2_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_il_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_il_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_il_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_il_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_il_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_il_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_il_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_il_lec_2_output_2_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_il_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_il_no_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_il_no_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_il_no_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_il_no_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_il_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_il_no_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_il_no_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_il_no_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_il_no_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_il_no_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_il_no_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_il_no_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_il_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_il_no_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_il_no_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_il_no_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_il_no_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_il_no_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_il_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_il_no_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_il_no_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_il_no_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_il_no_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_il_no_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_il_no_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_il_no_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_il_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_il_no_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_il_ord_ept_psept_2_output_10_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_il_ord_ept_psept_2_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_il_ord_palt_output_10_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_il_ord_palt_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_il_ord_psept_lec_1_output_10_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_il_ord_psept_lec_1_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_lec_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_lec_1_output_2_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_lec_2_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_lec_2_output_2_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_no_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_no_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_no_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_no_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_no_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_no_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_no_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_no_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_no_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_no_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_no_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_no_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_no_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_no_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_no_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_no_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_no_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_no_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_no_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_no_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_no_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_no_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_no_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_no_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_fu_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_fu_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_fu_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_fu_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_fu_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_fu_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_fu_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_fu_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_fu_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_fu_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_fu_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_fu_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_fu_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_fu_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_fu_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_fu_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_fu_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_fu_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_fu_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_fu_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_fu_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_fu_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_fu_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_ws_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_ws_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_ws_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_ws_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_ws_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_ws_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_ws_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_ws_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_ws_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_ws_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_ws_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_ws_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_ws_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_ws_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_ws_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_ws_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_ws_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_ws_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_ws_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_ws_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_ws_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_ws_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_ws_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_ord_ept_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_ord_ept_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_ord_ept_1_output_20_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_ord_ept_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_ord_ept_psept_lec_2_output_10_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_ord_ept_psept_lec_2_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_ord_palt_output_10_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_ord_palt_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_ord_psept_2_output_10_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_ord_psept_2_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_pltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_pltcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_pltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_pltcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_pltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_pltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_pltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_pltcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_pltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_pltcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_pltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_pltcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_pltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_pltcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_pltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_pltcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_pltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_pltcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_pltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_pltcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_pltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_pltcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_pltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_pltcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_pltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_pltcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_pltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_pltcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_pltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_pltcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_pltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_pltcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_pltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_pltcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_pltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_pltcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_pltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_pltcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_pltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_pltcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_pltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_pltcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_pltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_pltcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_pltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_pltcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_pltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_pltcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_pltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_pltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_summarycalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_summarycalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_summarycalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_summarycalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_summarycalc_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_summarycalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_summarycalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_summarycalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_summarycalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_summarycalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_summarycalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_summarycalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_summarycalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_summarycalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_summarycalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_summarycalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_summarycalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_summarycalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_summarycalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_summarycalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_summarycalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_summarycalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_summarycalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_summarycalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_summarycalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_summarycalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_summarycalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_summarycalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_summarycalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_summarycalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_summarycalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_summarycalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_summarycalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_summarycalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_summarycalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_summarycalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_summarycalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_summarycalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_summarycalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_summarycalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_summarycalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_summarycalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_summarycalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_summarycalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_summarycalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_summarycalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_summarycalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_summarycalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_summarycalc_1_output_20_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_summarycalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_aalcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/il_aalcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_aalcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/il_aalcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_aalcalc_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_aalcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_aalcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/il_aalcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_aalcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/lb_kparse_reference/il_aalcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_aalcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/lb_kparse_reference/il_aalcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_aalcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/lb_kparse_reference/il_aalcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_aalcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/lb_kparse_reference/il_aalcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_aalcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/lb_kparse_reference/il_aalcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_aalcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/lb_kparse_reference/il_aalcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_aalcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/lb_kparse_reference/il_aalcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_aalcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/lb_kparse_reference/il_aalcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_aalcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/lb_kparse_reference/il_aalcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_aalcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/lb_kparse_reference/il_aalcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_aalcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/lb_kparse_reference/il_aalcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_aalcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/lb_kparse_reference/il_aalcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_aalcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/lb_kparse_reference/il_aalcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_aalcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/lb_kparse_reference/il_aalcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_aalcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/lb_kparse_reference/il_aalcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_aalcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/lb_kparse_reference/il_aalcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_aalcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/lb_kparse_reference/il_aalcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_aalcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/lb_kparse_reference/il_aalcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_aalcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/lb_kparse_reference/il_aalcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_aalcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/il_aalcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_aalcalc_1_output_20_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_aalcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_fu_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_fu_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_fu_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_fu_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_fu_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_fu_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_fu_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_fu_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_fu_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_fu_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_fu_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_fu_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_fu_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_fu_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_fu_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_fu_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_fu_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_fu_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_fu_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_fu_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_fu_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_fu_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_fu_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_ws_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_ws_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_ws_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_ws_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_ws_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_ws_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_ws_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_ws_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_ws_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_ws_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_ws_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_ws_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_ws_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_ws_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_ws_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_ws_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_ws_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_ws_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_ws_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_ws_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_ws_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_ws_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_ws_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_eltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/il_eltcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_eltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/il_eltcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_eltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_eltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_eltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/il_eltcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_eltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/lb_kparse_reference/il_eltcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_eltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/lb_kparse_reference/il_eltcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_eltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/lb_kparse_reference/il_eltcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_eltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/lb_kparse_reference/il_eltcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_eltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/lb_kparse_reference/il_eltcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_eltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/lb_kparse_reference/il_eltcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_eltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/lb_kparse_reference/il_eltcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_eltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/lb_kparse_reference/il_eltcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_eltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/lb_kparse_reference/il_eltcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_eltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/lb_kparse_reference/il_eltcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_eltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/lb_kparse_reference/il_eltcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_eltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/lb_kparse_reference/il_eltcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_eltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/lb_kparse_reference/il_eltcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_eltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/lb_kparse_reference/il_eltcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_eltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/lb_kparse_reference/il_eltcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_eltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/lb_kparse_reference/il_eltcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_eltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/lb_kparse_reference/il_eltcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_eltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/lb_kparse_reference/il_eltcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_eltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/lb_kparse_reference/il_eltcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_eltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/il_eltcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_eltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_eltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/il_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/il_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_lec_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/il_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/lb_kparse_reference/il_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/il_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_lec_1_output_2_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/il_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/il_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_lec_2_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/il_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/lb_kparse_reference/il_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/il_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_lec_2_output_2_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_no_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/il_no_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_no_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/il_no_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_no_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_no_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/il_no_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_no_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/lb_kparse_reference/il_no_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_no_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/il_no_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_no_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_no_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/il_no_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_no_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/il_no_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_no_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_no_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/il_no_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_no_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/lb_kparse_reference/il_no_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_no_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/il_no_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_no_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_fu_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_fu_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_fu_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_fu_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_fu_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_fu_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_fu_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_fu_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_fu_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_fu_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_fu_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_fu_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_fu_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_fu_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_fu_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_fu_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_fu_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_fu_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_fu_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_fu_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_fu_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_fu_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_fu_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_ws_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_ws_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_ws_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_ws_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_ws_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_ws_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_ws_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_ws_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_ws_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_ws_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_ws_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_ws_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_ws_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_ws_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_ws_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_ws_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_ws_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_ws_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_ws_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_ws_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_ws_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_ws_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_ws_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_pltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/il_pltcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_pltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/il_pltcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_pltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_pltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_pltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/il_pltcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_pltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/lb_kparse_reference/il_pltcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_pltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/lb_kparse_reference/il_pltcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_pltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/lb_kparse_reference/il_pltcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_pltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/lb_kparse_reference/il_pltcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_pltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/lb_kparse_reference/il_pltcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_pltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/lb_kparse_reference/il_pltcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_pltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/lb_kparse_reference/il_pltcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_pltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/lb_kparse_reference/il_pltcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_pltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/lb_kparse_reference/il_pltcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_pltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/lb_kparse_reference/il_pltcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_pltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/lb_kparse_reference/il_pltcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_pltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/lb_kparse_reference/il_pltcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_pltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/lb_kparse_reference/il_pltcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_pltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/lb_kparse_reference/il_pltcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_pltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/lb_kparse_reference/il_pltcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_pltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/lb_kparse_reference/il_pltcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_pltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/lb_kparse_reference/il_pltcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_pltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/lb_kparse_reference/il_pltcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_pltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/lb_kparse_reference/il_pltcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_pltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/il_pltcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_pltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_pltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_summarycalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/il_summarycalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_summarycalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/il_summarycalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_summarycalc_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_summarycalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_summarycalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/lb_kparse_reference/il_summarycalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_summarycalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/lb_kparse_reference/il_summarycalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_summarycalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/lb_kparse_reference/il_summarycalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_summarycalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/lb_kparse_reference/il_summarycalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_summarycalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/lb_kparse_reference/il_summarycalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_summarycalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/lb_kparse_reference/il_summarycalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_summarycalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/lb_kparse_reference/il_summarycalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_summarycalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/lb_kparse_reference/il_summarycalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_summarycalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/lb_kparse_reference/il_summarycalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_summarycalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/lb_kparse_reference/il_summarycalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_summarycalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/lb_kparse_reference/il_summarycalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_summarycalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/lb_kparse_reference/il_summarycalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_summarycalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/lb_kparse_reference/il_summarycalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_summarycalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/lb_kparse_reference/il_summarycalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_summarycalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/lb_kparse_reference/il_summarycalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_summarycalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/lb_kparse_reference/il_summarycalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_summarycalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/lb_kparse_reference/il_summarycalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_summarycalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/lb_kparse_reference/il_summarycalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_summarycalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/lb_kparse_reference/il_summarycalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_summarycalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/lb_kparse_reference/il_summarycalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_summarycalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/lb_kparse_reference/il_summarycalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_summarycalc_1_output_20_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_summarycalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_20_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_20_partition.1.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_20_partition.10.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_20_partition.11.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_20_partition.12.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_20_partition.13.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_20_partition.14.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_20_partition.15.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_20_partition.16.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_20_partition.17.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_20_partition.18.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_20_partition.19.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_20_partition.2.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_20_partition.3.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_20_partition.4.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_20_partition.5.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_20_partition.6.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_20_partition.7.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_20_partition.8.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_20_partition.9.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_20_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.1.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.10.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.11.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.12.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.13.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.14.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.15.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.16.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.17.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.18.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.19.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.2.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.20.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.20.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.21.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.21.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.22.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.22.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.23.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.23.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.24.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.24.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.25.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.25.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.26.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.26.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.27.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.27.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.28.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.28.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.29.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.29.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.3.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.30.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.30.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.31.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.31.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.32.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.32.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.33.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.33.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.34.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.34.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.35.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.35.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.36.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.36.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.37.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.37.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.38.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.38.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.39.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.39.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.4.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.5.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.6.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.7.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.8.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.9.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/analysis_settings_1_1_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/analysis_settings_1_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/analysis_settings_1_1_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/analysis_settings_1_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/analysis_settings_1_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/analysis_settings_1_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/analysis_settings_2_1_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/analysis_settings_2_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/analysis_settings_2_1_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/analysis_settings_2_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/analysis_settings_2_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/analysis_settings_2_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/analysis_settings_5_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/analysis_settings_5_1_reins_layer_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_aalcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_aalcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_aalcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_aalcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_aalcalc_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_aalcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_aalcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_aalcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_aalcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_aalcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_aalcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_aalcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_aalcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_aalcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_aalcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_aalcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_aalcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_aalcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_aalcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_aalcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_aalcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_aalcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_aalcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_aalcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_aalcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_aalcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_aalcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_aalcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_aalcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_aalcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_aalcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_aalcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_aalcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_aalcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_aalcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_aalcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_aalcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_aalcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_aalcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_aalcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_aalcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_aalcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_aalcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_aalcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_aalcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_aalcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_aalcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_aalcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_aalcalc_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_aalcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_fu_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_fu_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_eltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_eltcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_eltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_eltcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_eltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_eltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_eltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_eltcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_eltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_eltcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_eltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_eltcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_eltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_eltcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_eltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_eltcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_eltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_eltcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_eltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_eltcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_eltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_eltcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_eltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_eltcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_eltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_eltcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_eltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_eltcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_eltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_eltcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_eltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_eltcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_eltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_eltcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_eltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_eltcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_eltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_eltcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_eltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_eltcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_eltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_eltcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_eltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_eltcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_eltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_eltcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_eltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_eltcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_eltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_eltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_1_output_2_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_2_output_10_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_2_output_10_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_2_output_10_partition.1.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_2_output_10_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_2_output_10_partition.2.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_2_output_10_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_2_output_10_partition.3.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_2_output_10_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_2_output_10_partition.4.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_2_output_10_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_2_output_10_partition.5.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_2_output_10_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_2_output_10_partition.6.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_2_output_10_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_2_output_10_partition.7.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_2_output_10_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_2_output_10_partition.8.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_2_output_10_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_2_output_10_partition.9.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_2_output_10_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_2_output_10_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_2_output_10_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_2_output_10_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_2_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_2_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_2_output_2_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_il_no_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_il_no_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_il_no_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_il_no_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_il_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_il_no_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_il_no_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_il_no_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_il_no_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_il_no_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_il_no_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_il_no_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_il_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_il_no_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_il_no_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_il_no_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_il_no_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_il_no_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_il_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_il_no_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_il_no_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_il_no_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_il_no_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_il_no_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_il_no_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_il_no_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_il_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_il_no_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_il_ord_ept_psept_2_output_10_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_il_ord_ept_psept_2_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_il_ord_palt_output_10_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_il_ord_palt_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_il_ord_psept_lec_1_output_10_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_il_ord_psept_lec_1_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_lec_1_output_2_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_lec_2_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_lec_2_output_2_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_no_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_no_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_no_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_no_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_no_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_no_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_no_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_no_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_no_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_no_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_no_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_no_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_no_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_no_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_no_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_no_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_no_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_no_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_no_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_no_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_no_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_no_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_no_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_no_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_fu_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_fu_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_ord_ept_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_ord_ept_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_ord_ept_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_ord_ept_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_ord_ept_psept_lec_2_output_10_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_ord_ept_psept_lec_2_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_ord_palt_output_10_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_ord_palt_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_ord_psept_2_output_10_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_ord_psept_2_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_pltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_pltcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_pltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_pltcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_pltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_pltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_pltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_pltcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_pltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_pltcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_pltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_pltcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_pltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_pltcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_pltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_pltcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_pltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_pltcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_pltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_pltcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_pltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_pltcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_pltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_pltcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_pltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_pltcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_pltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_pltcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_pltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_pltcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_pltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_pltcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_pltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_pltcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_pltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_pltcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_pltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_pltcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_pltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_pltcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_pltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_pltcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_pltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_pltcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_pltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_pltcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_pltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_pltcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_pltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_pltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_summarycalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_summarycalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_summarycalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_summarycalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_summarycalc_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_summarycalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_summarycalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_summarycalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_summarycalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_summarycalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_summarycalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_summarycalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_summarycalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_summarycalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_summarycalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_summarycalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_summarycalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_summarycalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_summarycalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_summarycalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_summarycalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_summarycalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_summarycalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_summarycalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_summarycalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_summarycalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_summarycalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_summarycalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_summarycalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_summarycalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_summarycalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_summarycalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_summarycalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_summarycalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_summarycalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_summarycalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_summarycalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_summarycalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_summarycalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_summarycalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_summarycalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_summarycalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_summarycalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_summarycalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_summarycalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_summarycalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_summarycalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_summarycalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_summarycalc_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_summarycalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_aalcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_aalcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_aalcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_aalcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_aalcalc_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_aalcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_aalcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_aalcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_aalcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_aalcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_aalcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_aalcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_aalcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_aalcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_aalcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_aalcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_aalcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_aalcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_aalcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_aalcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_aalcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_aalcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_aalcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_aalcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_aalcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_aalcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_aalcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_aalcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_aalcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_aalcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_aalcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_aalcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_aalcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_aalcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_aalcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_aalcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_aalcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_aalcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_aalcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_aalcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_aalcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_aalcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_aalcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_aalcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_aalcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_aalcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_aalcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_aalcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_aalcalc_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_aalcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_fu_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_fu_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_eltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_eltcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_eltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_eltcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_eltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_eltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_eltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_eltcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_eltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_eltcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_eltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_eltcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_eltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_eltcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_eltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_eltcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_eltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_eltcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_eltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_eltcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_eltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_eltcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_eltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_eltcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_eltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_eltcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_eltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_eltcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_eltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_eltcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_eltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_eltcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_eltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_eltcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_eltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_eltcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_eltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_eltcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_eltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_eltcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_eltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_eltcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_eltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_eltcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_eltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_eltcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_eltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_eltcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_eltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_eltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_lec_1_output_2_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_lec_2_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_lec_2_output_2_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_no_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_no_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_no_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_no_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_no_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_no_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_no_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_no_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_no_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_no_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_no_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_no_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_no_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_no_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_no_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_no_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_no_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_no_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_no_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_no_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_no_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_no_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_no_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_no_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_fu_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_fu_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_pltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_pltcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_pltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_pltcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_pltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_pltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_pltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_pltcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_pltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_pltcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_pltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_pltcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_pltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_pltcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_pltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_pltcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_pltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_pltcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_pltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_pltcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_pltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_pltcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_pltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_pltcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_pltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_pltcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_pltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_pltcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_pltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_pltcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_pltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_pltcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_pltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_pltcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_pltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_pltcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_pltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_pltcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_pltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_pltcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_pltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_pltcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_pltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_pltcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_pltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_pltcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_pltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_pltcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_pltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_pltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_summarycalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_summarycalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_summarycalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_summarycalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_summarycalc_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_summarycalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_summarycalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_summarycalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_summarycalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_summarycalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_summarycalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_summarycalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_summarycalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_summarycalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_summarycalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_summarycalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_summarycalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_summarycalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_summarycalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_summarycalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_summarycalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_summarycalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_summarycalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_summarycalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_summarycalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_summarycalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_summarycalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_summarycalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_summarycalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_summarycalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_summarycalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_summarycalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_summarycalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_summarycalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_summarycalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_summarycalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_summarycalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_summarycalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_summarycalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_summarycalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_summarycalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_summarycalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_summarycalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_summarycalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_summarycalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_summarycalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_summarycalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_summarycalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_summarycalc_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_summarycalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_20_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_20_partition.1.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_20_partition.10.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_20_partition.11.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_20_partition.12.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_20_partition.13.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_20_partition.14.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_20_partition.15.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_20_partition.16.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_20_partition.17.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_20_partition.18.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_20_partition.19.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_20_partition.2.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_20_partition.3.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_20_partition.4.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_20_partition.5.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_20_partition.6.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_20_partition.7.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_20_partition.8.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_20_partition.9.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_20_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.1.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.10.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.11.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.12.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.13.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.14.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.15.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.16.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.17.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.18.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.19.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.2.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.20.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.20.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.21.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.21.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.22.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.22.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.23.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.23.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.24.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.24.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.25.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.25.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.26.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.26.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.27.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.27.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.28.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.28.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.29.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.29.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.3.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.30.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.30.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.31.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.31.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.32.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.32.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.33.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.33.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.34.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.34.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.35.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.35.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.36.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.36.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.37.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.37.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.38.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.38.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.39.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.39.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.4.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.5.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.6.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.7.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.8.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.9.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/analysis_settings_1_1_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/analysis_settings_1_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/analysis_settings_1_1_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/analysis_settings_1_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/analysis_settings_1_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/analysis_settings_1_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/analysis_settings_2_1_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/analysis_settings_2_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/analysis_settings_2_1_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/analysis_settings_2_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/analysis_settings_2_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/analysis_settings_2_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/analysis_settings_5_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/analysis_settings_5_1_reins_layer_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_aalcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_aalcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_aalcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_aalcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_aalcalc_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_aalcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_aalcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_aalcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_aalcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_aalcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_aalcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_aalcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_aalcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_aalcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_aalcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_aalcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_aalcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_aalcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_aalcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_aalcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_aalcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_aalcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_aalcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_aalcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_aalcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_aalcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_aalcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_aalcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_aalcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_aalcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_aalcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_aalcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_aalcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_aalcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_aalcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_aalcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_aalcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_aalcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_aalcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_aalcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_aalcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_aalcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_aalcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_aalcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_aalcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_aalcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_aalcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_aalcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_aalcalc_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_aalcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_fu_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_fu_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_fu_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_fu_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_fu_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_fu_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_fu_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_fu_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_fu_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_fu_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_fu_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_fu_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_fu_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_fu_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_fu_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_fu_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_fu_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_fu_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_fu_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_fu_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_fu_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_fu_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_fu_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_ws_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_ws_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_ws_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_ws_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_ws_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_ws_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_ws_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_ws_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_ws_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_ws_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_ws_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_ws_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_ws_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_ws_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_ws_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_ws_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_ws_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_ws_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_ws_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_ws_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_ws_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_ws_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_ws_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_eltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_eltcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_eltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_eltcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_eltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_eltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_eltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_eltcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_eltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_eltcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_eltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_eltcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_eltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_eltcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_eltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_eltcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_eltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_eltcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_eltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_eltcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_eltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_eltcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_eltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_eltcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_eltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_eltcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_eltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_eltcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_eltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_eltcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_eltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_eltcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_eltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_eltcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_eltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_eltcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_eltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_eltcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_eltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_eltcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_eltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_eltcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_eltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_eltcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_eltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_eltcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_eltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_eltcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_eltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_eltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_il_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_il_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_il_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_il_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_il_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_il_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_il_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_il_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_il_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_il_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_il_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_il_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_il_lec_1_output_2_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_il_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_il_lec_2_output_10_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_il_lec_2_output_10_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_il_lec_2_output_10_partition.1.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_il_lec_2_output_10_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_il_lec_2_output_10_partition.2.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_il_lec_2_output_10_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_il_lec_2_output_10_partition.3.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_il_lec_2_output_10_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_il_lec_2_output_10_partition.4.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_il_lec_2_output_10_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_il_lec_2_output_10_partition.5.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_il_lec_2_output_10_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_il_lec_2_output_10_partition.6.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_il_lec_2_output_10_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_il_lec_2_output_10_partition.7.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_il_lec_2_output_10_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_il_lec_2_output_10_partition.8.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_il_lec_2_output_10_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_il_lec_2_output_10_partition.9.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_il_lec_2_output_10_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_il_lec_2_output_10_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_il_lec_2_output_10_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_il_lec_2_output_10_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_il_lec_2_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_il_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_il_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_il_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_il_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_il_lec_2_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_il_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_il_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_il_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_il_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_il_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_il_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_il_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_il_lec_2_output_2_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_il_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_il_no_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_il_no_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_il_no_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_il_no_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_il_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_il_no_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_il_no_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_il_no_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_il_no_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_il_no_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_il_no_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_il_no_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_il_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_il_no_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_il_no_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_il_no_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_il_no_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_il_no_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_il_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_il_no_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_il_no_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_il_no_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_il_no_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_il_no_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_il_no_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_il_no_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_il_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_il_no_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_il_ord_ept_psept_2_output_10_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_il_ord_ept_psept_2_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_il_ord_palt_output_10_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_il_ord_palt_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_il_ord_psept_lec_1_output_10_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_il_ord_psept_lec_1_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_lec_1_output_2_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_lec_2_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_lec_2_output_2_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_no_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_no_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_no_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_no_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_no_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_no_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_no_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_no_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_no_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_no_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_no_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_no_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_no_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_no_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_no_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_no_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_no_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_no_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_no_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_no_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_no_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_no_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_no_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_no_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_fu_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_fu_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_fu_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_fu_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_fu_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_fu_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_fu_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_fu_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_fu_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_fu_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_fu_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_fu_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_fu_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_fu_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_fu_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_fu_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_fu_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_fu_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_fu_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_fu_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_fu_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_fu_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_fu_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_ws_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_ws_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_ws_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_ws_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_ws_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_ws_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_ws_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_ws_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_ws_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_ws_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_ws_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_ws_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_ws_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_ws_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_ws_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_ws_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_ws_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_ws_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_ws_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_ws_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_ws_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_ws_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_ws_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_ord_ept_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_ord_ept_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_ord_ept_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_ord_ept_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_ord_ept_psept_lec_2_output_10_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_ord_ept_psept_lec_2_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_ord_palt_output_10_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_ord_palt_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_ord_psept_2_output_10_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_ord_psept_2_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_pltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_pltcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_pltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_pltcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_pltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_pltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_pltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_pltcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_pltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_pltcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_pltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_pltcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_pltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_pltcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_pltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_pltcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_pltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_pltcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_pltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_pltcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_pltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_pltcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_pltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_pltcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_pltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_pltcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_pltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_pltcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_pltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_pltcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_pltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_pltcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_pltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_pltcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_pltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_pltcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_pltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_pltcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_pltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_pltcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_pltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_pltcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_pltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_pltcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_pltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_pltcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_pltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_pltcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_pltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_pltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_summarycalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_summarycalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_summarycalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_summarycalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_summarycalc_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_summarycalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_summarycalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_summarycalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_summarycalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_summarycalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_summarycalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_summarycalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_summarycalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_summarycalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_summarycalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_summarycalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_summarycalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_summarycalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_summarycalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_summarycalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_summarycalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_summarycalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_summarycalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_summarycalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_summarycalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_summarycalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_summarycalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_summarycalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_summarycalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_summarycalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_summarycalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_summarycalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_summarycalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_summarycalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_summarycalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_summarycalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_summarycalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_summarycalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_summarycalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_summarycalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_summarycalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_summarycalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_summarycalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_summarycalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_summarycalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_summarycalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_summarycalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_summarycalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_summarycalc_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_summarycalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_aalcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_aalcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_aalcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_aalcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_aalcalc_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_aalcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_aalcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_aalcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_aalcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_aalcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_aalcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_aalcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_aalcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_aalcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_aalcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_aalcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_aalcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_aalcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_aalcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_aalcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_aalcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_aalcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_aalcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_aalcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_aalcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_aalcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_aalcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_aalcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_aalcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_aalcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_aalcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_aalcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_aalcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_aalcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_aalcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_aalcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_aalcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_aalcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_aalcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_aalcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_aalcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_aalcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_aalcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_aalcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_aalcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_aalcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_aalcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_aalcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_aalcalc_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_aalcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_fu_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_fu_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_fu_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_fu_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_fu_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_fu_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_fu_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_fu_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_fu_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_fu_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_fu_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_fu_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_fu_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_fu_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_fu_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_fu_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_fu_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_fu_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_fu_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_fu_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_fu_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_fu_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_fu_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_ws_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_ws_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_ws_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_ws_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_ws_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_ws_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_ws_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_ws_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_ws_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_ws_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_ws_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_ws_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_ws_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_ws_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_ws_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_ws_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_ws_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_ws_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_ws_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_ws_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_ws_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_ws_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_ws_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_eltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_eltcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_eltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_eltcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_eltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_eltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_eltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_eltcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_eltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_eltcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_eltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_eltcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_eltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_eltcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_eltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_eltcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_eltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_eltcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_eltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_eltcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_eltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_eltcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_eltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_eltcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_eltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_eltcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_eltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_eltcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_eltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_eltcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_eltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_eltcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_eltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_eltcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_eltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_eltcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_eltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_eltcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_eltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_eltcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_eltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_eltcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_eltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_eltcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_eltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_eltcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_eltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_eltcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_eltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_eltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_lec_1_output_2_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_lec_2_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_lec_2_output_2_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_no_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_no_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_no_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_no_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_no_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_no_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_no_lec_1_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_no_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_no_lec_1_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_no_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_no_lec_1_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_no_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_no_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_no_lec_2_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_no_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_no_lec_2_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_no_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_no_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_no_lec_2_output_2_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_no_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_no_lec_2_output_2_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_no_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_no_lec_2_output_2_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_no_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_fu_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_fu_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_fu_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_fu_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_fu_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_fu_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_fu_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_fu_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_fu_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_fu_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_fu_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_fu_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_fu_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_fu_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_fu_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_fu_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_fu_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_fu_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_fu_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_fu_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_fu_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_fu_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_fu_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_ws_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_ws_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_ws_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_ws_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_ws_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_ws_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_ws_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_ws_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_ws_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_ws_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_ws_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_ws_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_ws_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_ws_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_ws_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_ws_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_ws_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_ws_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_ws_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_ws_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_ws_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_ws_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_ws_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_pltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_pltcalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_pltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_pltcalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_pltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_pltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_pltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_pltcalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_pltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_pltcalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_pltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_pltcalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_pltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_pltcalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_pltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_pltcalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_pltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_pltcalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_pltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_pltcalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_pltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_pltcalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_pltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_pltcalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_pltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_pltcalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_pltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_pltcalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_pltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_pltcalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_pltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_pltcalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_pltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_pltcalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_pltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_pltcalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_pltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_pltcalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_pltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_pltcalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_pltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_pltcalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_pltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_pltcalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_pltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_pltcalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_pltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_pltcalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_pltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_pltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_summarycalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_summarycalc_1_output_1_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_summarycalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_summarycalc_1_output_1_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_summarycalc_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_summarycalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_summarycalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_summarycalc_1_output_20_partition.0.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_summarycalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_summarycalc_1_output_20_partition.1.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_summarycalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_summarycalc_1_output_20_partition.10.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_summarycalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_summarycalc_1_output_20_partition.11.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_summarycalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_summarycalc_1_output_20_partition.12.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_summarycalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_summarycalc_1_output_20_partition.13.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_summarycalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_summarycalc_1_output_20_partition.14.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_summarycalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_summarycalc_1_output_20_partition.15.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_summarycalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_summarycalc_1_output_20_partition.16.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_summarycalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_summarycalc_1_output_20_partition.17.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_summarycalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_summarycalc_1_output_20_partition.18.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_summarycalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_summarycalc_1_output_20_partition.19.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_summarycalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_summarycalc_1_output_20_partition.2.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_summarycalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_summarycalc_1_output_20_partition.3.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_summarycalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_summarycalc_1_output_20_partition.4.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_summarycalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_summarycalc_1_output_20_partition.5.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_summarycalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_summarycalc_1_output_20_partition.6.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_summarycalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_summarycalc_1_output_20_partition.7.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_summarycalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_summarycalc_1_output_20_partition.8.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_summarycalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_summarycalc_1_output_20_partition.9.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_summarycalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_summarycalc_1_output_20_partition.output.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_summarycalc_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_summarycalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*


### PR DESCRIPTION
<!--start_release_notes-->
### Fix error guard and support older bash versions 
* Fixed running the ktools script on older bash version, added compatibility checks to disable unsupported features and print warnings. 
* Fixed script options getting overridden by python subprocess calls  #936 

**Example - Bash v4.0**
```
$ bash_4 --version
GNU bash, version 4.0.38(1)-release (x86_64-unknown-linux-gnu)

$ bash_4 run_ktools.sh
WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected.
WARNING: logging disabled, bash version '4.0.38(1)-release' is not supported, minimum requirement is bash v4.4
[OK] eve
[OK] getmodel
[OK] gulcalc
[OK] fmcalc
[OK] summarycalc
[OK] eltcalc
[OK] aalcalc
[OK] leccalc
Run Completed
```


<!--end_release_notes-->
