### PR TITLE
Fix/936 bash error capture backport

### DIFF
--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_20_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/all_calcs_1_output_40_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/analysis_settings_1_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/analysis_settings_1_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/analysis_settings_2_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/analysis_settings_2_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_aalcalc_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_aalcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_aalcalc_1_output_20_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_aalcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_eltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_eltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_eltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_eltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_il_lec_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_il_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_il_lec_1_output_2_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_il_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_il_lec_2_output_10_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_il_lec_2_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_il_lec_2_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_il_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_il_lec_2_output_2_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_il_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_il_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_il_no_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_il_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_il_no_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_il_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_il_no_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_il_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_il_no_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_lec_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_lec_1_output_2_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_lec_2_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_lec_2_output_2_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_no_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_no_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_no_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_no_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_pltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_pltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_pltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_pltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_summarycalc_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_summarycalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/gul_summarycalc_1_output_20_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/gul_summarycalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_aalcalc_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_aalcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_aalcalc_1_output_20_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_aalcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_eltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_eltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_eltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_eltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_lec_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_lec_1_output_2_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_lec_2_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_lec_2_output_2_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_no_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_no_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_no_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_no_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_pltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_pltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_pltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_pltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_summarycalc_1_output_1_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_summarycalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/cov_kparse_reference/il_summarycalc_1_output_20_partition.sh
+++ b/tests/model_execution/cov_kparse_reference/il_summarycalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/all_calcs_1_output_40_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/analysis_settings_1_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/analysis_settings_1_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/analysis_settings_2_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/analysis_settings_2_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_aalcalc_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_aalcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_aalcalc_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_aalcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_eltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_eltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_eltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_eltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_il_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_il_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_il_lec_1_output_2_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_il_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_il_lec_2_output_10_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_il_lec_2_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_il_lec_2_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_il_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_il_lec_2_output_2_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_il_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_il_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_il_no_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_il_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_il_no_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_il_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_il_no_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_il_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_il_no_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_lec_1_output_2_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_lec_2_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_lec_2_output_2_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_no_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_no_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_no_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_no_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_pltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_pltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_pltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_pltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_summarycalc_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_summarycalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/gul_summarycalc_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/gul_summarycalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_aalcalc_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_aalcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_aalcalc_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_aalcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_eltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_eltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_eltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_eltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_lec_1_output_2_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_lec_2_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_lec_2_output_2_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_no_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_no_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_no_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_no_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_pltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_pltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_pltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_pltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_summarycalc_1_output_1_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_summarycalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/eve_kparse_reference/il_summarycalc_1_output_20_partition.sh
+++ b/tests/model_execution/eve_kparse_reference/il_summarycalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_20_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/all_calcs_1_output_40_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/analysis_settings_1_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/analysis_settings_1_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/analysis_settings_2_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/analysis_settings_2_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_aalcalc_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_aalcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_aalcalc_1_output_20_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_aalcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_eltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_eltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_eltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_eltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_1_output_2_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_2_output_10_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_2_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_2_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_2_output_2_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_il_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_il_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_il_no_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_il_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_il_no_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_il_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_il_no_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_il_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_il_no_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_lec_1_output_2_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_lec_2_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_lec_2_output_2_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_no_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_no_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_no_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_no_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_pltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_pltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_pltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_pltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_summarycalc_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_summarycalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/gul_summarycalc_1_output_20_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/gul_summarycalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_aalcalc_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_aalcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_aalcalc_1_output_20_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_aalcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_eltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_eltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_eltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_eltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_lec_1_output_2_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_lec_2_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_lec_2_output_2_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_no_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_no_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_no_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_no_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_pltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_pltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_pltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_pltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_summarycalc_1_output_1_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_summarycalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_fc_kparse_reference/il_summarycalc_1_output_20_partition.sh
+++ b/tests/model_execution/itm_fc_kparse_reference/il_summarycalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_20_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/all_calcs_1_output_40_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/analysis_settings_1_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/analysis_settings_1_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/analysis_settings_2_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/analysis_settings_2_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_aalcalc_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_aalcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_aalcalc_1_output_20_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_aalcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_eltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_eltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_eltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_eltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_il_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_il_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_il_lec_1_output_2_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_il_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_il_lec_2_output_10_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_il_lec_2_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_il_lec_2_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_il_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_il_lec_2_output_2_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_il_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_il_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_il_no_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_il_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_il_no_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_il_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_il_no_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_il_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_il_no_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_lec_1_output_2_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_lec_2_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_lec_2_output_2_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_no_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_no_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_no_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_no_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_pltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_pltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_pltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_pltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_summarycalc_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_summarycalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/gul_summarycalc_1_output_20_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/gul_summarycalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_aalcalc_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_aalcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_aalcalc_1_output_20_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_aalcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_eltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_eltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_eltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_eltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_lec_1_output_2_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_lec_2_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_lec_2_output_2_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_no_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_no_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_no_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_no_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_pltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_pltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_pltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_pltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_summarycalc_1_output_1_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_summarycalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/itm_kparse_reference/il_summarycalc_1_output_20_partition.sh
+++ b/tests/model_execution/itm_kparse_reference/il_summarycalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_20_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/all_calcs_1_output_40_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/analysis_settings_1_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/analysis_settings_1_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/analysis_settings_2_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/analysis_settings_2_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_aalcalc_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_aalcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_aalcalc_1_output_20_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_aalcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_eltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_eltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_eltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_eltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_il_lec_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_il_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_il_lec_1_output_2_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_il_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_il_lec_2_output_10_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_il_lec_2_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_il_lec_2_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_il_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_il_lec_2_output_2_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_il_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_il_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_il_no_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_il_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_il_no_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_il_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_il_no_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_il_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_il_no_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_lec_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_lec_1_output_2_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_lec_2_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_lec_2_output_2_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_no_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_no_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_no_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_no_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_pltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_pltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_pltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_pltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_summarycalc_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_summarycalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/gul_summarycalc_1_output_20_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/gul_summarycalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_aalcalc_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_aalcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_aalcalc_1_output_20_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_aalcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_eltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_eltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_eltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_eltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_lec_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_lec_1_output_2_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_lec_2_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_lec_2_output_2_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_no_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_no_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_no_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_no_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_pltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_pltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_pltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_pltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_summarycalc_1_output_1_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_summarycalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/lb_kparse_reference/il_summarycalc_1_output_20_partition.sh
+++ b/tests/model_execution/lb_kparse_reference/il_summarycalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/all_calcs_1_output_40_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/analysis_settings_1_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/analysis_settings_1_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/analysis_settings_2_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/analysis_settings_2_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_aalcalc_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_aalcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_aalcalc_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_aalcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_eltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_eltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_eltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_eltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_1_output_2_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_2_output_10_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_2_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_2_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_2_output_2_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_il_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_il_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_il_no_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_il_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_il_no_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_il_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_il_no_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_il_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_il_no_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_lec_1_output_2_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_lec_2_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_lec_2_output_2_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_no_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_no_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_no_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_no_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_pltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_pltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_pltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_pltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_summarycalc_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_summarycalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/gul_summarycalc_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/gul_summarycalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_aalcalc_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_aalcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_aalcalc_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_aalcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_eltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_eltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_eltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_eltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_lec_1_output_2_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_lec_2_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_lec_2_output_2_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_no_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_no_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_no_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_no_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_pltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_pltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_pltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_pltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_summarycalc_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_summarycalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_fc_kparse_reference/il_summarycalc_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_fc_kparse_reference/il_summarycalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/all_calcs_1_output_40_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/analysis_settings_1_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/analysis_settings_1_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/analysis_settings_2_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/analysis_settings_2_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_aalcalc_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_aalcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_aalcalc_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_aalcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_eltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_eltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_eltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_eltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_il_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_il_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_il_lec_1_output_2_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_il_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_il_lec_2_output_10_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_il_lec_2_output_10_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_il_lec_2_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_il_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_il_lec_2_output_2_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_il_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_il_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_il_no_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_il_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_il_no_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_il_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_il_no_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_il_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_il_no_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_lec_1_output_2_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_lec_2_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_lec_2_output_2_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_no_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_no_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_no_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_no_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_pltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_pltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_pltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_pltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_summarycalc_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_summarycalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/gul_summarycalc_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/gul_summarycalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_aalcalc_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_aalcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_aalcalc_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_aalcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_eltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_eltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_eltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_eltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_lec_1_output_2_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_lec_2_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_lec_2_output_2_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_no_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_no_lec_1_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_no_lec_2_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_no_lec_2_output_2_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_fu_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_fu_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_ws_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_ws_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_pltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_pltcalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_pltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_pltcalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_summarycalc_1_output_1_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_summarycalc_1_output_1_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*

--- a/tests/model_execution/tmp_kparse_reference/il_summarycalc_1_output_20_partition.sh
+++ b/tests/model_execution/tmp_kparse_reference/il_summarycalc_1_output_20_partition.sh
@@ -1,7 +1,9 @@
-#!/usr/bin/env -S bash -euET -o pipefail -O inherit_errexit
+#!/bin/bash
 SCRIPT=$(readlink -f "$0") && cd $(dirname "$SCRIPT")
 
 # --- Script Init ---
+set -euET -o pipefail
+shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."
 
 mkdir -p log
 rm -R -f log/*


### PR DESCRIPTION
<!--start_release_notes-->
### Fix error guard and support older bash versions 
* Fixed running the ktools script on older bash version, added compatibility checks to disable unsupported features and print warnings. 
* Fixed script options getting overridden by python subprocess calls  #936 

**Example - Bash v4.0**
```
$ bash_4 --version
GNU bash, version 4.0.38(1)-release (x86_64-unknown-linux-gnu)

$ bash_4 run_ktools.sh
WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected.
WARNING: logging disabled, bash version '4.0.38(1)-release' is not supported, minimum requirement is bash v4.4
[OK] eve
[OK] getmodel
[OK] gulcalc
[OK] fmcalc
[OK] summarycalc
[OK] eltcalc
[OK] aalcalc
[OK] leccalc
Run Completed
```
<!--end_release_notes-->
