### PR TITLE
Add cdftocsvpy tool

### DIFF
--- a/oasislmf/pytools/cdftocsv.py
+++ b/oasislmf/pytools/cdftocsv.py
@@ -4,119 +4,93 @@ import sys
 import os
 from contextlib import ExitStack
 import argparse
-import logging
 import numpy as np
 
 from oasislmf.pytools.getmodel.manager import get_mean_damage_bins
 from oasislmf.pytools.gul.common import ProbMean, damagecdfrec
-
-logger = logging.getLogger(__name__)
 
 parser = argparse.ArgumentParser(
     usage='use "%(prog)s --help" for more information',
     formatter_class=argparse.RawTextHelpFormatter  # for multi-line help text
 )
 
-parser.add_argument('-i', '--file-in', help='input filename', action='store', type=str)
 parser.add_argument('-s', help='skip header (default: False).', default=False, action='store_true', dest='skip_header')
 parser.add_argument('--run-dir', help='path to the run directory', default='.')
-parser.add_argument('--logging-level',
-                    help='logging level (debug:10, info:20, warning:30, error:40, critical:50)', default=30, type=int)
 
 
-def run(run_dir, skip_header, file_in=None, file_out=None):
+def run(run_dir, skip_header):
     """Run cdftocsv command: convert the cdf output from getmodel into csv format.
-    Presently, the csv file is streamed to stdout.
+    The binary data is read from an input stream, and the csv file is streamed to stdout.
 
     Args:
         run_dir ([str]): Path to the run directory.
+
         skip_header ([bool]): If True, does not print the csv header.
-        file_in ([str], optional): If provided, it reads the cdf from that file. Defaults to None.
-        file_out ([str], optional): Placeholder for a future output file writer. Defaults to None.
 
     Raises:
-        NotImplementedError: If file_out is not None.
         ValueError: If the stream type is not 1.
 
     """
-    with ExitStack() as stack:
-        if file_in is None:
-            streams_in = sys.stdin.buffer
+    # set up the streams
+    streams_in = sys.stdin.buffer
+    stream_out = sys.stdout
 
-        else:
-            streams_in = stack.enter_context(open(file_in, 'rb'))
+    # get damage bins from file
+    static_path = os.path.join(run_dir, 'static')
+    damage_bins = get_mean_damage_bins(static_path=static_path)
 
-        if file_out is None:
-            stream_out = sys.stdout
-        else:
-            # implement here a file-writer (e.g., csv writer)
-            raise NotImplementedError("file_out has not been implemented yet.")
+    # maximum number of damage bins (individual items can have up to `total_bins` bins)
+    if damage_bins.shape[0] == 0:
+        total_bins = 1000
+    else:
+        total_bins = damage_bins.shape[0]
 
-        # get damage bins from file
-        static_path = os.path.join(run_dir, 'static')
-        damage_bins = get_mean_damage_bins(static_path=static_path)
+    # determine stream type
+    stream_type = np.frombuffer(streams_in.read(4), dtype='i4')
 
-        # maximum number of damage bins (individual items can have up to `total_bins` bins)
-        if damage_bins.shape[0] == 0:
-            total_bins = 1000
-        else:
-            total_bins = damage_bins.shape[0]
+    if stream_type[0] != 1:
+        raise ValueError(f"FATAL: Invalid stream type: expect 1, got {stream_type[0]}.")
 
-        # determine stream type
-        stream_type = np.frombuffer(streams_in.read(4), dtype='i4')
+    if not skip_header:
+        stream_out.write("event_id,areaperil_id,vulnerability_id,bin_index,prob_to,bin_mean\n")
 
-        if stream_type[0] != 1:
-            raise ValueError(f"FATAL: Invalid stream type: expect 1, got {stream_type[0]}.")
+    # prepare all the data buffers
+    damagecdf_mv = memoryview(bytearray(damagecdfrec.size))
+    damagecdf = np.ndarray(1, buffer=damagecdf_mv, dtype=damagecdfrec.dtype)
+    Nbins_mv = memoryview(bytearray(4))
+    Nbins = np.ndarray(1, buffer=Nbins_mv, dtype='i4')
+    rec_mv = memoryview(bytearray(total_bins * ProbMean.size))
+    rec = np.ndarray(total_bins, buffer=rec_mv, dtype=ProbMean.dtype)
 
-        if not skip_header:
-            stream_out.write("event_id,areaperil_id,vulnerability_id,bin_index,prob_to,bin_mean")
+    # start reading the stream
+    # each record from getmodel is expected to contain:
+    # 1 damagecdfrec obj, 1 int (Nbins), a number `Nbins` of ProbMean objects
+    while True:
+        len_read = streams_in.readinto(damagecdf_mv)
+        len_read = streams_in.readinto(Nbins_mv)
+        len_read = streams_in.readinto(rec_mv[:Nbins[0] * ProbMean.size])
 
-        # prepare all the data buffers
-        damagecdf_mv = memoryview(bytearray(damagecdfrec.size))
-        damagecdf = np.ndarray(1, buffer=damagecdf_mv, dtype=damagecdfrec.dtype)
-        Nbins_mv = memoryview(bytearray(4))
-        Nbins = np.ndarray(1, buffer=Nbins_mv, dtype='i4')
-        rec_mv = memoryview(bytearray(total_bins * ProbMean.size))
-        rec = np.ndarray(total_bins, buffer=rec_mv, dtype=ProbMean.dtype)
+        # exit if the stream has ended
+        if len_read == 0:
+            break
 
-        # start reading the stream
-        # each record from getmodel is expected to contain:
-        # 1 damagecdfrec obj, 1 int (Nbins), a number `Nbins` of ProbMean objects
-        while True:
-            len_read = streams_in.readinto(damagecdf_mv)
-            len_read = streams_in.readinto(Nbins_mv)
-            len_read = streams_in.readinto(rec_mv[:Nbins[0] * ProbMean.size])
+        # print out in csv format
+        csv_line_fixed = ",".join([f"{x}" for x in [damagecdf['event_id'][0],
+                                                    damagecdf['areaperil_id'][0],
+                                                    damagecdf['vulnerability_id'][0]]]) + ","
 
-            # exit if the stream has ended
-            if len_read == 0:
-                break
+        for i in range(Nbins[0]):
+            csv_line = csv_line_fixed
+            csv_line += f"{i+1},"     # bin index starts from 1
+            csv_line += ",".join([f"{x:8.6f}" for x in [rec[i]["prob_to"], rec[i]["bin_mean"]]])
 
-            # print out in csv format
-            csv_line_fixed = ",".join([f"{x}" for x in [damagecdf['event_id'][0],
-                                                        damagecdf['areaperil_id'][0],
-                                                        damagecdf['vulnerability_id'][0]]]) + ","
-
-            for i in range(Nbins[0]):
-                csv_line = csv_line_fixed
-                csv_line += f"{i+1},"     # bin index starts from 1
-                csv_line += ",".join([f"{x:8.6f}" for x in [rec[i]["prob_to"], rec[i]["bin_mean"]]])
-
-                stream_out.write(csv_line + "\n")
+            stream_out.write(csv_line + "\n")
 
     return
 
 
 def main():
     kwargs = vars(parser.parse_args())
-
-    # add handler to cdftocsv logger
-    ch = logging.StreamHandler()
-    formatter = logging.Formatter(
-        '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-    ch.setFormatter(formatter)
-    logger.addHandler(ch)
-    logging_level = kwargs.pop('logging_level')
-    logger.setLevel(logging_level)
 
     run(**kwargs)
 

--- a/oasislmf/pytools/cdftocsv.py
+++ b/oasislmf/pytools/cdftocsv.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python
+
+import sys
+import os
+from contextlib import ExitStack
+import argparse
+import logging
+import numpy as np
+
+from oasislmf.pytools.getmodel.manager import get_mean_damage_bins
+from oasislmf.pytools.gul.common import ProbMean, damagecdfrec
+
+logger = logging.getLogger(__name__)
+
+parser = argparse.ArgumentParser(
+    usage='use "%(prog)s --help" for more information',
+    formatter_class=argparse.RawTextHelpFormatter  # for multi-line help text
+)
+
+parser.add_argument('-i', '--file-in', help='input filename', action='store', type=str)
+parser.add_argument('-s', help='skip header (default: False).', default=False, action='store_true', dest='skip_header')
+parser.add_argument('--run-dir', help='path to the run directory', default='.')
+parser.add_argument('--logging-level',
+                    help='logging level (debug:10, info:20, warning:30, error:40, critical:50)', default=30, type=int)
+
+
+def run(run_dir, skip_header, file_in=None, file_out=None):
+    """Run cdftocsv command: convert the cdf output from getmodel into csv format.
+    Presently, the csv file is streamed to stdout.
+
+    Args:
+        run_dir ([str]): Path to the run directory.
+        skip_header ([bool]): If True, does not print the csv header.
+        file_in ([str], optional): If provided, it reads the cdf from that file. Defaults to None.
+        file_out ([str], optional): Placeholder for a future output file writer. Defaults to None.
+
+    Raises:
+        NotImplementedError: If file_out is not None.
+        ValueError: If the stream type is not 1.
+
+    """
+    with ExitStack() as stack:
+        if file_in is None:
+            streams_in = sys.stdin.buffer
+
+        else:
+            streams_in = stack.enter_context(open(file_in, 'rb'))
+
+        if file_out is None:
+            stream_out = sys.stdout
+        else:
+            # implement here a file-writer (e.g., csv writer)
+            raise NotImplementedError("file_out has not been implemented yet.")
+
+        # get damage bins from file
+        static_path = os.path.join(run_dir, 'static')
+        damage_bins = get_mean_damage_bins(static_path=static_path)
+
+        # maximum number of damage bins (individual items can have up to `total_bins` bins)
+        if damage_bins.shape[0] == 0:
+            total_bins = 1000
+        else:
+            total_bins = damage_bins.shape[0]
+
+        # determine stream type
+        stream_type_mv = memoryview(bytearray(4))
+        stream_type = np.ndarray(1, buffer=stream_type_mv, dtype='i4')
+        len_read = streams_in.readinto(stream_type_mv)
+
+        if stream_type[0] != 1:
+            raise ValueError(f"FATAL: Invalid stream type: expect 1, got {stream_type[0]}.")
+
+        if not skip_header:
+            stream_out.write("event_id,areaperil_id,vulnerability_id,bin_index,prob_to,bin_mean")
+
+        # prepare all the data buffers
+        damagecdf_mv = memoryview(bytearray(damagecdfrec.size))
+        damagecdf = np.ndarray(1, buffer=damagecdf_mv, dtype=damagecdfrec.dtype)
+        Nbins_mv = memoryview(bytearray(4))
+        Nbins = np.ndarray(1, buffer=Nbins_mv, dtype='i4')
+        rec_mv = memoryview(bytearray(total_bins * ProbMean.size))
+        rec = np.ndarray(total_bins, buffer=rec_mv, dtype=ProbMean.dtype)
+
+        # start reading the stream
+        # each record from getmodel is expected to contain:
+        # 1 damagecdfrec obj, 1 int (Nbins), a number `Nbins` of ProbMean objects
+        while True:
+            len_read = streams_in.readinto1(damagecdf_mv)
+            len_read = streams_in.readinto1(Nbins_mv)
+            len_read = streams_in.readinto1(rec_mv[:Nbins[0] * ProbMean.size])
+
+            # exit if the stream has ended
+            if len_read == 0:
+                break
+
+            # print out in csv format
+            csv_line_fixed = ",".join([f"{x}" for x in [damagecdf['event_id'][0],
+                                                        damagecdf['areaperil_id'][0],
+                                                        damagecdf['vulnerability_id'][0]]]) + ","
+
+            for i in range(Nbins[0]):
+                csv_line = csv_line_fixed
+                csv_line += f"{i+1},"     # bin index starts from 1
+                csv_line += ",".join([f"{x:8.6f}" for x in [rec[i]["prob_to"], rec[i]["bin_mean"]]])
+
+                stream_out.write(csv_line + "\n")
+
+    return
+
+
+def main():
+    kwargs = vars(parser.parse_args())
+
+    # add handler to cdftocsv logger
+    ch = logging.StreamHandler()
+    formatter = logging.Formatter(
+        '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    ch.setFormatter(formatter)
+    logger.addHandler(ch)
+    logging_level = kwargs.pop('logging_level')
+    logger.setLevel(logging_level)
+
+    run(**kwargs)
+
+
+if __name__ == '__main__':
+    main()

--- a/oasislmf/pytools/cdftocsv.py
+++ b/oasislmf/pytools/cdftocsv.py
@@ -15,7 +15,7 @@ parser = argparse.ArgumentParser(
 )
 
 parser.add_argument('-s', help='skip header (default: False).', default=False, action='store_true', dest='skip_header')
-parser.add_argument('--run-dir', help='path to the run directory', default='.')
+parser.add_argument('--run-dir', help='path to the run directory (default: ".")', default='.')
 
 
 def run(run_dir, skip_header):

--- a/oasislmf/pytools/cdftocsv.py
+++ b/oasislmf/pytools/cdftocsv.py
@@ -83,9 +83,9 @@ def run(run_dir, skip_header, file_in=None, file_out=None):
         # each record from getmodel is expected to contain:
         # 1 damagecdfrec obj, 1 int (Nbins), a number `Nbins` of ProbMean objects
         while True:
-            len_read = streams_in.readinto1(damagecdf_mv)
-            len_read = streams_in.readinto1(Nbins_mv)
-            len_read = streams_in.readinto1(rec_mv[:Nbins[0] * ProbMean.size])
+            len_read = streams_in.readinto(damagecdf_mv)
+            len_read = streams_in.readinto(Nbins_mv)
+            len_read = streams_in.readinto(rec_mv[:Nbins[0] * ProbMean.size])
 
             # exit if the stream has ended
             if len_read == 0:

--- a/oasislmf/pytools/cdftocsv.py
+++ b/oasislmf/pytools/cdftocsv.py
@@ -63,9 +63,7 @@ def run(run_dir, skip_header, file_in=None, file_out=None):
             total_bins = damage_bins.shape[0]
 
         # determine stream type
-        stream_type_mv = memoryview(bytearray(4))
-        stream_type = np.ndarray(1, buffer=stream_type_mv, dtype='i4')
-        len_read = streams_in.readinto(stream_type_mv)
+        stream_type = np.frombuffer(streams_in.read(4), dtype='i4')
 
         if stream_type[0] != 1:
             raise ValueError(f"FATAL: Invalid stream type: expect 1, got {stream_type[0]}.")

--- a/oasislmf/pytools/gul/common.py
+++ b/oasislmf/pytools/gul/common.py
@@ -1,0 +1,18 @@
+"""
+This file defines the data types that are loaded from the data files.
+"""
+import os
+
+import numba as nb
+import numpy as np
+
+from oasislmf.pytools.getmodel.common import oasis_float, areaperil_int
+
+ProbMean = nb.from_dtype(np.dtype([('prob_to', oasis_float),
+                                   ('bin_mean', oasis_float)
+                                   ]))
+
+damagecdfrec = nb.from_dtype(np.dtype([('event_id', np.int32),
+                                       ('areaperil_id', areaperil_int),
+                                       ('vulnerability_id', np.int32)
+                                       ]))

--- a/setup.py
+++ b/setup.py
@@ -354,6 +354,7 @@ setup(
             'load_balancer=oasislmf.execution.load_balancer:main',
             'fmpy=oasislmf.pytools.fmpy:main',
             'modelpy=oasislmf.pytools.modelpy:main',
+            'cdftocsvpy=oasislmf.pytools.cdftocsv:main',
             'footprintconvpy=oasislmf.pytools.footprintconv:footprintconvpy',
             'vulntoparquet=oasislmf.pytools.getmodel.vulnerability:main',
             "servedata=oasislmf.pytools.data_layer.footprint_layer:main",


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->
This PR closes #987.

<!--start_release_notes-->
### Added `cdftocsvpy` tool
A Python implementation of the `cdftocsv` tool is now available: it is called `cdftocsvpy`.

Like `cdftocsv`, `cdftocsvpy` prints the cdf produced by `getmodel` to `stdout` in `csv` format.
It has the same input/output interface of `cdftocsv`. It can be used with a stream as an input, e.g.:
```bash
eve 1 1 | getmodel | cdftocsv | head
```
produces:
```bash
event_id,areaperil_id,vulnerability_id,bin_index,prob_to,bin_mean
1,1,9,1,0.268378,0.000000
1,1,9,2,0.318824,0.125000
1,1,9,3,0.665534,0.375000
1,1,9,4,0.818048,0.625000
1,1,9,5,0.933643,0.875000
1,1,9,6,1.000000,1.000000
1,1,10,1,0.048263,0.000000
1,1,10,2,0.548144,0.125000
1,1,10,3,0.597388,0.375000
```
By passing the `-s` optional argument, the header is not printed, e.g.:
```bash
eve 1 1 | getmodel | cdftocsv -s | head
```
produces:
```bash
1,1,9,1,0.268378,0.000000
1,1,9,2,0.318824,0.125000
1,1,9,3,0.665534,0.375000
1,1,9,4,0.818048,0.625000
1,1,9,5,0.933643,0.875000
1,1,9,6,1.000000,1.000000
1,1,10,1,0.048263,0.000000
1,1,10,2,0.548144,0.125000
1,1,10,3,0.597388,0.375000
```

<!--end_release_notes-->
