### PR TITLE
Fix/negative sidx issue

### DIFF
--- a/oasislmf/pytools/fm/compute_sparse.py
+++ b/oasislmf/pytools/fm/compute_sparse.py
@@ -485,7 +485,7 @@ def init_variable(compute_info, max_sidx_val, temp_dir, low_memory):
     therefore we can use only sidx_indexes to tract the length of each node values
     """
     max_sidx_count = max_sidx_val + EXTRA_VALUES
-    len_array = max_sidx_val + 4
+    len_array = max_sidx_val + 6
 
     if low_memory:
         sidx_val = np.memmap(os.path.join(temp_dir, "sidx_val.bin"), mode='w+',

--- a/oasislmf/pytools/fm/stream_sparse.py
+++ b/oasislmf/pytools/fm/stream_sparse.py
@@ -214,7 +214,7 @@ def load_event(event_agg_view, sidx_loss_view, event_id, nodes_array,
             node_loss_start = loss_indptr[node['ba'] + layer]
             if output_id and node_val_len:  # if output is not in xref output_id is 0
                 if i_index == -1:
-                    if nb_values - cursor < 4: # header + -5, -3, -1 sample
+                    if nb_values - cursor < 5: # header + -5, -3, -1 sample
                         return cursor * number_size, compute_i, layer, i_index
                     else:
                         # write the header


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!--start_release_notes-->
### fix size of intermediary dense array 
with the introduction of sidx -5, intermediary dense array  was too small and overlap with sidx (num_sample - 1).
increase the size by 2 to fix the issue
<!--end_release_notes-->
