### PR TITLE
Fix/996 bash exit handler

### DIFF
--- a/oasislmf/execution/bash.py
+++ b/oasislmf/execution/bash.py
@@ -113,6 +113,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/oasislmf/execution/bash.py
+++ b/oasislmf/execution/bash.py
@@ -1470,7 +1470,6 @@ def bash_wrapper(filename, bash_trace, stderr_guard):
     if stderr_guard:
         print_command(filename, '')
         print_command(filename, 'check_complete')
-        print_command(filename, 'exit_handler')
 
 
 def create_bash_analysis(

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_1_partition.0.sh
@@ -200,4 +200,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_1_partition.output.sh
@@ -77,4 +77,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_1_partition.sh
@@ -213,4 +213,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.0.sh
@@ -200,4 +200,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.1.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.10.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.10.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.11.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.11.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.12.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.12.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.13.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.13.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.14.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.14.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.15.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.15.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.16.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.16.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.17.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.17.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.18.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.18.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.19.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.19.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.2.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.2.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.3.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.3.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.4.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.4.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.5.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.5.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.6.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.6.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.7.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.7.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.8.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.8.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.9.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.9.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.output.sh
@@ -77,4 +77,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.sh
@@ -1258,4 +1258,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_20_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.0.sh
@@ -200,4 +200,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.1.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.10.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.10.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.11.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.11.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.12.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.12.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.13.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.13.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.14.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.14.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.15.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.15.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.16.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.16.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.17.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.17.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.18.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.18.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.19.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.19.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.2.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.2.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.20.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.20.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.20.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.20.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.21.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.21.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.21.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.21.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.22.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.22.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.22.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.22.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.23.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.23.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.23.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.23.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.24.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.24.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.24.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.24.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.25.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.25.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.25.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.25.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.26.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.26.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.26.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.26.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.27.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.27.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.27.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.27.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.28.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.28.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.28.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.28.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.29.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.29.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.29.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.29.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.3.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.3.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.30.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.30.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.30.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.30.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.31.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.31.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.31.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.31.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.32.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.32.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.32.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.32.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.33.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.33.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.33.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.33.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.34.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.34.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.34.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.34.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.35.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.35.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.35.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.35.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.36.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.36.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.36.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.36.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.37.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.37.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.37.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.37.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.38.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.38.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.38.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.38.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.39.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.39.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.39.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.39.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.4.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.4.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.5.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.5.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.6.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.6.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.7.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.7.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.8.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.8.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.9.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.9.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.output.sh
@@ -77,4 +77,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/all_calcs_1_output_40_partition.sh
@@ -2358,4 +2358,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/analysis_settings_1_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/analysis_settings_1_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/analysis_settings_1_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/analysis_settings_1_1_partition.0.sh
@@ -139,4 +139,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/analysis_settings_1_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/analysis_settings_1_1_partition.output.sh
@@ -71,4 +71,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/analysis_settings_1_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/analysis_settings_1_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/analysis_settings_1_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/analysis_settings_1_1_partition.sh
@@ -146,4 +146,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/analysis_settings_1_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/analysis_settings_1_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/analysis_settings_2_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/analysis_settings_2_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/analysis_settings_2_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/analysis_settings_2_1_partition.0.sh
@@ -139,4 +139,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/analysis_settings_2_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/analysis_settings_2_1_partition.output.sh
@@ -71,4 +71,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/analysis_settings_2_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/analysis_settings_2_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/analysis_settings_2_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/analysis_settings_2_1_partition.sh
@@ -146,4 +146,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/analysis_settings_2_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/analysis_settings_2_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.0.sh
@@ -250,4 +250,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.output.sh
@@ -75,4 +75,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.sh
@@ -261,4 +261,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.0.sh
@@ -252,4 +252,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.output.sh
@@ -77,4 +77,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.sh
@@ -265,4 +265,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/analysis_settings_5_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/analysis_settings_5_1_reins_layer_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/analysis_settings_5_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/analysis_settings_5_1_reins_layer_1_partition.sh
@@ -225,4 +225,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_1_partition.0.sh
@@ -119,4 +119,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_1_partition.output.sh
@@ -71,4 +71,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_1_partition.sh
@@ -126,4 +126,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.0.sh
@@ -119,4 +119,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.1.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.10.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.10.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.11.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.11.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.12.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.12.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.13.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.13.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.14.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.14.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.15.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.15.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.16.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.16.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.17.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.17.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.18.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.18.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.19.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.19.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.2.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.2.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.3.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.3.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.4.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.4.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.5.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.5.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.6.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.6.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.7.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.7.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.8.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.8.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.9.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.9.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.output.sh
@@ -71,4 +71,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_aalcalc_1_output_20_partition.sh
@@ -411,4 +411,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_1_partition.0.sh
@@ -119,4 +119,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_1_partition.output.sh
@@ -71,4 +71,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_1_partition.sh
@@ -126,4 +126,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.0.sh
@@ -119,4 +119,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.1.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.10.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.10.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.11.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.11.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.12.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.12.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.13.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.13.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.14.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.14.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.15.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.15.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.16.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.16.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.17.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.17.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.18.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.18.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.19.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.19.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.2.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.2.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.3.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.3.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.4.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.4.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.5.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.5.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.6.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.6.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.7.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.7.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.8.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.8.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.9.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.9.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.output.sh
@@ -71,4 +71,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_fu_lec_1_output_20_partition.sh
@@ -411,4 +411,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_1_partition.0.sh
@@ -119,4 +119,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_1_partition.output.sh
@@ -71,4 +71,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_1_partition.sh
@@ -126,4 +126,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.0.sh
@@ -119,4 +119,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.1.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.10.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.10.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.11.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.11.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.12.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.12.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.13.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.13.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.14.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.14.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.15.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.15.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.16.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.16.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.17.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.17.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.18.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.18.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.19.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.19.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.2.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.2.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.3.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.3.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.4.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.4.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.5.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.5.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.6.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.6.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.7.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.7.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.8.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.8.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.9.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.9.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.output.sh
@@ -71,4 +71,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_lec_1_output_20_partition.sh
@@ -411,4 +411,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.0.sh
@@ -119,4 +119,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.output.sh
@@ -71,4 +71,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.sh
@@ -126,4 +126,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.0.sh
@@ -119,4 +119,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.1.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.10.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.10.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.11.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.11.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.12.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.12.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.13.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.13.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.14.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.14.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.15.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.15.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.16.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.16.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.17.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.17.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.18.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.18.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.19.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.19.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.2.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.2.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.3.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.3.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.4.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.4.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.5.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.5.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.6.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.6.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.7.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.7.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.8.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.8.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.9.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.9.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.output.sh
@@ -71,4 +71,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.sh
@@ -411,4 +411,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_1_partition.0.sh
@@ -121,4 +121,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_1_partition.output.sh
@@ -67,4 +67,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_1_partition.sh
@@ -124,4 +124,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.0.sh
@@ -121,4 +121,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.1.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.10.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.10.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.11.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.11.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.12.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.12.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.13.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.13.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.14.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.14.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.15.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.15.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.16.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.16.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.17.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.17.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.18.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.18.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.19.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.19.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.2.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.2.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.3.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.3.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.4.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.4.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.5.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.5.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.6.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.6.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.7.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.7.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.8.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.8.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.9.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.9.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.output.sh
@@ -67,4 +67,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.sh
@@ -409,4 +409,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_eltcalc_1_output_20_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_1_output_1_partition.0.sh
@@ -200,4 +200,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_1_output_1_partition.output.sh
@@ -77,4 +77,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_1_output_1_partition.sh
@@ -213,4 +213,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_1_output_2_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_1_output_2_partition.0.sh
@@ -200,4 +200,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_1_output_2_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_1_output_2_partition.1.sh
@@ -184,4 +184,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_1_output_2_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_1_output_2_partition.output.sh
@@ -77,4 +77,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_1_output_2_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_1_output_2_partition.sh
@@ -268,4 +268,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_1_output_2_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_1_output_2_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.0.sh
@@ -260,4 +260,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.1.sh
@@ -244,4 +244,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.2.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.2.sh
@@ -244,4 +244,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.3.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.3.sh
@@ -244,4 +244,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.4.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.4.sh
@@ -244,4 +244,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.5.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.5.sh
@@ -244,4 +244,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.6.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.6.sh
@@ -244,4 +244,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.7.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.7.sh
@@ -244,4 +244,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.8.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.8.sh
@@ -244,4 +244,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.9.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.9.sh
@@ -244,4 +244,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.output.sh
@@ -85,4 +85,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_10_partition.sh
@@ -1136,4 +1136,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_1_partition.0.sh
@@ -260,4 +260,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_1_partition.output.sh
@@ -85,4 +85,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_1_partition.sh
@@ -281,4 +281,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_2_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_2_partition.0.sh
@@ -260,4 +260,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_2_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_2_partition.1.sh
@@ -244,4 +244,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_2_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_2_partition.output.sh
@@ -85,4 +85,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_2_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_2_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_2_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_lec_2_output_2_partition.sh
@@ -376,4 +376,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_1_output_1_partition.0.sh
@@ -196,4 +196,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_1_output_1_partition.output.sh
@@ -73,4 +73,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_1_output_1_partition.sh
@@ -205,4 +205,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_1_output_2_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_1_output_2_partition.0.sh
@@ -196,4 +196,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_1_output_2_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_1_output_2_partition.1.sh
@@ -180,4 +180,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_1_output_2_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_1_output_2_partition.output.sh
@@ -73,4 +73,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_1_output_2_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_1_output_2_partition.sh
@@ -260,4 +260,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_2_output_1_partition.0.sh
@@ -252,4 +252,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_2_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_2_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_2_output_1_partition.output.sh
@@ -77,4 +77,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_2_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_2_output_1_partition.sh
@@ -265,4 +265,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_2_output_2_partition.0.sh
@@ -252,4 +252,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_2_output_2_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_2_output_2_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_2_output_2_partition.1.sh
@@ -236,4 +236,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_2_output_2_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_2_output_2_partition.output.sh
@@ -77,4 +77,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_2_output_2_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_no_lec_2_output_2_partition.sh
@@ -360,4 +360,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_ord_ept_psept_2_output_10_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_ord_ept_psept_2_output_10_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_ord_ept_psept_2_output_10_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_ord_ept_psept_2_output_10_partition.sh
@@ -1136,4 +1136,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_ord_palt_output_10_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_ord_palt_output_10_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_ord_palt_output_10_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_ord_palt_output_10_partition.sh
@@ -609,4 +609,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_ord_psept_lec_1_output_10_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_ord_psept_lec_1_output_10_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_il_ord_psept_lec_1_output_10_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_il_ord_psept_lec_1_output_10_partition.sh
@@ -712,4 +712,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_lec_1_output_1_partition.0.sh
@@ -141,4 +141,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_lec_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_lec_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_lec_1_output_1_partition.output.sh
@@ -73,4 +73,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_lec_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_lec_1_output_1_partition.sh
@@ -150,4 +150,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_lec_1_output_2_partition.0.sh
@@ -141,4 +141,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_lec_1_output_2_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_lec_1_output_2_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_lec_1_output_2_partition.1.sh
@@ -133,4 +133,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_lec_1_output_2_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_lec_1_output_2_partition.output.sh
@@ -73,4 +73,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_lec_1_output_2_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_lec_1_output_2_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_lec_1_output_2_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_lec_1_output_2_partition.sh
@@ -177,4 +177,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_lec_2_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_lec_2_output_1_partition.0.sh
@@ -171,4 +171,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_lec_2_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_lec_2_output_1_partition.output.sh
@@ -77,4 +77,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_lec_2_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_lec_2_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_lec_2_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_lec_2_output_1_partition.sh
@@ -184,4 +184,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_lec_2_output_2_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_lec_2_output_2_partition.0.sh
@@ -171,4 +171,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_lec_2_output_2_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_lec_2_output_2_partition.1.sh
@@ -163,4 +163,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_lec_2_output_2_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_lec_2_output_2_partition.output.sh
@@ -77,4 +77,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_lec_2_output_2_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_lec_2_output_2_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_lec_2_output_2_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_lec_2_output_2_partition.sh
@@ -231,4 +231,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_no_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_no_lec_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_no_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_no_lec_1_output_1_partition.0.sh
@@ -139,4 +139,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_no_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_no_lec_1_output_1_partition.output.sh
@@ -71,4 +71,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_no_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_no_lec_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_no_lec_1_output_1_partition.sh
@@ -146,4 +146,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_no_lec_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_no_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_no_lec_1_output_2_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_no_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_no_lec_1_output_2_partition.0.sh
@@ -139,4 +139,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_no_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_no_lec_1_output_2_partition.1.sh
@@ -131,4 +131,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_no_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_no_lec_1_output_2_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_no_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_no_lec_1_output_2_partition.output.sh
@@ -71,4 +71,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_no_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_no_lec_1_output_2_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_no_lec_1_output_2_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_no_lec_1_output_2_partition.sh
@@ -173,4 +173,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_no_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_no_lec_2_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_no_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_no_lec_2_output_1_partition.0.sh
@@ -167,4 +167,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_no_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_no_lec_2_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_no_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_no_lec_2_output_1_partition.output.sh
@@ -73,4 +73,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_no_lec_2_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_no_lec_2_output_1_partition.sh
@@ -176,4 +176,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_no_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_no_lec_2_output_2_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_no_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_no_lec_2_output_2_partition.0.sh
@@ -167,4 +167,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_no_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_no_lec_2_output_2_partition.1.sh
@@ -159,4 +159,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_no_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_no_lec_2_output_2_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_no_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_no_lec_2_output_2_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_no_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_no_lec_2_output_2_partition.output.sh
@@ -73,4 +73,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_no_lec_2_output_2_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_no_lec_2_output_2_partition.sh
@@ -223,4 +223,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_1_partition.0.sh
@@ -119,4 +119,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_1_partition.output.sh
@@ -71,4 +71,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_1_partition.sh
@@ -126,4 +126,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.0.sh
@@ -119,4 +119,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.1.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.10.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.10.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.11.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.11.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.12.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.12.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.13.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.13.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.14.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.14.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.15.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.15.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.16.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.16.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.17.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.17.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.18.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.18.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.19.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.19.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.2.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.2.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.3.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.3.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.4.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.4.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.5.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.5.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.6.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.6.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.7.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.7.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.8.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.8.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.9.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.9.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.output.sh
@@ -71,4 +71,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_fu_lec_1_output_20_partition.sh
@@ -411,4 +411,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_1_partition.0.sh
@@ -119,4 +119,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_1_partition.output.sh
@@ -71,4 +71,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_1_partition.sh
@@ -126,4 +126,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.0.sh
@@ -119,4 +119,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.1.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.10.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.10.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.11.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.11.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.12.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.12.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.13.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.13.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.14.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.14.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.15.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.15.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.16.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.16.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.17.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.17.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.18.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.18.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.19.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.19.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.2.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.2.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.3.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.3.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.4.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.4.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.5.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.5.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.6.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.6.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.7.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.7.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.8.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.8.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.9.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.9.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.output.sh
@@ -71,4 +71,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_lec_1_output_20_partition.sh
@@ -411,4 +411,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.0.sh
@@ -119,4 +119,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.output.sh
@@ -71,4 +71,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.sh
@@ -126,4 +126,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.0.sh
@@ -119,4 +119,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.1.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.10.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.10.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.11.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.11.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.12.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.12.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.13.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.13.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.14.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.14.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.15.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.15.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.16.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.16.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.17.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.17.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.18.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.18.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.19.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.19.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.2.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.2.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.3.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.3.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.4.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.4.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.5.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.5.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.6.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.6.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.7.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.7.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.8.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.8.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.9.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.9.sh
@@ -111,4 +111,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.output.sh
@@ -71,4 +71,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.sh
@@ -411,4 +411,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_ord_ept_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_ord_ept_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_ord_ept_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_ord_ept_1_output_1_partition.sh
@@ -126,4 +126,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_ord_ept_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_ord_ept_1_output_20_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_ord_ept_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_ord_ept_1_output_20_partition.sh
@@ -411,4 +411,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_ord_ept_psept_lec_2_output_10_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_ord_ept_psept_lec_2_output_10_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_ord_ept_psept_lec_2_output_10_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_ord_ept_psept_lec_2_output_10_partition.sh
@@ -611,4 +611,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_ord_palt_output_10_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_ord_palt_output_10_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_ord_palt_output_10_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_ord_palt_output_10_partition.sh
@@ -217,4 +217,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_ord_psept_2_output_10_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_ord_psept_2_output_10_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_ord_psept_2_output_10_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_ord_psept_2_output_10_partition.sh
@@ -345,4 +345,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_1_partition.0.sh
@@ -121,4 +121,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_1_partition.output.sh
@@ -67,4 +67,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_1_partition.sh
@@ -124,4 +124,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.0.sh
@@ -121,4 +121,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.1.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.10.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.10.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.11.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.11.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.12.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.12.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.13.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.13.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.14.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.14.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.15.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.15.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.16.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.16.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.17.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.17.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.18.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.18.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.19.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.19.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.2.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.2.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.3.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.3.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.4.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.4.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.5.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.5.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.6.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.6.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.7.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.7.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.8.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.8.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.9.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.9.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.output.sh
@@ -67,4 +67,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.sh
@@ -409,4 +409,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_pltcalc_1_output_20_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_1_partition.0.sh
@@ -121,4 +121,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_1_partition.output.sh
@@ -67,4 +67,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_1_partition.sh
@@ -124,4 +124,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.0.sh
@@ -121,4 +121,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.1.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.10.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.10.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.11.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.11.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.12.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.12.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.13.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.13.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.14.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.14.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.15.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.15.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.16.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.16.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.17.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.17.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.18.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.18.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.19.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.19.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.2.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.2.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.3.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.3.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.4.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.4.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.5.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.5.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.6.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.6.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.7.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.7.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.8.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.8.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.9.sh
@@ -113,4 +113,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.9.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.output.sh
@@ -67,4 +67,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.sh
@@ -409,4 +409,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/gul_summarycalc_1_output_20_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_1_partition.0.sh
@@ -122,4 +122,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_1_partition.output.sh
@@ -71,4 +71,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_1_partition.sh
@@ -129,4 +129,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.0.sh
@@ -122,4 +122,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.1.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.10.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.10.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.11.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.11.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.12.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.12.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.13.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.13.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.14.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.14.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.15.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.15.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.16.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.16.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.17.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.17.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.18.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.18.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.19.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.19.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.2.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.2.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.3.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.3.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.4.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.4.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.5.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.5.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.6.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.6.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.7.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.7.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.8.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.8.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.9.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.9.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.output.sh
@@ -71,4 +71,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.sh
@@ -452,4 +452,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_aalcalc_1_output_20_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_1_partition.0.sh
@@ -122,4 +122,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_1_partition.output.sh
@@ -71,4 +71,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_1_partition.sh
@@ -129,4 +129,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.0.sh
@@ -122,4 +122,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.1.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.10.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.10.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.11.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.11.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.12.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.12.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.13.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.13.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.14.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.14.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.15.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.15.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.16.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.16.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.17.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.17.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.18.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.18.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.19.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.19.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.2.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.2.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.3.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.3.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.4.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.4.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.5.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.5.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.6.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.6.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.7.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.7.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.8.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.8.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.9.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.9.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.output.sh
@@ -71,4 +71,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.sh
@@ -452,4 +452,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_fu_lec_1_output_20_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.0.sh
@@ -122,4 +122,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.output.sh
@@ -71,4 +71,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.sh
@@ -129,4 +129,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.0.sh
@@ -122,4 +122,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.1.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.10.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.10.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.11.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.11.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.12.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.12.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.13.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.13.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.14.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.14.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.15.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.15.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.16.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.16.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.17.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.17.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.18.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.18.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.19.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.19.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.2.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.2.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.3.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.3.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.4.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.4.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.5.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.5.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.6.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.6.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.7.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.7.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.8.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.8.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.9.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.9.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.output.sh
@@ -71,4 +71,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.sh
@@ -452,4 +452,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_1_partition.0.sh
@@ -122,4 +122,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_1_partition.output.sh
@@ -71,4 +71,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_1_partition.sh
@@ -129,4 +129,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.0.sh
@@ -122,4 +122,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.1.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.10.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.10.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.11.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.11.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.12.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.12.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.13.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.13.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.14.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.14.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.15.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.15.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.16.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.16.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.17.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.17.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.18.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.18.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.19.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.19.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.2.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.2.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.3.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.3.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.4.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.4.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.5.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.5.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.6.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.6.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.7.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.7.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.8.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.8.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.9.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.9.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.output.sh
@@ -71,4 +71,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.sh
@@ -452,4 +452,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_lec_1_output_20_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.0.sh
@@ -122,4 +122,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.output.sh
@@ -71,4 +71,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.sh
@@ -129,4 +129,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.0.sh
@@ -122,4 +122,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.1.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.10.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.10.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.11.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.11.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.12.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.12.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.13.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.13.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.14.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.14.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.15.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.15.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.16.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.16.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.17.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.17.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.18.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.18.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.19.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.19.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.2.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.2.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.3.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.3.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.4.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.4.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.5.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.5.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.6.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.6.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.7.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.7.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.8.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.8.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.9.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.9.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.output.sh
@@ -71,4 +71,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.sh
@@ -452,4 +452,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_1_partition.0.sh
@@ -124,4 +124,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_1_partition.output.sh
@@ -67,4 +67,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_1_partition.sh
@@ -127,4 +127,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.0.sh
@@ -124,4 +124,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.1.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.10.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.10.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.11.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.11.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.12.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.12.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.13.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.13.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.14.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.14.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.15.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.15.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.16.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.16.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.17.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.17.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.18.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.18.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.19.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.19.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.2.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.2.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.3.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.3.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.4.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.4.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.5.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.5.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.6.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.6.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.7.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.7.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.8.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.8.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.9.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.9.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.output.sh
@@ -67,4 +67,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_eltcalc_1_output_20_partition.sh
@@ -450,4 +450,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_lec_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_lec_1_output_1_partition.0.sh
@@ -144,4 +144,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_lec_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_lec_1_output_1_partition.output.sh
@@ -73,4 +73,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_lec_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_lec_1_output_1_partition.sh
@@ -153,4 +153,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_lec_1_output_2_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_lec_1_output_2_partition.0.sh
@@ -144,4 +144,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_lec_1_output_2_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_lec_1_output_2_partition.1.sh
@@ -136,4 +136,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_lec_1_output_2_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_lec_1_output_2_partition.output.sh
@@ -73,4 +73,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_lec_1_output_2_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_lec_1_output_2_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_lec_1_output_2_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_lec_1_output_2_partition.sh
@@ -182,4 +182,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_lec_2_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_lec_2_output_1_partition.0.sh
@@ -174,4 +174,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_lec_2_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_lec_2_output_1_partition.output.sh
@@ -77,4 +77,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_lec_2_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_lec_2_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_lec_2_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_lec_2_output_1_partition.sh
@@ -187,4 +187,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_lec_2_output_2_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_lec_2_output_2_partition.0.sh
@@ -174,4 +174,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_lec_2_output_2_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_lec_2_output_2_partition.1.sh
@@ -166,4 +166,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_lec_2_output_2_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_lec_2_output_2_partition.output.sh
@@ -77,4 +77,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_lec_2_output_2_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_lec_2_output_2_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_lec_2_output_2_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_lec_2_output_2_partition.sh
@@ -236,4 +236,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_no_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_no_lec_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_no_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_no_lec_1_output_1_partition.0.sh
@@ -142,4 +142,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_no_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_no_lec_1_output_1_partition.output.sh
@@ -71,4 +71,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_no_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_no_lec_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_no_lec_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_no_lec_1_output_1_partition.sh
@@ -149,4 +149,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_no_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_no_lec_1_output_2_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_no_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_no_lec_1_output_2_partition.0.sh
@@ -142,4 +142,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_no_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_no_lec_1_output_2_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_no_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_no_lec_1_output_2_partition.1.sh
@@ -134,4 +134,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_no_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_no_lec_1_output_2_partition.output.sh
@@ -71,4 +71,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_no_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_no_lec_1_output_2_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_no_lec_1_output_2_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_no_lec_1_output_2_partition.sh
@@ -178,4 +178,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_no_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_no_lec_2_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_no_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_no_lec_2_output_1_partition.0.sh
@@ -170,4 +170,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_no_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_no_lec_2_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_no_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_no_lec_2_output_1_partition.output.sh
@@ -73,4 +73,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_no_lec_2_output_1_partition.sh
@@ -179,4 +179,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_no_lec_2_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_no_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_no_lec_2_output_2_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_no_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_no_lec_2_output_2_partition.0.sh
@@ -170,4 +170,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_no_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_no_lec_2_output_2_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_no_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_no_lec_2_output_2_partition.1.sh
@@ -162,4 +162,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_no_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_no_lec_2_output_2_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_no_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_no_lec_2_output_2_partition.output.sh
@@ -73,4 +73,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_no_lec_2_output_2_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_no_lec_2_output_2_partition.sh
@@ -228,4 +228,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_1_partition.0.sh
@@ -122,4 +122,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_1_partition.output.sh
@@ -71,4 +71,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_1_partition.sh
@@ -129,4 +129,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.0.sh
@@ -122,4 +122,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.1.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.10.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.10.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.11.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.11.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.12.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.12.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.13.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.13.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.14.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.14.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.15.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.15.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.16.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.16.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.17.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.17.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.18.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.18.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.19.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.19.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.2.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.2.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.3.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.3.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.4.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.4.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.5.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.5.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.6.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.6.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.7.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.7.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.8.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.8.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.9.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.9.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.output.sh
@@ -71,4 +71,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.sh
@@ -452,4 +452,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_fu_lec_1_output_20_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.0.sh
@@ -122,4 +122,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.output.sh
@@ -71,4 +71,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.sh
@@ -129,4 +129,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.0.sh
@@ -122,4 +122,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.1.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.10.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.10.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.11.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.11.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.12.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.12.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.13.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.13.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.14.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.14.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.15.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.15.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.16.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.16.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.17.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.17.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.18.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.18.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.19.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.19.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.2.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.2.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.3.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.3.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.4.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.4.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.5.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.5.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.6.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.6.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.7.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.7.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.8.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.8.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.9.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.9.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.output.sh
@@ -71,4 +71,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.sh
@@ -452,4 +452,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_1_partition.0.sh
@@ -122,4 +122,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_1_partition.output.sh
@@ -71,4 +71,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_1_partition.sh
@@ -129,4 +129,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.0.sh
@@ -122,4 +122,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.1.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.10.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.10.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.11.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.11.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.12.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.12.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.13.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.13.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.14.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.14.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.15.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.15.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.16.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.16.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.17.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.17.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.18.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.18.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.19.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.19.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.2.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.2.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.3.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.3.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.4.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.4.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.5.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.5.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.6.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.6.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.7.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.7.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.8.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.8.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.9.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.9.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.output.sh
@@ -71,4 +71,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.sh
@@ -452,4 +452,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_lec_1_output_20_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.0.sh
@@ -122,4 +122,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.output.sh
@@ -71,4 +71,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.sh
@@ -129,4 +129,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.0.sh
@@ -122,4 +122,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.1.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.10.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.10.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.11.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.11.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.12.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.12.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.13.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.13.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.14.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.14.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.15.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.15.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.16.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.16.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.17.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.17.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.18.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.18.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.19.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.19.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.2.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.2.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.3.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.3.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.4.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.4.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.5.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.5.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.6.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.6.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.7.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.7.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.8.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.8.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.9.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.9.sh
@@ -114,4 +114,3 @@ wait $pid1 $pid2 $pid3 $pid4
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.output.sh
@@ -71,4 +71,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.sh
@@ -452,4 +452,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_1_partition.0.sh
@@ -124,4 +124,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_1_partition.output.sh
@@ -67,4 +67,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_1_partition.sh
@@ -127,4 +127,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.0.sh
@@ -124,4 +124,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.1.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.10.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.10.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.11.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.11.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.12.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.12.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.13.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.13.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.14.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.14.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.15.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.15.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.16.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.16.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.17.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.17.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.18.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.18.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.19.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.19.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.2.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.2.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.3.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.3.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.4.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.4.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.5.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.5.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.6.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.6.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.7.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.7.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.8.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.8.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.9.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.9.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.output.sh
@@ -67,4 +67,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_pltcalc_1_output_20_partition.sh
@@ -450,4 +450,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_1_partition.0.sh
@@ -124,4 +124,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_1_partition.output.sh
@@ -67,4 +67,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_1_partition.sh
@@ -127,4 +127,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.0.sh
@@ -124,4 +124,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.1.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.10.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.10.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.11.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.11.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.12.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.12.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.13.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.13.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.14.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.14.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.15.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.15.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.16.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.16.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.17.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.17.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.18.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.18.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.19.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.19.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.2.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.2.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.3.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.3.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.4.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.4.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.5.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.5.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.6.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.6.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.7.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.7.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.8.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.8.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.9.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.9.sh
@@ -116,4 +116,3 @@ wait $kpid1 $kpid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.output.sh
@@ -67,4 +67,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_fc_kparse_reference/il_summarycalc_1_output_20_partition.sh
@@ -450,4 +450,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_1_partition.0.sh
@@ -137,4 +137,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_1_partition.output.sh
@@ -73,4 +73,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_1_partition.sh
@@ -146,4 +146,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.0.sh
@@ -137,4 +137,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.1.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.10.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.10.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.11.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.11.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.12.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.12.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.13.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.13.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.14.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.14.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.15.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.15.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.16.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.16.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.17.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.17.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.18.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.18.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.19.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.19.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.2.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.2.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.3.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.3.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.4.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.4.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.5.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.5.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.6.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.6.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.7.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.7.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.8.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.8.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.9.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.9.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.output.sh
@@ -73,4 +73,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_20_partition.sh
@@ -659,4 +659,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.0.sh
@@ -137,4 +137,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.1.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.10.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.10.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.11.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.11.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.12.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.12.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.13.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.13.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.14.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.14.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.15.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.15.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.16.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.16.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.17.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.17.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.18.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.18.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.19.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.19.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.2.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.2.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.20.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.20.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.20.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.20.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.21.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.21.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.21.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.21.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.22.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.22.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.22.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.22.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.23.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.23.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.23.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.23.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.24.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.24.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.24.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.24.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.25.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.25.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.25.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.25.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.26.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.26.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.26.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.26.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.27.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.27.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.27.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.27.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.28.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.28.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.28.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.28.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.29.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.29.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.29.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.29.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.3.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.3.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.30.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.30.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.30.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.30.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.31.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.31.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.31.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.31.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.32.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.32.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.32.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.32.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.33.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.33.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.33.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.33.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.34.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.34.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.34.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.34.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.35.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.35.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.35.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.35.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.36.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.36.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.36.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.36.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.37.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.37.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.37.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.37.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.38.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.38.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.38.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.38.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.39.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.39.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.39.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.39.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.4.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.4.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.5.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.5.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.6.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.6.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.7.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.7.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.8.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.8.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.9.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.9.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.output.sh
@@ -73,4 +73,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.sh
+++ b/tests/model_execution/err_kparse_reference/all_calcs_1_output_40_partition.sh
@@ -1199,4 +1199,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/analysis_settings_1_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/analysis_settings_1_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/analysis_settings_1_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/analysis_settings_1_1_partition.0.sh
@@ -108,4 +108,3 @@ wait $kpid1 $kpid2 $kpid3
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/analysis_settings_1_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/analysis_settings_1_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/analysis_settings_1_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/analysis_settings_1_1_partition.output.sh
@@ -70,4 +70,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/analysis_settings_1_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/analysis_settings_1_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/analysis_settings_1_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/analysis_settings_1_1_partition.sh
@@ -114,4 +114,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/analysis_settings_2_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/analysis_settings_2_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/analysis_settings_2_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/analysis_settings_2_1_partition.0.sh
@@ -108,4 +108,3 @@ wait $kpid1 $kpid2 $kpid3
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/analysis_settings_2_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/analysis_settings_2_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/analysis_settings_2_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/analysis_settings_2_1_partition.output.sh
@@ -70,4 +70,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/analysis_settings_2_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/analysis_settings_2_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/analysis_settings_2_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/analysis_settings_2_1_partition.sh
@@ -114,4 +114,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.0.sh
@@ -162,4 +162,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.output.sh
@@ -72,4 +72,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/analysis_settings_3_1_reins_layer_1_partition.sh
@@ -170,4 +170,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.0.sh
@@ -163,4 +163,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.output.sh
@@ -73,4 +73,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/analysis_settings_4_1_reins_layer_1_partition.sh
@@ -172,4 +172,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/analysis_settings_5_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/analysis_settings_5_1_reins_layer_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/analysis_settings_5_1_reins_layer_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/analysis_settings_5_1_reins_layer_1_partition.sh
@@ -152,4 +152,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_1_partition.0.sh
@@ -97,4 +97,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_1_partition.output.sh
@@ -70,4 +70,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_1_partition.sh
@@ -103,4 +103,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.0.sh
@@ -97,4 +97,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.1.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.10.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.10.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.11.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.11.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.12.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.12.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.13.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.13.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.14.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.14.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.15.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.15.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.16.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.16.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.17.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.17.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.18.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.18.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.19.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.19.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.2.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.2.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.3.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.3.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.4.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.4.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.5.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.5.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.6.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.6.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.7.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.7.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.8.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.8.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.9.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.9.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.output.sh
@@ -70,4 +70,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_aalcalc_1_output_20_partition.sh
@@ -255,4 +255,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_1_partition.0.sh
@@ -97,4 +97,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_1_partition.output.sh
@@ -70,4 +70,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_1_partition.sh
@@ -103,4 +103,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.0.sh
@@ -97,4 +97,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.1.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.10.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.10.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.11.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.11.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.12.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.12.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.13.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.13.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.14.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.14.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.15.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.15.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.16.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.16.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.17.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.17.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.18.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.18.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.19.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.19.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.2.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.2.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.3.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.3.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.4.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.4.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.5.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.5.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.6.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.6.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.7.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.7.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.8.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.8.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.9.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.9.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.output.sh
@@ -70,4 +70,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_fu_lec_1_output_20_partition.sh
@@ -255,4 +255,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_1_partition.0.sh
@@ -97,4 +97,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_1_partition.output.sh
@@ -70,4 +70,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_1_partition.sh
@@ -103,4 +103,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.0.sh
@@ -97,4 +97,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.1.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.10.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.10.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.11.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.11.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.12.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.12.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.13.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.13.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.14.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.14.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.15.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.15.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.16.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.16.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.17.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.17.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.18.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.18.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.19.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.19.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.2.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.2.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.3.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.3.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.4.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.4.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.5.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.5.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.6.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.6.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.7.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.7.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.8.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.8.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.9.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.9.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.output.sh
@@ -70,4 +70,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_lec_1_output_20_partition.sh
@@ -255,4 +255,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.0.sh
@@ -97,4 +97,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.output.sh
@@ -70,4 +70,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.sh
@@ -103,4 +103,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.0.sh
@@ -97,4 +97,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.1.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.10.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.10.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.11.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.11.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.12.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.12.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.13.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.13.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.14.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.14.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.15.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.15.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.16.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.16.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.17.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.17.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.18.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.18.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.19.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.19.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.2.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.2.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.3.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.3.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.4.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.4.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.5.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.5.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.6.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.6.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.7.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.7.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.8.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.8.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.9.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.9.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.output.sh
@@ -70,4 +70,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_agg_ws_mean_lec_1_output_20_partition.sh
@@ -255,4 +255,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_1_partition.0.sh
@@ -99,4 +99,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_1_partition.output.sh
@@ -67,4 +67,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_1_partition.sh
@@ -102,4 +102,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.0.sh
@@ -99,4 +99,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.1.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.10.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.10.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.11.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.11.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.12.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.12.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.13.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.13.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.14.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.14.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.15.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.15.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.16.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.16.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.17.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.17.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.18.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.18.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.19.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.19.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.2.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.2.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.3.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.3.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.4.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.4.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.5.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.5.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.6.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.6.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.7.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.7.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.8.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.8.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.9.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.9.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.output.sh
@@ -67,4 +67,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_eltcalc_1_output_20_partition.sh
@@ -254,4 +254,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_1_output_1_partition.0.sh
@@ -137,4 +137,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_1_output_1_partition.output.sh
@@ -73,4 +73,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_1_output_1_partition.sh
@@ -146,4 +146,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_1_output_2_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_1_output_2_partition.0.sh
@@ -137,4 +137,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_1_output_2_partition.1.sh
@@ -129,4 +129,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_1_output_2_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_1_output_2_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_1_output_2_partition.output.sh
@@ -73,4 +73,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_1_output_2_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_1_output_2_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_1_output_2_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_1_output_2_partition.sh
@@ -173,4 +173,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.0.sh
@@ -167,4 +167,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.1.sh
@@ -159,4 +159,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.2.sh
@@ -159,4 +159,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.2.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.3.sh
@@ -159,4 +159,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.3.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.4.sh
@@ -159,4 +159,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.4.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.5.sh
@@ -159,4 +159,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.5.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.6.sh
@@ -159,4 +159,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.6.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.7.sh
@@ -159,4 +159,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.7.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.8.sh
@@ -159,4 +159,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.8.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.9.sh
@@ -159,4 +159,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.9.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.output.sh
@@ -77,4 +77,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_10_partition.sh
@@ -603,4 +603,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_1_partition.0.sh
@@ -167,4 +167,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_1_partition.output.sh
@@ -77,4 +77,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_1_partition.sh
@@ -180,4 +180,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_2_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_2_partition.0.sh
@@ -167,4 +167,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_2_partition.1.sh
@@ -159,4 +159,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_2_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_2_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_2_partition.output.sh
@@ -77,4 +77,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_2_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_2_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_2_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_lec_2_output_2_partition.sh
@@ -227,4 +227,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_il_no_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_no_lec_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_il_no_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_no_lec_1_output_1_partition.0.sh
@@ -135,4 +135,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_il_no_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_no_lec_1_output_1_partition.output.sh
@@ -71,4 +71,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_il_no_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_no_lec_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_il_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_no_lec_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_il_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_no_lec_1_output_1_partition.sh
@@ -142,4 +142,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_il_no_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_no_lec_1_output_2_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_il_no_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_no_lec_1_output_2_partition.0.sh
@@ -135,4 +135,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_il_no_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_no_lec_1_output_2_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_il_no_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_no_lec_1_output_2_partition.1.sh
@@ -127,4 +127,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_il_no_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_no_lec_1_output_2_partition.output.sh
@@ -71,4 +71,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_il_no_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_no_lec_1_output_2_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_il_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_no_lec_1_output_2_partition.sh
@@ -169,4 +169,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_il_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_no_lec_1_output_2_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_il_no_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_no_lec_2_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_il_no_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_no_lec_2_output_1_partition.0.sh
@@ -163,4 +163,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_il_no_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_no_lec_2_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_il_no_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_no_lec_2_output_1_partition.output.sh
@@ -73,4 +73,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_il_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_no_lec_2_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_il_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_no_lec_2_output_1_partition.sh
@@ -172,4 +172,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_il_no_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_no_lec_2_output_2_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_il_no_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_no_lec_2_output_2_partition.0.sh
@@ -163,4 +163,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_il_no_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_no_lec_2_output_2_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_il_no_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_no_lec_2_output_2_partition.1.sh
@@ -155,4 +155,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6 $kpid7 $kpid8 $kpid9 $kpid10 $kpi
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_il_no_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_no_lec_2_output_2_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_il_no_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_no_lec_2_output_2_partition.output.sh
@@ -73,4 +73,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_il_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_no_lec_2_output_2_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_il_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_no_lec_2_output_2_partition.sh
@@ -219,4 +219,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_il_ord_ept_psept_2_output_10_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_ord_ept_psept_2_output_10_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_il_ord_ept_psept_2_output_10_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_ord_ept_psept_2_output_10_partition.sh
@@ -603,4 +603,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_il_ord_palt_output_10_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_ord_palt_output_10_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_il_ord_palt_output_10_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_ord_palt_output_10_partition.sh
@@ -609,4 +609,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_il_ord_psept_lec_1_output_10_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_ord_psept_lec_1_output_10_partition.sh
@@ -391,4 +391,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_il_ord_psept_lec_1_output_10_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_il_ord_psept_lec_1_output_10_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_lec_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_lec_1_output_1_partition.0.sh
@@ -109,4 +109,3 @@ wait $kpid1 $kpid2 $kpid3
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_lec_1_output_1_partition.output.sh
@@ -71,4 +71,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_lec_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_lec_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_lec_1_output_1_partition.sh
@@ -116,4 +116,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_lec_1_output_2_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_lec_1_output_2_partition.0.sh
@@ -109,4 +109,3 @@ wait $kpid1 $kpid2 $kpid3
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_lec_1_output_2_partition.1.sh
@@ -105,4 +105,3 @@ wait $kpid1 $kpid2 $kpid3
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_lec_1_output_2_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_lec_1_output_2_partition.output.sh
@@ -71,4 +71,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_lec_1_output_2_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_lec_1_output_2_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_lec_1_output_2_partition.sh
@@ -130,4 +130,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_lec_1_output_2_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_lec_1_output_2_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_lec_2_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_lec_2_output_1_partition.0.sh
@@ -124,4 +124,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_lec_2_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_lec_2_output_1_partition.output.sh
@@ -73,4 +73,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_lec_2_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_lec_2_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_lec_2_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_lec_2_output_1_partition.sh
@@ -133,4 +133,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_lec_2_output_2_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_lec_2_output_2_partition.0.sh
@@ -124,4 +124,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_lec_2_output_2_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_lec_2_output_2_partition.1.sh
@@ -120,4 +120,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_lec_2_output_2_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_lec_2_output_2_partition.output.sh
@@ -73,4 +73,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_lec_2_output_2_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_lec_2_output_2_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_lec_2_output_2_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_lec_2_output_2_partition.sh
@@ -157,4 +157,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_no_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_no_lec_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_no_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_no_lec_1_output_1_partition.0.sh
@@ -108,4 +108,3 @@ wait $kpid1 $kpid2 $kpid3
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_no_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_no_lec_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_no_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_no_lec_1_output_1_partition.output.sh
@@ -70,4 +70,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_no_lec_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_no_lec_1_output_1_partition.sh
@@ -114,4 +114,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_no_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_no_lec_1_output_2_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_no_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_no_lec_1_output_2_partition.0.sh
@@ -108,4 +108,3 @@ wait $kpid1 $kpid2 $kpid3
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_no_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_no_lec_1_output_2_partition.1.sh
@@ -104,4 +104,3 @@ wait $kpid1 $kpid2 $kpid3
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_no_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_no_lec_1_output_2_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_no_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_no_lec_1_output_2_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_no_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_no_lec_1_output_2_partition.output.sh
@@ -70,4 +70,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_no_lec_1_output_2_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_no_lec_1_output_2_partition.sh
@@ -128,4 +128,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_no_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_no_lec_2_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_no_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_no_lec_2_output_1_partition.0.sh
@@ -122,4 +122,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_no_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_no_lec_2_output_1_partition.output.sh
@@ -71,4 +71,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_no_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_no_lec_2_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_no_lec_2_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_no_lec_2_output_1_partition.sh
@@ -129,4 +129,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_no_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_no_lec_2_output_2_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_no_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_no_lec_2_output_2_partition.0.sh
@@ -122,4 +122,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_no_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_no_lec_2_output_2_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_no_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_no_lec_2_output_2_partition.1.sh
@@ -118,4 +118,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_no_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_no_lec_2_output_2_partition.output.sh
@@ -71,4 +71,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_no_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_no_lec_2_output_2_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_no_lec_2_output_2_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_no_lec_2_output_2_partition.sh
@@ -153,4 +153,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_1_partition.0.sh
@@ -97,4 +97,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_1_partition.output.sh
@@ -70,4 +70,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_1_partition.sh
@@ -103,4 +103,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.0.sh
@@ -97,4 +97,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.1.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.10.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.10.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.11.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.11.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.12.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.12.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.13.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.13.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.14.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.14.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.15.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.15.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.16.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.16.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.17.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.17.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.18.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.18.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.19.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.19.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.2.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.2.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.3.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.3.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.4.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.4.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.5.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.5.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.6.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.6.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.7.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.7.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.8.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.8.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.9.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.9.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.output.sh
@@ -70,4 +70,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_fu_lec_1_output_20_partition.sh
@@ -255,4 +255,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_1_partition.0.sh
@@ -97,4 +97,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_1_partition.output.sh
@@ -70,4 +70,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_1_partition.sh
@@ -103,4 +103,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.0.sh
@@ -97,4 +97,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.1.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.10.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.10.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.11.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.11.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.12.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.12.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.13.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.13.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.14.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.14.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.15.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.15.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.16.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.16.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.17.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.17.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.18.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.18.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.19.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.19.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.2.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.2.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.3.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.3.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.4.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.4.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.5.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.5.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.6.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.6.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.7.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.7.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.8.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.8.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.9.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.9.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.output.sh
@@ -70,4 +70,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_lec_1_output_20_partition.sh
@@ -255,4 +255,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.0.sh
@@ -97,4 +97,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.output.sh
@@ -70,4 +70,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.sh
@@ -103,4 +103,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.0.sh
@@ -97,4 +97,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.1.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.10.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.10.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.11.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.11.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.12.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.12.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.13.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.13.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.14.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.14.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.15.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.15.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.16.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.16.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.17.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.17.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.18.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.18.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.19.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.19.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.2.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.2.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.3.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.3.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.4.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.4.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.5.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.5.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.6.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.6.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.7.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.7.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.8.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.8.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.9.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.9.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.output.sh
@@ -70,4 +70,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_occ_ws_mean_lec_1_output_20_partition.sh
@@ -255,4 +255,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_ord_ept_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_ord_ept_1_output_1_partition.sh
@@ -103,4 +103,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_ord_ept_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_ord_ept_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_ord_ept_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_ord_ept_1_output_20_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_ord_ept_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_ord_ept_1_output_20_partition.sh
@@ -255,4 +255,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_ord_ept_psept_lec_2_output_10_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_ord_ept_psept_lec_2_output_10_partition.sh
@@ -351,4 +351,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_ord_ept_psept_lec_2_output_10_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_ord_ept_psept_lec_2_output_10_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_ord_palt_output_10_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_ord_palt_output_10_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_ord_palt_output_10_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_ord_palt_output_10_partition.sh
@@ -217,4 +217,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_ord_psept_2_output_10_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_ord_psept_2_output_10_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_ord_psept_2_output_10_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_ord_psept_2_output_10_partition.sh
@@ -217,4 +217,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_1_partition.0.sh
@@ -99,4 +99,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_1_partition.output.sh
@@ -67,4 +67,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_1_partition.sh
@@ -102,4 +102,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.0.sh
@@ -99,4 +99,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.1.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.10.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.10.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.11.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.11.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.12.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.12.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.13.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.13.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.14.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.14.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.15.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.15.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.16.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.16.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.17.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.17.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.18.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.18.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.19.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.19.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.2.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.2.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.3.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.3.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.4.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.4.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.5.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.5.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.6.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.6.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.7.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.7.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.8.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.8.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.9.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.9.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.output.sh
@@ -67,4 +67,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_pltcalc_1_output_20_partition.sh
@@ -254,4 +254,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_1_partition.0.sh
@@ -99,4 +99,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_1_partition.output.sh
@@ -67,4 +67,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_1_partition.sh
@@ -102,4 +102,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.0.sh
@@ -99,4 +99,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.1.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.10.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.10.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.11.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.11.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.12.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.12.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.13.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.13.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.14.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.14.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.15.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.15.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.16.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.16.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.17.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.17.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.18.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.18.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.19.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.19.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.2.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.2.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.3.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.3.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.4.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.4.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.5.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.5.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.6.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.6.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.7.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.7.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.8.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.8.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.9.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.9.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.output.sh
@@ -67,4 +67,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/gul_summarycalc_1_output_20_partition.sh
@@ -254,4 +254,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_1_partition.0.sh
@@ -97,4 +97,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_1_partition.output.sh
@@ -70,4 +70,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_1_partition.sh
@@ -103,4 +103,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.0.sh
@@ -97,4 +97,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.1.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.10.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.10.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.11.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.11.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.12.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.12.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.13.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.13.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.14.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.14.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.15.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.15.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.16.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.16.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.17.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.17.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.18.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.18.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.19.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.19.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.2.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.2.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.3.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.3.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.4.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.4.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.5.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.5.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.6.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.6.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.7.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.7.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.8.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.8.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.9.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.9.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.output.sh
@@ -70,4 +70,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_aalcalc_1_output_20_partition.sh
@@ -255,4 +255,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_1_partition.0.sh
@@ -97,4 +97,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_1_partition.output.sh
@@ -70,4 +70,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_1_partition.sh
@@ -103,4 +103,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.0.sh
@@ -97,4 +97,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.1.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.10.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.10.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.11.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.11.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.12.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.12.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.13.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.13.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.14.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.14.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.15.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.15.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.16.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.16.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.17.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.17.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.18.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.18.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.19.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.19.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.2.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.2.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.3.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.3.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.4.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.4.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.5.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.5.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.6.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.6.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.7.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.7.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.8.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.8.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.9.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.9.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.output.sh
@@ -70,4 +70,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_fu_lec_1_output_20_partition.sh
@@ -255,4 +255,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.0.sh
@@ -97,4 +97,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.output.sh
@@ -70,4 +70,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.sh
@@ -103,4 +103,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.0.sh
@@ -97,4 +97,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.1.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.10.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.10.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.11.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.11.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.12.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.12.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.13.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.13.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.14.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.14.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.15.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.15.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.16.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.16.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.17.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.17.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.18.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.18.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.19.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.19.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.2.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.2.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.3.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.3.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.4.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.4.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.5.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.5.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.6.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.6.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.7.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.7.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.8.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.8.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.9.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.9.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.output.sh
@@ -70,4 +70,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_sample_mean_lec_1_output_20_partition.sh
@@ -255,4 +255,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_1_partition.0.sh
@@ -97,4 +97,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_1_partition.output.sh
@@ -70,4 +70,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_1_partition.sh
@@ -103,4 +103,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.0.sh
@@ -97,4 +97,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.1.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.10.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.10.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.11.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.11.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.12.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.12.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.13.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.13.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.14.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.14.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.15.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.15.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.16.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.16.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.17.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.17.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.18.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.18.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.19.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.19.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.2.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.2.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.3.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.3.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.4.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.4.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.5.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.5.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.6.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.6.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.7.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.7.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.8.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.8.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.9.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.9.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.output.sh
@@ -70,4 +70,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_lec_1_output_20_partition.sh
@@ -255,4 +255,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.0.sh
@@ -97,4 +97,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.output.sh
@@ -70,4 +70,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.sh
@@ -103,4 +103,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.0.sh
@@ -97,4 +97,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.1.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.10.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.10.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.11.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.11.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.12.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.12.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.13.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.13.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.14.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.14.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.15.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.15.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.16.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.16.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.17.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.17.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.18.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.18.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.19.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.19.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.2.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.2.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.3.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.3.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.4.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.4.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.5.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.5.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.6.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.6.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.7.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.7.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.8.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.8.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.9.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.9.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.output.sh
@@ -70,4 +70,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_agg_ws_mean_lec_1_output_20_partition.sh
@@ -255,4 +255,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_1_partition.0.sh
@@ -99,4 +99,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_1_partition.output.sh
@@ -67,4 +67,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_1_partition.sh
@@ -102,4 +102,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.0.sh
@@ -99,4 +99,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.1.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.10.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.10.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.11.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.11.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.12.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.12.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.13.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.13.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.14.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.14.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.15.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.15.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.16.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.16.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.17.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.17.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.18.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.18.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.19.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.19.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.2.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.2.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.3.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.3.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.4.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.4.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.5.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.5.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.6.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.6.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.7.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.7.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.8.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.8.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.9.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.9.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.output.sh
@@ -67,4 +67,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_eltcalc_1_output_20_partition.sh
@@ -254,4 +254,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_lec_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_lec_1_output_1_partition.0.sh
@@ -109,4 +109,3 @@ wait $kpid1 $kpid2 $kpid3
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_lec_1_output_1_partition.output.sh
@@ -71,4 +71,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_lec_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_lec_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_lec_1_output_1_partition.sh
@@ -116,4 +116,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_lec_1_output_2_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_lec_1_output_2_partition.0.sh
@@ -109,4 +109,3 @@ wait $kpid1 $kpid2 $kpid3
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/il_lec_1_output_2_partition.1.sh
@@ -105,4 +105,3 @@ wait $kpid1 $kpid2 $kpid3
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/il_lec_1_output_2_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_lec_1_output_2_partition.output.sh
@@ -71,4 +71,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_lec_1_output_2_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_lec_1_output_2_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_lec_1_output_2_partition.sh
@@ -130,4 +130,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_lec_1_output_2_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_lec_1_output_2_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_lec_2_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_lec_2_output_1_partition.0.sh
@@ -124,4 +124,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_lec_2_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_lec_2_output_1_partition.output.sh
@@ -73,4 +73,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_lec_2_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_lec_2_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_lec_2_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_lec_2_output_1_partition.sh
@@ -133,4 +133,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_lec_2_output_2_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_lec_2_output_2_partition.0.sh
@@ -124,4 +124,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/il_lec_2_output_2_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/il_lec_2_output_2_partition.1.sh
@@ -120,4 +120,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_lec_2_output_2_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_lec_2_output_2_partition.output.sh
@@ -73,4 +73,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_lec_2_output_2_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_lec_2_output_2_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_lec_2_output_2_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_lec_2_output_2_partition.sh
@@ -157,4 +157,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_no_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_no_lec_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_no_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_no_lec_1_output_1_partition.0.sh
@@ -108,4 +108,3 @@ wait $kpid1 $kpid2 $kpid3
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_no_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_no_lec_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_no_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_no_lec_1_output_1_partition.output.sh
@@ -70,4 +70,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_no_lec_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_no_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_no_lec_1_output_1_partition.sh
@@ -114,4 +114,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_no_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_no_lec_1_output_2_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_no_lec_1_output_2_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_no_lec_1_output_2_partition.0.sh
@@ -108,4 +108,3 @@ wait $kpid1 $kpid2 $kpid3
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_no_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/il_no_lec_1_output_2_partition.1.sh
@@ -104,4 +104,3 @@ wait $kpid1 $kpid2 $kpid3
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_no_lec_1_output_2_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/il_no_lec_1_output_2_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_no_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_no_lec_1_output_2_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_no_lec_1_output_2_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_no_lec_1_output_2_partition.output.sh
@@ -70,4 +70,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_no_lec_1_output_2_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_no_lec_1_output_2_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_no_lec_1_output_2_partition.sh
@@ -128,4 +128,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_no_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_no_lec_2_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_no_lec_2_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_no_lec_2_output_1_partition.0.sh
@@ -122,4 +122,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_no_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_no_lec_2_output_1_partition.output.sh
@@ -71,4 +71,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_no_lec_2_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_no_lec_2_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_no_lec_2_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_no_lec_2_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_no_lec_2_output_1_partition.sh
@@ -129,4 +129,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_no_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_no_lec_2_output_2_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_no_lec_2_output_2_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_no_lec_2_output_2_partition.0.sh
@@ -122,4 +122,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_no_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/il_no_lec_2_output_2_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_no_lec_2_output_2_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/il_no_lec_2_output_2_partition.1.sh
@@ -118,4 +118,3 @@ wait $kpid1 $kpid2 $kpid3 $kpid4 $kpid5 $kpid6
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_no_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_no_lec_2_output_2_partition.output.sh
@@ -71,4 +71,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_no_lec_2_output_2_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_no_lec_2_output_2_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_no_lec_2_output_2_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_no_lec_2_output_2_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_no_lec_2_output_2_partition.sh
@@ -153,4 +153,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_1_partition.0.sh
@@ -97,4 +97,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_1_partition.output.sh
@@ -70,4 +70,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_1_partition.sh
@@ -103,4 +103,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.0.sh
@@ -97,4 +97,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.1.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.10.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.10.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.11.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.11.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.12.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.12.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.13.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.13.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.14.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.14.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.15.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.15.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.16.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.16.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.17.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.17.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.18.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.18.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.19.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.19.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.2.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.2.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.3.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.3.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.4.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.4.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.5.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.5.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.6.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.6.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.7.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.7.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.8.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.8.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.9.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.9.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.output.sh
@@ -70,4 +70,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_fu_lec_1_output_20_partition.sh
@@ -255,4 +255,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.0.sh
@@ -97,4 +97,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.output.sh
@@ -70,4 +70,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.sh
@@ -103,4 +103,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.0.sh
@@ -97,4 +97,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.1.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.10.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.10.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.11.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.11.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.12.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.12.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.13.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.13.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.14.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.14.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.15.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.15.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.16.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.16.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.17.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.17.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.18.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.18.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.19.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.19.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.2.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.2.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.3.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.3.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.4.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.4.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.5.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.5.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.6.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.6.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.7.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.7.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.8.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.8.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.9.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.9.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.output.sh
@@ -70,4 +70,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_sample_mean_lec_1_output_20_partition.sh
@@ -255,4 +255,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_1_partition.0.sh
@@ -97,4 +97,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_1_partition.output.sh
@@ -70,4 +70,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_1_partition.sh
@@ -103,4 +103,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.0.sh
@@ -97,4 +97,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.1.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.10.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.10.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.11.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.11.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.12.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.12.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.13.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.13.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.14.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.14.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.15.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.15.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.16.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.16.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.17.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.17.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.18.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.18.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.19.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.19.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.2.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.2.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.3.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.3.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.4.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.4.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.5.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.5.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.6.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.6.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.7.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.7.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.8.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.8.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.9.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.9.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.output.sh
@@ -70,4 +70,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_lec_1_output_20_partition.sh
@@ -255,4 +255,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.0.sh
@@ -97,4 +97,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.output.sh
@@ -70,4 +70,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.sh
@@ -103,4 +103,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.0.sh
@@ -97,4 +97,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.1.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.10.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.10.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.11.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.11.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.12.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.12.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.13.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.13.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.14.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.14.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.15.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.15.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.16.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.16.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.17.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.17.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.18.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.18.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.19.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.19.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.2.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.2.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.3.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.3.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.4.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.4.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.5.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.5.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.6.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.6.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.7.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.7.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.8.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.8.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.9.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.9.sh
@@ -93,4 +93,3 @@ wait $pid1 $pid2
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.output.sh
@@ -70,4 +70,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_occ_ws_mean_lec_1_output_20_partition.sh
@@ -255,4 +255,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_1_partition.0.sh
@@ -99,4 +99,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_1_partition.output.sh
@@ -67,4 +67,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_1_partition.sh
@@ -102,4 +102,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.0.sh
@@ -99,4 +99,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.1.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.10.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.10.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.11.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.11.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.12.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.12.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.13.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.13.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.14.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.14.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.15.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.15.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.16.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.16.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.17.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.17.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.18.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.18.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.19.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.19.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.2.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.2.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.3.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.3.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.4.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.4.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.5.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.5.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.6.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.6.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.7.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.7.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.8.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.8.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.9.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.9.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.output.sh
@@ -67,4 +67,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_pltcalc_1_output_20_partition.sh
@@ -254,4 +254,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_1_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_1_partition.0.sh
@@ -99,4 +99,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_1_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_1_partition.output.sh
@@ -67,4 +67,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_1_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_1_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_1_partition.sh
@@ -102,4 +102,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.0.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.0.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.0.sh
@@ -99,4 +99,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.1.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.1.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.1.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.10.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.10.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.10.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.11.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.11.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.11.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.12.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.12.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.12.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.13.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.13.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.13.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.14.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.14.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.14.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.15.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.15.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.15.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.16.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.16.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.16.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.17.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.17.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.17.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.18.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.18.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.18.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.19.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.19.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.19.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.2.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.2.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.2.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.3.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.3.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.3.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.4.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.4.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.4.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.5.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.5.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.5.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.6.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.6.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.6.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.7.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.7.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.7.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.8.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.8.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.8.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.9.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.9.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.9.sh
@@ -95,4 +95,3 @@ wait $kpid1
 
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.output.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.output.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.output.sh
@@ -67,4 +67,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.sh
@@ -14,6 +14,10 @@ ktools_monitor.sh $$ & pid0=$!
 
 exit_handler(){
    exit_code=$?
+
+   # disable handler
+   trap - QUIT HUP INT KILL TERM ERR EXIT
+
    kill -9 $pid0 2> /dev/null
    if [ "$exit_code" -gt 0 ]; then
        # Error - run process clean up

--- a/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.sh
+++ b/tests/model_execution/err_kparse_reference/il_summarycalc_1_output_20_partition.sh
@@ -254,4 +254,3 @@ rm -R -f work/*
 rm -R -f fifo/*
 
 check_complete
-exit_handler


### PR DESCRIPTION
<!--start_release_notes-->
### Fix for ktools script
* Successful runs were intermittently marked as failed by an issue in the bash `exit_handler`

<!--end_release_notes-->
