### PR TITLE
Prevent memory blowup when grouping categoricals

### DIFF
--- a/oasislmf/preparation/reinsurance_layer.py
+++ b/oasislmf/preparation/reinsurance_layer.py
@@ -603,7 +603,7 @@ class ReinsuranceLayer(object):
         )
         ri_df['layer_id'] = 0
         ri_df.columns = ri_df.columns.str.lower()
-        ri_df.loc[ri_df['reinstype'] == oed.REINS_TYPE_FAC, 'layer_id'] = ri_df.loc[ri_df['reinstype'] == oed.REINS_TYPE_FAC].groupby(fields).cumcount() + 1
+        ri_df.loc[ri_df['reinstype'] == oed.REINS_TYPE_FAC, 'layer_id'] = ri_df.loc[ri_df['reinstype'] == oed.REINS_TYPE_FAC].groupby(fields, observed=True).cumcount() + 1
         ri_info_no_fac = self.ri_info_df[self.ri_info_df['ReinsType'] != oed.REINS_TYPE_FAC].reset_index(drop=True)
         ri_info_no_fac.columns = ri_info_no_fac.columns.str.lower()
         ri_info_no_fac['layer_id'] = ri_info_no_fac.index + 1 + ri_df['layer_id'].max()

--- a/oasislmf/preparation/summaries.py
+++ b/oasislmf/preparation/summaries.py
@@ -207,7 +207,7 @@ def group_by_oed(oed_col_group, summary_map_df, exposure_df, sort_by, accounts_d
     fill_na_with_categoricals(summary_group_df, 0)
     summary_group_df.sort_values(by=[sort_by], inplace=True)
     summary_ids = factorize_dataframe(summary_group_df, by_col_labels=oed_cols)
-    summary_tiv = summary_group_df.drop_duplicates(['loc_id', 'coverage_type_id'] + oed_col_group, keep='first').groupby(oed_col_group).agg({'tiv': np.sum})
+    summary_tiv = summary_group_df.drop_duplicates(['loc_id', 'coverage_type_id'] + oed_col_group, keep='first').groupby(oed_col_group, observed=True).agg({'tiv': np.sum})
 
     return summary_ids[0], summary_ids[1], summary_tiv
 


### PR DESCRIPTION
<!--start_release_notes-->
### Fix for memory blowup when grouping categorical data 
Added `observed=True` to pandas groupby calls in file generation, from PR https://github.com/OasisLMF/OasisLMF/pull/990
<!--end_release_notes-->
