### PR TITLE
Bugfix: `--random-generator` and `--logging-level` should be parsed as `int` and not as `list` in `gulpy` CLI

### DIFF
--- a/oasislmf/pytools/gulpy.py
+++ b/oasislmf/pytools/gulpy.py
@@ -11,7 +11,7 @@ parser = argparse.ArgumentParser(
     formatter_class=argparse.RawTextHelpFormatter  # for multi-line help text
 )
 
-parser.add_argument('-a', help='back-allocation rule', default=0, choices=(0, 1, 2), type=int, dest='alloc_rule')
+parser.add_argument('-a', help='back-allocation rule', default=0, type=int, dest='alloc_rule')
 parser.add_argument('-d', help='output random numbers instead of gul (default: False).',
                     default=False, action='store_true', dest='debug')
 # parser.add_argument('-i', help='filename of items output', action='store', type=str, dest='items_outfile')
@@ -25,11 +25,11 @@ parser.add_argument('--file-in', action='store', type=str,)
 parser.add_argument('--ignore-file-type', nargs='*', help='the type of file to be loaded', default=set())
 parser.add_argument('--random-generator',
                     help='random number generator\n0: numpy default (MT19937), 1: Latin Hypercube. Default: 1.',
-                    default=1, nargs=1, choices=(0, 1), type=int)
+                    default=1, type=int)
 parser.add_argument('--run-dir', help='path to the run directory', default='.')
 parser.add_argument('--logging-level',
                     help='logging level (debug:10, info:20, warning:30, error:40, critical:50). Default: 30.',
-                    default=30, nargs=1, choices=(10, 20, 30, 40, 50), type=int)
+                    default=30, type=int)
 
 
 def main():


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->
I've found that using `nargs` in the argument definition parses an argument into a list, which breaks the subsequent code that needs a single `int`.
This PR solves these errors:
```bash
eve 1 1 | getmodel | gulpy -a0 -S0 --random-generator=1 --logging-level=10
Traceback (most recent call last):
  File "/home/mtazzari/envs/oasis/bin/gulpy", line 11, in <module>
    load_entry_point('oasislmf', 'console_scripts', 'gulpy')()
  File "/home/mtazzari/repos/OasisLMF/oasislmf/pytools/gulpy.py", line 47, in main
    logger.setLevel(logging_level)
  File "/usr/lib/python3.8/logging/__init__.py", line 1421, in setLevel
    self.level = _checkLevel(level)
  File "/usr/lib/python3.8/logging/__init__.py", line 201, in _checkLevel
    raise TypeError("Level not an integer or a valid string: %r" % level)
TypeError: Level not an integer or a valid string: [10]
^C
```
and
```bash
eve 1 1 | getmodel | gulpy -a0 -S0 --random-generator=1 
Traceback (most recent call last):
  File "/home/mtazzari/envs/oasis/bin/gulpy", line 11, in <module>
    load_entry_point('oasislmf', 'console_scripts', 'gulpy')()
  File "/home/mtazzari/repos/OasisLMF/oasislmf/pytools/gulpy.py", line 49, in main
    manager.run(**kwargs)
  File "/home/mtazzari/repos/OasisLMF/oasislmf/pytools/gul/manager.py", line 231, in run
    generate_rndm = get_random_generator(random_generator)
  File "/home/mtazzari/repos/OasisLMF/oasislmf/pytools/gul/random.py", line 33, in get_random_generator
    raise ValueError(f"No random generator exists for random_generator={random_generator}.")
ValueError: No random generator exists for random_generator=[1].
^C


```

I also tried `choices` to do some argument validation, but I consider that to be tested so this PR drops its usage in the few cases where I added it.


<!--start_release_notes-->
<!--end_release_notes-->
