### PR TITLE
Add fix for complex model wrapper calls

### DIFF
--- a/oasislmf/computation/generate/losses.py
+++ b/oasislmf/computation/generate/losses.py
@@ -292,7 +292,7 @@ class GenerateLossesPartial(GenerateLossesDir):
         if os.path.isfile(self.script_fp):
             os.remove(self.script_fp)
 
-        bash_params = model_runner_module.bash_params(
+        bash_params = bash.bash_params(
             analysis_settings,
             number_of_processes=self.ktools_num_processes,
             filename=self.script_fp,
@@ -365,7 +365,7 @@ class GenerateLossesOutput(GenerateLossesDir):
         if os.path.isfile(self.script_fp):
             os.remove(self.script_fp)
 
-        bash_params = model_runner_module.bash_params(
+        bash_params = bash.bash_params(
             analysis_settings,
             number_of_processes=self.ktools_num_processes,
             num_reinsurance_iterations=ri_layers,

--- a/oasislmf/execution/bash.py
+++ b/oasislmf/execution/bash.py
@@ -1,13 +1,14 @@
-import copy
 import contextlib
+import copy
 import io
+import logging
+import multiprocessing
 import os
 import pandas as pd
 import random
 import re
-import multiprocessing
+import shutil
 import string
-import logging
 from functools import partial
 logger = logging.getLogger()
 

--- a/oasislmf/execution/bash.py
+++ b/oasislmf/execution/bash.py
@@ -1113,7 +1113,6 @@ def get_getmodel_itm_cmd(
 
     if not gulpy:
         # append this arg only if gulcalc is used
-        item_output = '-{}'.format(item_output)
         cmd = '{} -i {}'.format(cmd, item_output)
     else:
         cmd = '{} {}'.format(cmd, item_output)
@@ -1152,7 +1151,7 @@ def get_getmodel_cov_cmd(
     """
 
     cmd = f'eve {eve_shuffle_flag}{process_id} {max_process_id} | {get_modelcmd(modelpy, modelpy_server)} | {get_gulcmd(gulpy)} -S{number_of_samples} -L{gul_threshold}'
-    
+
 
     if use_random_number_file:
         if not gulpy:
@@ -1819,10 +1818,10 @@ def create_bash_analysis(
         if gul_item_stream:
             if need_summary_fifo_for_gul:
                 getmodel_args['coverage_output'] = ''
-                getmodel_args['item_output'] = f' | tee {gul_fifo_name}'
+                getmodel_args['item_output'] = '{} | tee {}'.format('-' * (not gulpy), gul_fifo_name)
             else:
                 getmodel_args['coverage_output'] = ''
-                getmodel_args['item_output'] = ''
+                getmodel_args['item_output'] = '-' * (not gulpy)
             _get_getmodel_cmd = (_get_getmodel_cmd or get_getmodel_itm_cmd)
         else:
             if need_summary_fifo_for_gul:

--- a/oasislmf/execution/runner.py
+++ b/oasislmf/execution/runner.py
@@ -21,6 +21,7 @@ def run(analysis_settings,
         gul_legacy_stream=False,
         run_debug=False,
         custom_gulcalc_cmd=None,
+        custom_get_getmodel_cmd=None, 
         filename='run_ktools.sh',
         **kwargs
 ):
@@ -50,35 +51,36 @@ def run(analysis_settings,
 
     # TODO: should be integrated into bash.py
     if custom_gulcalc_cmd:
-        def custom_get_getmodel_cmd(
-            number_of_samples,
-            gul_threshold,
-            use_random_number_file,
-            coverage_output,
-            item_output,
-            process_id,
-            max_process_id,
-            gul_alloc_rule,
-            stderr_guard,
-            **kwargs
-        ):
-
-            cmd = "{} -e {} {} -a {} -p {}".format(
-                custom_gulcalc_cmd,
+        if not custom_get_getmodel_cmd:
+            def custom_get_getmodel_cmd(
+                number_of_samples,
+                gul_threshold,
+                use_random_number_file,
+                coverage_output,
+                item_output,
                 process_id,
                 max_process_id,
-                os.path.abspath("analysis_settings.json"),
-                "input")
-            if gul_legacy_stream and coverage_output != '':
-                cmd = '{} -c {}'.format(cmd, coverage_output)
-            if item_output != '':
-                cmd = '{} -i {}'.format(cmd, item_output)
-            if stderr_guard:
-                cmd = '({}) 2>> log/gul_stderror.err'.format(cmd)
+                gul_alloc_rule,
+                stderr_guard,
+                **kwargs
+            ):
 
-            return cmd
-    else:
-        custom_get_getmodel_cmd = None
+                cmd = "{} -e {} {} -a {} -p {}".format(
+                    custom_gulcalc_cmd,
+                    process_id,
+                    max_process_id,
+                    os.path.abspath("analysis_settings.json"),
+                    "input")
+                if gul_legacy_stream and coverage_output != '':
+                    cmd = '{} -c {}'.format(cmd, coverage_output)
+                if item_output != '':
+                    cmd = '{} -i {}'.format(cmd, item_output)
+                if stderr_guard:
+                    cmd = '({}) 2>> log/gul_stderror.err'.format(cmd)
+
+                return cmd
+        else:
+            custom_get_getmodel_cmd = None
 
     ###########################################################
 


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!--start_release_notes-->
### Fix for complex model command
Analysis loss chunks now generated correctly and added a check in case the `custom_get_getmodel_cmd` is set as a kwarg

**Example supplier_model_runner.py**
```
from oasislmf.execution.runner import run as oasislmf_run
from oasislmf.execution.runner import run_analysis as oasislmf_run_analysis_chunk
from oasislmf.execution.runner import run_outputs

CUSTOM_GULCALC_CMD = "CustomGulCalcBinary"
def custom_get_getmodel_cmd(**kwargs):
    return <generated complex model cmd> 

def run(analysis_settings, **params):
    params['custom_get_getmodel_cmd'] = custom_get_getmodel_cmd
    params['custom_gulcalc_cmd'] = CUSTOM_GULCALC_CMD
    oasislmf_run(analysis_settings, **params)

def run_analysis(**params):
    params['_get_getmodel_cmd'] = custom_get_getmodel_cmd
    params['custom_gulcalc_cmd'] = CUSTOM_GULCALC_CMD
    oasislmf_run_analysis_chunk(**params)
``` 
<!--end_release_notes-->
