### PR TITLE
Load default samples from model_settings file if given

### DIFF
--- a/oasislmf/computation/generate/losses.py
+++ b/oasislmf/computation/generate/losses.py
@@ -41,6 +41,7 @@ from ...utils.inputs import str2bool
 from ...utils.data import (
     fast_zip_dataframe_columns,
     get_analysis_settings,
+    get_model_settings,
     get_dataframe,
     get_utctimestamp,
     merge_dataframes,
@@ -186,6 +187,7 @@ class GenerateLossesDir(GenerateLossesBase):
         # Command line options
         {'name': 'oasis_files_dir',        'flag':'-o', 'is_path': True, 'pre_exist': True, 'required': True, 'help': 'Path to the directory in which to generate the Oasis files'},
         {'name': 'analysis_settings_json', 'flag':'-a', 'is_path': True, 'pre_exist': True, 'required': True,  'help': 'Analysis settings JSON file path'},
+        {'name': 'model_settings_json',    'flag':'-M', 'is_path': True, 'pre_exist': True,  'help': 'Model settings JSON file path'},
         {'name': 'user_data_dir',          'flag':'-D', 'is_path': True, 'pre_exist': False, 'help': 'Directory containing additional model data files which varies between analysis runs'},
         {'name': 'model_data_dir',         'flag':'-d', 'is_path': True, 'pre_exist': True,  'help': 'Model data directory path'},
         {'name': 'model_run_dir',          'flag':'-r', 'is_path': True, 'pre_exist': False, 'help': 'Model run directory path'},
@@ -245,6 +247,19 @@ class GenerateLossesDir(GenerateLossesBase):
         if not any(analysis_settings.get(output) for output in ['gul_output', 'il_output', 'ri_output']):
             raise OasisException(
                 'No valid output settings in: {}'.format(self.analysis_settings_json))
+
+        # Load default samples if not set in analysis settings
+        if not analysis_settings.get('number_of_samples'):
+            model_settings = get_model_settings(self.model_settings_json, {})
+            default_model_samples = model_settings.get('model_default_samples', None)
+            if default_model_samples == None:
+                raise OasisException(
+                    "'number_of_samples' not set in analysis_settings and no default value 'model_default_samples' found in model_settings file."
+                )
+            else:
+                self.logger.info(f"Loaded samples from model_settings file: 'model_default_samples = {default_model_samples}'")
+                analysis_settings['number_of_samples'] = default_model_samples
+
 
         prepare_run_inputs(analysis_settings, model_run_fp, ri=ri)
         self._store_run_settings(analysis_settings, os.path.join(model_run_fp, 'output'))

--- a/oasislmf/schema/analysis_settings.json
+++ b/oasislmf/schema/analysis_settings.json
@@ -372,7 +372,6 @@
     "required": [
         "model_supplier_id",
         "model_name_id",
-        "number_of_samples",
         "model_settings",
         "gul_output",
         "gul_summaries"


### PR DESCRIPTION
<!--start_release_notes-->
### Load default samples from model_settings  
The model run commands now includes a `--model-settings-json <file-path>` option. If set, or defined in the `oasislmf.json` config, this is used to load the default number of samples if not defined in the analysis settings. 

* Removed required field `number_of_samples` from the analysis_settings validation. 
* If `number_of_samples` is not set, the value will be taken from `model_default_samples` in the model_settings file.
* If neither  `number_of_samples` or `model_default_samples` is set then the run will fail with either: 
```
'number_of_samples' not set in analysis_settings and no default value 'model_default_samples' found in model_settings file.
```
```
'number_of_samples' not set in analysis_settings and no model_settings.json file provided for a default value.
```

<!--end_release_notes-->
