### PR TITLE
 Fixed RI outputs issue in platform-2

### DIFF
--- a/oasislmf/computation/generate/losses.py
+++ b/oasislmf/computation/generate/losses.py
@@ -393,15 +393,18 @@ class GenerateLossesOutput(GenerateLossesDir):
         {'name': 'ktools_fifo_relative',   'default': False, 'type': str2bool, 'const':True, 'nargs':'?', 'help': 'Create ktools fifo queues under the ./fifo dir'},
 
         # New vars for chunked loss generation
+        {'name': 'analysis_settings', 'default': None},
         {'name': 'script_fp', 'default': None},
         {'name': 'remove_working_file', 'default': False, 'help': 'Delete files in the "work/" dir onces outputs have completed'},
     ]
 
     def run(self):
         model_run_fp = GenerateLossesDir._get_output_dir(self)
-        analysis_settings = GenerateLossesDir.run(self)
+        if not self.analysis_settings:
+            self.analysis_settings = GenerateLossesDir.run(self)
+
         model_runner_module, _ = self._get_model_runner()
-        ri_layers = self._get_num_ri_layers(analysis_settings, model_run_fp)
+        ri_layers = self._get_num_ri_layers(self.analysis_settings, model_run_fp)
 
         if not self.script_fp:
             self.script_fp = os.path.join(os.path.abspath(model_run_fp), 'run_outputs.sh')
@@ -410,7 +413,7 @@ class GenerateLossesOutput(GenerateLossesDir):
             os.remove(self.script_fp)
 
         bash_params = bash.bash_params(
-            analysis_settings,
+            self.analysis_settings,
             number_of_processes=self.ktools_num_processes,
             num_reinsurance_iterations=ri_layers,
             filename=self.script_fp,


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!--start_release_notes-->
### Fixed RI output issue in platform-2
Fix issue where `output_reports` task re-runs bin.prepare_run_directory and fails the execution with: 
```
  File "/root/.local/lib/python3.8/site-packages/oasislmf/manager.py", line 93, in interface
    return computation_cls(**kwargs).run()
  File "/root/.local/lib/python3.8/site-packages/oasislmf/computation/generate/losses.py", line 402, in run
    analysis_settings = GenerateLossesDir.run(self)
  File "/root/.local/lib/python3.8/site-packages/oasislmf/computation/generate/losses.py", line 224, in run
    prepare_run_directory(
  File "/root/.local/lib/python3.8/site-packages/oasislmf/utils/log.py", line 111, in wrapper
    result = func(*args, **kwargs)
  File "/root/.local/lib/python3.8/site-packages/oasislmf/execution/bin.py", line 191, in prepare_run_directory
    raise OasisException("Error preparing the 'run' directory: {}".format(e))
oasislmf.utils.exceptions.OasisException: Error preparing the 'run' directory: Destination path '/tmp/run/analysis-38_losses-13df4aa5c74d457c8e2f64800acc62d6/run-data/ri_layers.json' already exists
```
<!--end_release_notes-->
