### PR TITLE
Infer the correct mime-type when uploading files to the oasis-platform

### DIFF
--- a/oasislmf/platform/client.py
+++ b/oasislmf/platform/client.py
@@ -14,9 +14,9 @@ import os
 import sys
 import tarfile
 import time
+import pathlib
 
 import pandas as pd
-import magic
 
 from tqdm import tqdm
 from requests_toolbelt import MultipartEncoder
@@ -121,10 +121,23 @@ class FileEndpoint(object):
             self.url_resource
         )
 
+    def _set_content_type(self, file_path):
+        content_type_map = {
+            'parquet': 'application/octet-stream',
+            'pq': 'application/octet-stream',
+            'csv': 'text/csv',
+            'gz': 'application/gzip',
+            'zip': 'application/zip',
+            'bz2': 'application/x-bzip2',
+        }
+        file_ext = pathlib.Path(file_path).suffix[1:].lower()
+        return content_type_map[file_ext] if file_ext in content_type_map else 'text/csv'
+
+
     def upload(self, ID, file_path, content_type=None):
         try:
             if not content_type:
-                content_type = magic.from_file(file_path, mime=True)
+                content_type = self._set_content_type(file_path)
             r = self.session.upload(self._build_url(ID), file_path, content_type)
             return r
         except HTTPError as e:

--- a/oasislmf/platform/client.py
+++ b/oasislmf/platform/client.py
@@ -16,6 +16,7 @@ import tarfile
 import time
 
 import pandas as pd
+import magic
 
 from tqdm import tqdm
 from requests_toolbelt import MultipartEncoder
@@ -120,8 +121,10 @@ class FileEndpoint(object):
             self.url_resource
         )
 
-    def upload(self, ID, file_path, content_type='text/csv'):
+    def upload(self, ID, file_path, content_type=None):
         try:
+            if not content_type:
+                content_type = magic.from_file(file_path, mime=True)
             r = self.session.upload(self._build_url(ID), file_path, content_type)
             return r
         except HTTPError as e:

--- a/requirements-package.in
+++ b/requirements-package.in
@@ -9,6 +9,7 @@ numba>=0.50.1
 numexpr
 ods-tools>=2.1.2
 pandas>=1.0.3,!=1.1.0,!=1.1.1
+python-magic
 pytz
 requests>=2.20.0
 requests-toolbelt

--- a/requirements-package.in
+++ b/requirements-package.in
@@ -9,7 +9,6 @@ numba>=0.50.1
 numexpr
 ods-tools>=2.1.2
 pandas>=1.0.3,!=1.1.0,!=1.1.1
-python-magic
 pytz
 requests>=2.20.0
 requests-toolbelt


### PR DESCRIPTION
### Fixed Platform client non-csv exposure upload 
The oasis platform client incorrectly sets all exposure files as `text/csv`, this creates problems when uploading parquet or compressed csv to the platform `oasislmf api run --oed-location-csv tests/inputs/SourceLocOEDPiWind10.parquet`  because the content-type doesn't match the file upload. Fixed by checking the file extension 

**Supported exposure file mine-types are:**
```
        'application/octet-stream',  (parquet)
        'text/csv',
        'application/gzip',
        'application/zip',
        'application/x-bzip2',
```