### PR TITLE
add unsupported peril in the keys-errors file

### DIFF
--- a/oasislmf/lookup/builtin.py
+++ b/oasislmf/lookup/builtin.py
@@ -267,7 +267,7 @@ class Lookup(AbstractBasicKeyLookup, MultiprocLookupMixin):
 
             location = locations.join(split_df).merge(peril_groups_df)
             if model_perils_covered:
-                location.drop(location[~location['peril_id'].isin(model_perils_covered)].index, inplace=True)
+                location.loc[~location['peril_id'].isin(model_perils_covered), ['status', 'message']] = OASIS_KEYS_STATUS['noreturn']['id'], f'unsuported peril_id'
             return location
         return fct
 


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!--start_release_notes-->
### add unsupported peril in the keys-errors file
In the keys server, Keys with Peril Id not present in the model peril covered were simply discarded. To make it clearer as to why the key was removed, they will now appear in the keys-errors.csv file with the status "noreturn" and message "unsuported peril_id"

<!--end_release_notes-->
