### PR TITLE
Fix/pre analysis hook

### DIFF
--- a/oasislmf/computation/hooks/pre_analysis.py
+++ b/oasislmf/computation/hooks/pre_analysis.py
@@ -85,10 +85,13 @@ class ExposurePreAnalysis(ComputationStep):
             raise OasisException(f"class {self.exposure_pre_analysis_class_name} "
                                  f"is not defined in module {self.exposure_pre_analysis_module}") from e.__cause__
 
+        modified_files = {k:v for (k,v) in kwargs.items() if k.startswith('oed')}
+        original_files = {k:v for (k,v) in kwargs.items() if k.startswith('raw')}
+
         self.logger.info('\nPre-analysis modified files: {}'.format(
-            json.dumps({k:v for (k,v) in kwargs.items() if k.startswith('oed')}, indent=4))
-        )
+            json.dumps(modified_files, indent=4)))
         self.logger.info('\nPre-analysis original files: {}'.format(
-            json.dumps({k:v for (k,v) in kwargs.items() if k.startswith('raw')}, indent=4))
-        )
-        return _class(**kwargs).run()
+            json.dumps(original_files, indent=4)))
+
+        _class_return = _class(**kwargs).run()
+        return _class_return, modified_files, original_files

--- a/oasislmf/computation/hooks/pre_analysis.py
+++ b/oasislmf/computation/hooks/pre_analysis.py
@@ -94,4 +94,8 @@ class ExposurePreAnalysis(ComputationStep):
             json.dumps(original_files, indent=4)))
 
         _class_return = _class(**kwargs).run()
-        return _class_return, modified_files, original_files
+        return {
+            "class": _class_return, 
+            "modified": modified_files, 
+            "original": original_files,
+        }    


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!--start_release_notes-->
### Updated the pre-analysis hook function to return edited files 
When calling `OasisManager().exposure_pre_analysis( .. )` from the oasis manager, there should be a way to get the list of file paths for `raw` and `edited` exposure files. Changed the function return to include these in a dictionary.

**Example**
```
OasisManager().exposure_pre_analysis(**params)
{
   'class':  <_class_return>,
   'modified': {
      "oed_location_csv": "/tmp/tmpaqq_k5pr/location.csv",
      "oed_accounts_csv": "/tmp/tmpaqq_k5pr/account.csv",
      "oed_info_csv": "/tmp/tmpaqq_k5pr/ri_info.csv",
      "oed_scope_csv": "/tmp/tmpaqq_k5pr/ri_scope.csv"
    },
   'original': {
     "raw_oed_location_csv": "/tmp/tmpaqq_k5pr/epa_location.csv",
     "raw_oed_accounts_csv": "/tmp/tmpaqq_k5pr/epa_account.csv",
     "raw_oed_info_csv": "/tmp/tmpaqq_k5pr/epa_ri_info.csv",
     "raw_oed_scope_csv": "/tmp/tmpaqq_k5pr/epa_ri_scope.csv"
   }
}   
```
<!--end_release_notes-->
