### PR TITLE
Feature/param loading

### DIFF
--- a/oasislmf/__init__.py
+++ b/oasislmf/__init__.py
@@ -85,7 +85,6 @@ class MyImport(MetaPathFinder):
                 )
                 warnings.simplefilter("always")
                 warnings.warn(deprecated)
-                import ipdb; ipdb.set_trace()
                 return MyLoader(self.depricated_modules[names[1]])
 
 sys.meta_path.append(MyImport())

--- a/oasislmf/__init__.py
+++ b/oasislmf/__init__.py
@@ -3,7 +3,6 @@ __version__ = '1.26.0'
 import sys
 import os
 from importlib.abc import MetaPathFinder, Loader
-from importlib.util import spec_from_loader
 import importlib
 import warnings
 
@@ -13,8 +12,6 @@ from logging import NullHandler
 logger = logging.getLogger(__name__)
 logger.addHandler(NullHandler())
 
-
-# https://docs.python.org/3/library/importlib.html#importlib.machinery.PathFinder
 
 class MyLoader(Loader):
 
@@ -33,14 +30,6 @@ class MyLoader(Loader):
         sys.modules[old_name] = module
         return module
 
-    def exec_module(self, module):
-        old_name = fullname = module.__name__
-        names = fullname.split(".")
-        names[1] = self.sub_module
-        fullname = ".".join(names)
-        module = importlib.import_module(fullname)
-        sys.modules[old_name] = module
-        return module
 
 class MyImport(MetaPathFinder):
     """ Support alias of depreciated sub-modules
@@ -62,18 +51,6 @@ class MyImport(MetaPathFinder):
             "api": "platform",
             "platform": "platform_api"
         }
-
-    def find_spec(self, fullname, path=None, target=None):
-        names = fullname.split(".")
-        if len(names) >= 2:
-            if names[0] == "oasislmf" and names[1] in self.depricated_modules:
-                deprecated = "imports from 'oasislmf.{}' are deprecated. Import by using 'oasislmf.{}' instead.".format(
-                    names[1],
-                    self.depricated_modules[names[1]]
-                )
-                warnings.simplefilter("always")
-                warnings.warn(deprecated)
-                return spec_from_loader(fullname, MyLoader(self.depricated_modules[names[1]]))
 
     def find_module(self, fullname, path=None):
         names = fullname.split(".")

--- a/oasislmf/computation/base.py
+++ b/oasislmf/computation/base.py
@@ -10,7 +10,9 @@ import inspect
 from collections import OrderedDict
 
 from ..utils.data import get_utctimestamp
+from ..utils.defaults import get_config_profile
 from ..utils.exceptions import OasisException
+from ..utils.inputs import update_config
 
 
 class ComputationStep:
@@ -88,16 +90,18 @@ class ComputationStep:
 
         return params
 
-    @classmethod 
+    @classmethod
     def get_arguments(cls, **kwargs):
         """
-        Return a list of default arguments values for the functions parameters 
-        If given arg values in 'kwargs' these will override the defaults 
+        Return a list of default arguments values for the functions parameters
+        If given arg values in 'kwargs' these will override the defaults
         """
         func_args = {el['name']: el.get('default', None) for el in cls.get_params()}
-        for param in kwargs: 
+        func_params = update_config(kwargs)
+
+        for param in func_params:
             if param in func_args:
-                func_args[param] = kwargs[param]
+                func_args[param] = func_params[param]
         return func_args
 
 

--- a/oasislmf/computation/base.py
+++ b/oasislmf/computation/base.py
@@ -12,7 +12,7 @@ from collections import OrderedDict
 from ..utils.data import get_utctimestamp
 from ..utils.defaults import get_config_profile
 from ..utils.exceptions import OasisException
-from ..utils.inputs import update_config
+from ..utils.inputs import update_config, str2bool, has_oasis_env, get_oasis_env
 
 
 class ComputationStep:
@@ -97,11 +97,16 @@ class ComputationStep:
         If given arg values in 'kwargs' these will override the defaults
         """
         func_args = {el['name']: el.get('default', None) for el in cls.get_params()}
-        func_params = update_config(kwargs)
+        type_map = {el['name']: el.get('type', None) for el in cls.get_params()}
 
-        for param in func_params:
-            if param in func_args:
-                func_args[param] = func_params[param]
+        func_kwargs = update_config(kwargs)
+        env_override = str2bool(os.getenv('OASIS_ENV_OVERRIDE', default=False))
+
+        for param in func_args:
+            if env_override and has_oasis_env(param):
+                func_args[param] = get_oasis_env(param, type_map[param])
+            elif param in func_kwargs:
+                func_args[param] = func_kwargs[param]
         return func_args
 
 

--- a/oasislmf/utils/inputs.py
+++ b/oasislmf/utils/inputs.py
@@ -1,5 +1,6 @@
 __all__ = [
     'InputValues',
+    'update_config',
 ]
 
 import io
@@ -13,23 +14,22 @@ from json.decoder import JSONDecodeError
 from argparse import ArgumentTypeError
 
 
-
-
 def update_config(config_data, config_map=get_config_profile()):
         config = config_data.copy()
         obsolete_keys = set(config) & set(config_map)
         logger = logging.getLogger()
-        
+
         if obsolete_keys:
             logger.warning('Deprecated key(s) in MDK config:')
             for key in obsolete_keys:
-                logger.warning(f'   {key} : {config_map[key]}')
 
                 # update key
                 if not config_map[key]['deleted']:
+                    logger.warning(f" '{key}' loaded as '{config_map[key]['updated_to']}'")
                     config[config_map[key]['updated_to']] = config[key]
+                else:
+                    logger.warning(f" '{key}' deleted")
                 del config[key]
-           
         return config
 
 
@@ -50,19 +50,11 @@ class InputValues(object):
 
         if self.config_fp is not None:
             try:
-                import ipdb; ipdb.set_trace()
                 self.config = update_config(self.load_config_file())
                 self.config_dir = os.path.dirname(self.config_fp)
                 self.list_unknown_keys()
             except JSONDecodeError as e:
                 raise OasisException(f"Configuration file {self.config_fp} is not a valid json file", e)
-
-        
-
-        #self.obsolete_keys = set(self.config) & set(self.config_mapping)
-        #self.list_obsolete_keys()
-        #if update_keys:
-        #    self.update_config_keys()
 
     def list_unknown_keys(self):
         """
@@ -79,27 +71,6 @@ class InputValues(object):
                     k,
                     self.config[k]
                 ))
-
-    #def list_obsolete_keys(self, fix_warning=True):
-    #    if self.obsolete_keys:
-    #        self.logger.warning('Deprecated key(s) in MDK config:')
-    #        for k in self.obsolete_keys:
-    #            self.logger.warning('   {} : {}'.format(
-    #                k,
-    #                self.config_mapping[k],
-    #            ))
-    #        self.logger.warning('')
-    #        if fix_warning:
-    #            self.logger.warning('  To fix run: oasislmf config update'.format(self.config_fp))
-
-    #def update_config_keys(self):
-    #    """
-    #    If command line flags change between package versions, update them internally
-    #    """
-    #    for key in self.obsolete_keys:
-    #        if not self.config_mapping[key]['deleted']:
-    #            self.config[self.config_mapping[key]['updated_to']] = self.config[key]
-    #        del self.config[key]
 
     def load_config_file(self):
         try:


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!--start_release_notes-->
### Check `get_config_profile` and environment variables when calling the `_param` functions 
Fix needed for https://github.com/OasisLMF/OasisPlatform/issues/630 


1. When loading older `oasislmf.json` files are processed programmatically, using `_param` functions in the [platform-2.0 branch](https://github.com/OasisLMF/OasisPlatform/blob/f71ce0960fbd9de8e2a6b467378ae0791921b709/src/model_execution_worker/distributed_tasks.py#L576-L578). The `config_compatibility_profile.json` file isn't checked for outdated key names, unlike with CLI. 
The update edits the **OasisManager.\_params\_\<funcName\>** methods so that outdated keys are replaced, making it equivalent to the CLI argument loading. 

3. If `export OASIS_ENV_OVERRIDE=True` is set, check if `OASIS_<param_name>` is defined and load value from override environment variable 

**Example 1 - Config profile**
the `source_exposure_file_path`  was updated to `oed_location_csv` if given to the function for loading default args, the newer name will be used. 
```
In [x]: OasisManager._params_generate_keys(
   ...:     **{"source_exposure_file_path": "my-location-file-path"}
   ...: )
Deprecated key(s) in MDK config:
 'source_exposure_file_path' loaded as 'oed_location_csv'

Out[x]: 
{'oed_location_csv': 'my-location-file-path',
 'keys_data_csv': None,
 'keys_errors_csv': None,
 'keys_format': 'oasis',
 'lookup_config_json': None,
 'lookup_data_dir': None,
 'lookup_module_path': None,
 'lookup_complex_config_json': None,
 'lookup_num_processes': -1,
 'lookup_num_chunks': -1,
 'model_version_csv': None,
 'user_data_dir': None,
 'lookup_multiprocessing': True,
 'verbose': False}
```

**Example 2 - override environment variable**
```
export OASIS_ENV_OVERRIDE=True
export OASIS_OED_LOCATION_CSV='override_path'

In [x]: OasisManager._params_generate_keys(
   ...:     **{"source_exposure_file_path": "my-location-file-path"}
   ...: )
Deprecated key(s) in MDK config:
 'source_exposure_file_path' loaded as 'oed_location_csv'
Out[x]: 
{'oed_location_csv': 'override_path',
 'keys_data_csv': None,
 'keys_errors_csv': None,
 'keys_format': 'oasis',
 'lookup_config_json': None,
 'lookup_data_dir': None,
 'lookup_module_path': None,
 'lookup_complex_config_json': None,
 'lookup_num_processes': -1,
 'lookup_num_chunks': -1,
 'model_version_csv': None,
 'user_data_dir': 'foo-path',
 'lookup_multiprocessing': True,
 'verbose': False}
```

<!--end_release_notes-->
