### PR TITLE
Fix Warning messages

### DIFF
--- a/oasislmf/__init__.py
+++ b/oasislmf/__init__.py
@@ -46,8 +46,6 @@ class MyImport(MetaPathFinder):
         self.depricated_modules = {
             "model_execution": "execution",
             "model_preparation": "preparation",
-            #"preparation.old_module" :"preparation.new_module",
-            #"preparation.reinsurance_layer" :"preparation.reinsurance",
             "api": "platform",
             "platform": "platform_api"
         }

--- a/oasislmf/__init__.py
+++ b/oasislmf/__init__.py
@@ -85,7 +85,6 @@ class MyImport(MetaPathFinder):
                 )
                 warnings.simplefilter("always")
                 warnings.warn(deprecated)
-                import ipdb; ipdb.set_trace()
                 return MyLoader(self.depricated_modules[names[1]])
 
 sys.meta_path.append(MyImport())

--- a/oasislmf/__init__.py
+++ b/oasislmf/__init__.py
@@ -59,7 +59,9 @@ class MyImport(MetaPathFinder):
             for deprecated in self.depricated_modules:
                 if deprecated == import_path or import_path.startswith(deprecated+'.'):
                     warnings.simplefilter("always")
-                    warnings.warn(deprecated)
+                    warnings.warn(
+                        f"imports from 'oasislmf.{deprecated}' are deprecated. Import by using 'oasislmf.{self.depricated_modules[deprecated]}' instead."
+                    )
                     import_path = import_path.replace(deprecated, self.depricated_modules[deprecated])
 
             return spec_from_loader(fullname, MyLoader(import_path))

--- a/oasislmf/__init__.py
+++ b/oasislmf/__init__.py
@@ -14,8 +14,6 @@ logger = logging.getLogger(__name__)
 logger.addHandler(NullHandler())
 
 
-# https://docs.python.org/3/library/importlib.html#importlib.machinery.PathFinder
-
 class MyLoader(Loader):
 
     def __init__(self, sub_module):
@@ -53,6 +51,7 @@ class MyImport(MetaPathFinder):
             `from oasislmf.model_execution.bash import genbash`
                 is the same as calling the new name
             `from oasislmf.execution.bash import genbash`
+            https://docs.python.org/3/library/importlib.html#importlib.machinery.PathFinder
     """
 
     def __init__(self):

--- a/oasislmf/computation/run/platform.py
+++ b/oasislmf/computation/run/platform.py
@@ -18,7 +18,7 @@ from mimetypes import guess_extension
 
 from requests.exceptions import HTTPError, ConnectionError
 
-from ...platform.client import APIClient
+from ...platform_api.client import APIClient
 from ...utils.exceptions import OasisException
 from ...utils.defaults import API_EXAMPLE_AUTH
 

--- a/oasislmf/utils/data.py
+++ b/oasislmf/utils/data.py
@@ -1131,7 +1131,10 @@ def fill_na_with_categoricals(df, fill_value):
             fill_value[col_name] = value
 
             if value not in col.cat.categories:
-                col.cat.add_categories([value], inplace=True)
+                df[col_name] = col.cat.add_categories([value])
+                # 'inplace=True' is Deprecated since version 1.3.0
+                # https://pandas.pydata.org/docs/reference/api/pandas.Series.cat.add_categories.html
+                #col.cat.add_categories([value], inplace=True)
 
     # Note that the following lines do not work properly with Pandas 1.1.0/1.1.1, due to a bug
     # related to fillna and categorical dtypes. This bug should be fixed in >1.1.2.

--- a/oasislmf/utils/data.py
+++ b/oasislmf/utils/data.py
@@ -1129,12 +1129,8 @@ def fill_na_with_categoricals(df, fill_value):
             # Force to be a string - using categorical for string columns
             value = str(value)
             fill_value[col_name] = value
-
             if value not in col.cat.categories:
                 df[col_name] = col.cat.add_categories([value])
-                # 'inplace=True' is Deprecated since version 1.3.0
-                # https://pandas.pydata.org/docs/reference/api/pandas.Series.cat.add_categories.html
-                #col.cat.add_categories([value], inplace=True)
 
     # Note that the following lines do not work properly with Pandas 1.1.0/1.1.1, due to a bug
     # related to fillna and categorical dtypes. This bug should be fixed in >1.1.2.


### PR DESCRIPTION
<!--start_release_notes-->
### Fix warning messages in package runs 
* Added minor changes to appease the package deprecation warnings, results in cleaner logs when running the MDK.  
* Updated the oasislmf deprecated module loader to support sub-module remapping `oasislmf.preparation.old_module` -> `oasislmf.preparation.new_module`

<!--end_release_notes-->

- [x] importlib
- [x] Pandas 
- [x] Shapely (linked to importlib)
- [x] ssl socket (linked to importlib)

[piwind_run_logs_before.txt](https://github.com/OasisLMF/OasisLMF/files/9070455/piwind_run_logs_before.txt)
[piwind_run_logs_after.txt](https://github.com/OasisLMF/OasisLMF/files/9070456/piwind_run_logs_after.txt)
[package_vers.txt](https://github.com/OasisLMF/OasisLMF/files/9070457/package_vers.txt)


