### PR TITLE
add peril_filter to run settings spec

### DIFF
--- a/oasislmf/computation/generate/losses.py
+++ b/oasislmf/computation/generate/losses.py
@@ -151,7 +151,8 @@ class GenerateLossesBase(ComputationStep):
         option
         """
         user_peril_filter = analysis_settings.get('peril_filter', None)
-        return user_peril_filter if user_peril_filter else self.peril_filter
+        peril_filter = list(map(str.upper, user_peril_filter if user_peril_filter else self.peril_filter))
+        return peril_filter
 
     def _print_error_logs(self, run_log_fp, e):
         """

--- a/oasislmf/computation/generate/losses.py
+++ b/oasislmf/computation/generate/losses.py
@@ -144,6 +144,15 @@ class GenerateLossesBase(ComputationStep):
                     ri_layers = len(json.load(f))
         return ri_layers
 
+
+    def _get_peril_filter(self, analysis_settings):
+        """
+        Check the 'analysis_settings' for user set peril filter, if empty return the MDK peril filter
+        option
+        """
+        user_peril_filter = analysis_settings.get('peril_filter', None)
+        return user_peril_filter if user_peril_filter else self.peril_filter
+
     def _print_error_logs(self, run_log_fp, e):
         """
         Error handling Method: Call if a run error has accursed,
@@ -308,6 +317,7 @@ class GenerateLossesPartial(GenerateLossesDir):
         {'name': 'fmpy_low_memory',        'default': False, 'type': str2bool, 'const':True, 'nargs':'?', 'help': 'use memory map instead of RAM to store loss array (may decrease performance but reduce RAM usage drastically)'},
         {'name': 'fmpy_sort_output',       'default': False, 'type': str2bool, 'const':True, 'nargs':'?', 'help': 'order fmpy output by item_id'},
         {'name': 'model_custom_gulcalc',   'default': None,  'help': 'Custom gulcalc binary name to call in the model losses step'},
+        {'name': 'peril_filter',           'default': [], 'nargs':'+', 'help': 'Peril specific run'},
 
         # New vars for chunked loss generation
         {'name': 'analysis_settings', 'default': None},
@@ -357,7 +367,8 @@ class GenerateLossesPartial(GenerateLossesDir):
             event_shuffle=self.ktools_event_shuffle,
             process_number=self.process_number,
             max_process_id=self.max_process_id,
-            modelpy=self.modelpy
+            modelpy=self.modelpy,
+            peril_filter = self._get_peril_filter(analysis_settings)
         )
         ## Workaround test -- needs adding into bash_params
         if self.ktools_fifo_queue_dir:
@@ -520,7 +531,7 @@ class GenerateLosses(GenerateLossesDir):
                         event_shuffle=self.ktools_event_shuffle,
                         modelpy=self.modelpy,
                         model_py_server=self.model_py_server,
-                        peril_filter = self.peril_filter
+                        peril_filter = self._get_peril_filter(analysis_settings)
                     )
                 except TypeError:
                     warnings.simplefilter("always")

--- a/oasislmf/schema/analysis_settings.json
+++ b/oasislmf/schema/analysis_settings.json
@@ -307,6 +307,19 @@
             "title": "User set event ids",
             "description": "List of event ids as integers '[1, 5, 123 .. etc]'"
         },
+        "peril_filter": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "type":"string",
+                "title":"OED peril",
+                "description":"OED three letter peril code",
+                "minLength":3,
+                "maxLength":3
+            },
+            "title": "Run filter by peril id",
+            "description": "List of OED peril ids '['WSS', 'WTC' .. ]'"
+        },
         "quantiles": {
             "type": "array",
             "minItems": 1,


### PR DESCRIPTION
<!--start_release_notes-->
### Add peril filter to analysis settings 
* peril filter is also read from `analysis_settings.json` and overrides options set via `oasislmf.json` or CLi

 **analysis_settings.json**     
```
{                                                                                                                              
    "analysis_tag": "base_example",
    "source_tag": "MDK",
    "model_name_id": "PiWind",
    "peril_filter": ["WTC"],
     ... 
```

<!--end_release_notes-->
