### PR TITLE
Request token refresh on HTTP error 403 - Forbidden

### DIFF
--- a/oasislmf/platform_api/session.py
+++ b/oasislmf/platform_api/session.py
@@ -103,7 +103,7 @@ class APISession(Session):
             if http_err_code in [502, 503, 504]:
                 error = "HTTP {}".format(http_err_code)
                 return True
-            elif http_err_code in [401]:
+            elif http_err_code in [401, 403]:
                 if self.tkn_refresh is not None:
                     self.logger.debug(f"requesting refresh token")
                     self._refresh_token()


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!--start_release_notes-->
### Minor fix for Platform client 
Attempt to request a refresh token on 403 errors, otherwise runs can fail on token timeouts.
```
Creating portfolio
File uploaded: ~/ram/location.csv
Settings JSON uploaded: ~/ram/analysis_settings.json
Inputs Generation: Starting (id=61)
Input Generation: Queued (id=61)
Input Generation: Executing (id=61)
Input Generation:  38%|████████████████████████▌                                       | 10/26 [04:51<07:45, 29.10s/ sub_task]
run_generate: failed
api error: 403, url: https://xxxxxxx.northcentralus.cloudapp.azure.com/api/V1/analyses/61/sub_task_list/, msg: {"detail":"Token verification failed"}

```
<!--end_release_notes-->
