### PR TITLE
Add check for parquet output before running model

### DIFF
--- a/oasislmf/computation/run/model.py
+++ b/oasislmf/computation/run/model.py
@@ -38,31 +38,6 @@ class RunModel(ComputationStep):
         ExposurePreAnalysis,
     ]
 
-    _analysis_settings = {}
-    _runtypes = ['gul', 'il', 'ri']
-
-
-    def __check_for_parquet_output(self):
-        """
-        Private method to check whether ktools components were linked to third
-        party parquet libraries during compilation if user requests parquet
-        output.
-        """
-        for runtype in self._runtypes:
-            for summary in self._analysis_settings.get(f'{runtype}_summaries', {}):
-                if summary.get('ord_output', {}).get('parquet_format'):
-                    katparquet_output = subprocess.run(
-                        ['katparquet', '-v'],
-                        stdout=subprocess.PIPE,
-                        stderr=subprocess.PIPE
-                    )
-                    if not 'Parquet output enabled' in katparquet_output.stderr.decode():
-                        raise OasisException(
-                            'Parquet output format requested but not supported by ktools components. '
-                            'Please set "parquet_format" to false in analysis settings file.'
-                        )
-                    return   # Only need to find a single request
-
 
     def pre_analysis_kwargs(self):
         updated_inputs = {}
@@ -90,8 +65,7 @@ class RunModel(ComputationStep):
         self.kwargs['oasis_files_dir'] = os.path.join(self.model_run_dir, 'input')
 
         # Validate JSON files (Fail at entry point not after input generation)
-        self._analysis_settings = get_analysis_settings(self.analysis_settings_json)
-        self.__check_for_parquet_output()
+        get_analysis_settings(self.analysis_settings_json)
         if self.model_settings_json:
             get_model_settings(self.model_settings_json)
 

--- a/oasislmf/computation/run/model.py
+++ b/oasislmf/computation/run/model.py
@@ -49,7 +49,7 @@ class RunModel(ComputationStep):
         output.
         """
         for runtype in self._runtypes:
-            for summary in self._analysis_settings.get(f'{runtype}_summaries'):
+            for summary in self._analysis_settings.get(f'{runtype}_summaries', {}):
                 if summary.get('ord_output', {}).get('parquet_format'):
                     katparquet_output = subprocess.run(
                         ['katparquet', '-v'],


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!--start_release_notes-->
### Add check for parquet output before running model
Optional third party libraries are required for parquet output of `ktools` components (see https://github.com/OasisLMF/ktools/pull/283 for more details). A user can request parquet output by setting the `parquet_format` flag to `true` in the `analysis_settings.json` file. It is possible to compile `ktools` binaries without linking to these optional parquet libraries, as is the case with the Mac OS build. In this case, requesting parquet output will result in an error after all loss calculations have been performed.

A check to determine whether the `ktools` components have been linked with parquet libraries during compilation has been introduced before input generation, yielding an error message if parquet output has been requested but is not supported by the `ktools` build.
<!--end_release_notes-->
